### PR TITLE
chore: use env version in rust outputs

### DIFF
--- a/crates/floe-cli/src/main.rs
+++ b/crates/floe-cli/src/main.rs
@@ -3,23 +3,26 @@ use floe_core::{load_config, run, validate, FloeResult, RunOptions, ValidateOpti
 use std::path::PathBuf;
 
 const VERSION: &str = env!("FLOE_VERSION");
-const ROOT_LONG_ABOUT: &str = r#"Floe is a single-node, config-driven ingestion runner. It loads one YAML config
-and executes each entity in order, producing per-entity and summary reports.
-
-Config (v0.1.0) structure:
-  version
-  metadata
-  report.path
-  entities[]
-
-entity:
-  name
-  metadata
-  source { format, path, options, cast_mode }
-  sink { accepted, rejected }
-  policy { severity }
-  schema { normalize_columns, columns[] }
-"#;
+const ROOT_LONG_ABOUT: &str = concat!(
+    "Floe is a single-node, config-driven ingestion runner. It loads one YAML config\n",
+    "and executes each entity in order, producing per-entity and summary reports.\n",
+    "\n",
+    "Config (v",
+    env!("CARGO_PKG_VERSION"),
+    ") structure:\n",
+    "  version\n",
+    "  metadata\n",
+    "  report.path\n",
+    "  entities[]\n",
+    "\n",
+    "entity:\n",
+    "  name\n",
+    "  metadata\n",
+    "  source { format, path, options, cast_mode }\n",
+    "  sink { accepted, rejected }\n",
+    "  policy { severity }\n",
+    "  schema { normalize_columns, columns[] }\n",
+);
 
 const RUN_LONG_ABOUT: &str = r#"Run all configured entities sequentially (or restrict with --entities).
 
@@ -39,15 +42,18 @@ Reports are written to:
   <report.path>/run_<run_id>/<entity.name>/run.json
 "#;
 
-const VALIDATE_LONG_ABOUT: &str = r#"Validate a configuration file before running.
-
-Validation checks:
-  - YAML parsing
-  - schema validation against the v0.1.0 structure
-
-Example:
-  floe validate -c example/config.yml
-"#;
+const VALIDATE_LONG_ABOUT: &str = concat!(
+    "Validate a configuration file before running.\n",
+    "\n",
+    "Validation checks:\n",
+    "  - YAML parsing\n",
+    "  - schema validation against the v",
+    env!("CARGO_PKG_VERSION"),
+    " structure\n",
+    "\n",
+    "Example:\n",
+    "  floe validate -c example/config.yml\n",
+);
 
 mod output;
 

--- a/crates/floe-cli/src/output.rs
+++ b/crates/floe-cli/src/output.rs
@@ -222,12 +222,13 @@ mod tests {
         let run_id = "run-123".to_string();
         let report_base_path = "/tmp/reports".to_string();
         let report_file = "/tmp/reports/run_run-123/customer/run.json".to_string();
+        let version = env!("CARGO_PKG_VERSION").to_string();
 
         let report = report::RunReport {
-            spec_version: "0.1.0".to_string(),
+            spec_version: version.clone(),
             tool: report::ToolInfo {
                 name: "floe".to_string(),
-                version: "0.1.0".to_string(),
+                version: version.clone(),
                 git: None,
             },
             run: report::RunInfo {
@@ -240,7 +241,7 @@ mod tests {
             },
             config: report::ConfigEcho {
                 path: "/tmp/config.yml".to_string(),
-                version: "0.1.0".to_string(),
+                version,
                 metadata: None,
             },
             entity: report::EntityEcho {

--- a/crates/floe-core/src/report/mod.rs
+++ b/crates/floe-core/src/report/mod.rs
@@ -364,7 +364,7 @@ mod tests {
             spec_version: "0.1".to_string(),
             tool: ToolInfo {
                 name: "floe".to_string(),
-                version: "0.1.0".to_string(),
+                version: env!("CARGO_PKG_VERSION").to_string(),
                 git: None,
             },
             run: RunInfo {


### PR DESCRIPTION
Replace hardcoded 0.1.0 strings in Rust sources with build-time version envs.\n\n- report sample uses CARGO_PKG_VERSION\n- CLI help text uses CARGO_PKG_VERSION\n- CLI output tests use CARGO_PKG_VERSION