### PR TITLE
chore: prepare v0.1.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,22 @@
+# Changelog
+
+All notable changes to Floe are documented in this file.
+
+## v0.1.2
+
+- Config validation now rejects unknown fields and adds broader negative test coverage.
+- CLI and report examples use build-time version strings (no hardcoded 0.1.0).
+- Release pipeline hardening: portable version bumping, allow-dirty publish, and tap checkout fixes.
+
+## v0.1.1
+
+- Global report layout with run-scoped directories and per-entity reports.
+- CI/CD release pipeline (crate publish, binaries, checksums, GitHub Release, Homebrew tap).
+- CLI output improvements and documentation refreshes for reports/checks.
+
+## v0.1.0
+
+- Initial CLI (`validate`, `run`) and YAML configuration schema.
+- CSV ingestion with Parquet accepted output and CSV rejected output.
+- Core checks: casting, not-null, unique; row-level rejection and run reports.
+- Multi-entity support with run-scoped reporting.

--- a/crates/floe-cli/Cargo.toml
+++ b/crates/floe-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "floe-cli"
-version = "0.1.0"
+version = "0.1.2"
 edition = "2021"
 description = "CLI for Floe, a YAML-driven technical ingestion tool."
 license = "MIT"
@@ -17,4 +17,4 @@ path = "src/main.rs"
 
 [dependencies]
 clap = { version = "4", features = ["derive"] }
-floe-core = { path = "../floe-core", version = "0.1.0" }
+floe-core = { path = "../floe-core", version = "0.1.2" }

--- a/crates/floe-core/Cargo.toml
+++ b/crates/floe-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "floe-core"
-version = "0.1.0"
+version = "0.1.2"
 edition = "2021"
 description = "Core library for Floe, a YAML-driven technical ingestion tool."
 license = "MIT"


### PR DESCRIPTION
Prepare v0.1.2 release metadata.
- add CHANGELOG.md with v0.1.0/0.1.1/0.1.2 notes
- bump floe-core and floe-cli versions to 0.1.2
- update floe-cli dependency on floe-core