### PR TITLE
feat(config): add filesystem definitions and local URI resolution

### DIFF
--- a/config.schema.yaml
+++ b/config.schema.yaml
@@ -15,6 +15,8 @@ properties:
     type: string
   metadata:
     $ref: "#/$defs/project_metadata"
+  filesystems:
+    $ref: "#/$defs/filesystems"
   report:
     $ref: "#/$defs/report"
   entities:
@@ -121,6 +123,8 @@ $defs:
         enum: [csv, parquet, json]
       path:
         type: string
+      filesystem:
+        type: string
       options:
         $ref: "#/$defs/source_options"
       cast_mode:
@@ -167,6 +171,8 @@ $defs:
         enum: [parquet, delta]
       path:
         type: string
+      filesystem:
+        type: string
 
   sink_rejected:
     type: object
@@ -180,6 +186,8 @@ $defs:
         enum: [csv]
       path:
         type: string
+      filesystem:
+        type: string
 
   report:
     type: object
@@ -188,6 +196,37 @@ $defs:
       - path
     properties:
       path:
+        type: string
+
+  filesystems:
+    type: object
+    additionalProperties: false
+    required:
+      - default
+      - definitions
+    properties:
+      default:
+        type: string
+      definitions:
+        type: array
+        items:
+          $ref: "#/$defs/filesystem_definition"
+
+  filesystem_definition:
+    type: object
+    additionalProperties: false
+    required:
+      - name
+      - type
+    properties:
+      name:
+        type: string
+      type:
+        type: string
+        enum: [local, s3]
+      bucket:
+        type: string
+      region:
         type: string
 
   archive_target:

--- a/crates/floe-core/src/config/filesystem.rs
+++ b/crates/floe-core/src/config/filesystem.rs
@@ -1,0 +1,168 @@
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+
+use crate::config::{FilesystemDefinition, RootConfig};
+use crate::{ConfigError, FloeResult};
+
+#[derive(Debug, Clone)]
+pub struct ResolvedPath {
+    pub filesystem: String,
+    pub uri: String,
+    pub local_path: Option<PathBuf>,
+}
+
+pub struct FilesystemResolver {
+    config_dir: PathBuf,
+    default_name: String,
+    definitions: HashMap<String, FilesystemDefinition>,
+    has_config: bool,
+}
+
+impl FilesystemResolver {
+    pub fn new(config: &RootConfig, config_path: &Path) -> FloeResult<Self> {
+        let config_dir = config_path
+            .parent()
+            .unwrap_or_else(|| Path::new("."))
+            .to_path_buf();
+        if let Some(filesystems) = &config.filesystems {
+            let mut definitions = HashMap::new();
+            for definition in &filesystems.definitions {
+                if definitions
+                    .insert(definition.name.clone(), definition.clone())
+                    .is_some()
+                {
+                    return Err(Box::new(ConfigError(format!(
+                        "filesystems.definitions name={} is duplicated",
+                        definition.name
+                    ))));
+                }
+            }
+            let default_name = filesystems.default.clone().ok_or_else(|| {
+                Box::new(ConfigError("filesystems.default is required".to_string()))
+            })?;
+            if !definitions.contains_key(&default_name) {
+                return Err(Box::new(ConfigError(format!(
+                    "filesystems.default={} does not match any definition",
+                    default_name
+                ))));
+            }
+            Ok(Self {
+                config_dir,
+                default_name,
+                definitions,
+                has_config: true,
+            })
+        } else {
+            Ok(Self {
+                config_dir,
+                default_name: "local".to_string(),
+                definitions: HashMap::new(),
+                has_config: false,
+            })
+        }
+    }
+
+    pub fn resolve_path(
+        &self,
+        entity_name: &str,
+        field: &str,
+        filesystem_name: Option<&str>,
+        raw_path: &str,
+    ) -> FloeResult<ResolvedPath> {
+        let name = filesystem_name.unwrap_or(self.default_name.as_str());
+        if !self.has_config && name != "local" {
+            return Err(Box::new(ConfigError(format!(
+                "entity.name={} {field} references unknown filesystem {} (no filesystems block)",
+                entity_name, name
+            ))));
+        }
+
+        let definition = if self.has_config {
+            self.definitions.get(name).cloned().ok_or_else(|| {
+                Box::new(ConfigError(format!(
+                    "entity.name={} {field} references unknown filesystem {}",
+                    entity_name, name
+                )))
+            })?
+        } else {
+            FilesystemDefinition {
+                name: "local".to_string(),
+                fs_type: "local".to_string(),
+                bucket: None,
+                region: None,
+            }
+        };
+
+        match definition.fs_type.as_str() {
+            "local" => {
+                let resolved = resolve_local_path(&self.config_dir, raw_path);
+                Ok(ResolvedPath {
+                    filesystem: name.to_string(),
+                    uri: local_uri(&resolved),
+                    local_path: Some(resolved),
+                })
+            }
+            "s3" => {
+                let uri = resolve_s3_uri(&definition, raw_path)?;
+                Ok(ResolvedPath {
+                    filesystem: name.to_string(),
+                    uri,
+                    local_path: None,
+                })
+            }
+            _ => Err(Box::new(ConfigError(format!(
+                "filesystem type {} is unsupported",
+                definition.fs_type
+            )))),
+        }
+    }
+}
+
+pub fn resolve_local_path(config_dir: &Path, raw_path: &str) -> PathBuf {
+    let path = Path::new(raw_path);
+    if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        config_dir.join(path)
+    }
+}
+
+fn local_uri(path: &Path) -> String {
+    format!("local://{}", path.display())
+}
+
+fn resolve_s3_uri(definition: &FilesystemDefinition, raw_path: &str) -> FloeResult<String> {
+    let bucket = definition.bucket.as_ref().ok_or_else(|| {
+        Box::new(ConfigError(format!(
+            "filesystem {} requires bucket for type s3",
+            definition.name
+        )))
+    })?;
+    if let Some((bucket_in_path, key)) = parse_s3_uri(raw_path) {
+        if bucket_in_path != *bucket {
+            return Err(Box::new(ConfigError(format!(
+                "filesystem {} bucket mismatch: {}",
+                definition.name, bucket_in_path
+            ))));
+        }
+        return Ok(format!("s3://{}/{}", bucket, key));
+    }
+
+    let trimmed = raw_path.trim_start_matches('/');
+    if trimmed.is_empty() {
+        Ok(format!("s3://{}", bucket))
+    } else {
+        Ok(format!("s3://{}/{}", bucket, trimmed))
+    }
+}
+
+fn parse_s3_uri(value: &str) -> Option<(String, String)> {
+    let stripped = value.strip_prefix("s3://")?;
+    let mut parts = stripped.splitn(2, '/');
+    let bucket = parts.next()?.to_string();
+    if bucket.is_empty() {
+        return None;
+    }
+    let key = parts.next().unwrap_or("").to_string();
+    Some((bucket, key))
+}

--- a/crates/floe-core/src/config/mod.rs
+++ b/crates/floe-core/src/config/mod.rs
@@ -1,8 +1,10 @@
+mod filesystem;
 mod parse;
 mod types;
 mod validate;
 mod yaml_decode;
 
+pub use filesystem::{resolve_local_path, FilesystemResolver, ResolvedPath};
 pub use types::*;
 
 pub(crate) use parse::parse_config;

--- a/crates/floe-core/src/config/types.rs
+++ b/crates/floe-core/src/config/types.rs
@@ -11,6 +11,7 @@ use crate::{ConfigError, FloeResult};
 pub struct RootConfig {
     pub version: String,
     pub metadata: Option<ProjectMetadata>,
+    pub filesystems: Option<FilesystemsConfig>,
     pub report: ReportConfig,
     pub entities: Vec<EntityConfig>,
 }
@@ -46,6 +47,7 @@ pub struct EntityMetadata {
 pub struct SourceConfig {
     pub format: String,
     pub path: String,
+    pub filesystem: Option<String>,
     pub options: Option<SourceOptions>,
     pub cast_mode: Option<String>,
 }
@@ -138,6 +140,21 @@ pub struct SinkConfig {
 pub struct SinkTarget {
     pub format: String,
     pub path: String,
+    pub filesystem: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct FilesystemsConfig {
+    pub default: Option<String>,
+    pub definitions: Vec<FilesystemDefinition>,
+}
+
+#[derive(Debug, Clone)]
+pub struct FilesystemDefinition {
+    pub name: String,
+    pub fs_type: String,
+    pub bucket: Option<String>,
+    pub region: Option<String>,
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
## Summary
- add filesystem definitions and selectors to config parsing/validation
- add local path resolver with canonical local:// URIs in reports
- add filesystem validation tests and update schema doc

## Testing
- cargo fmt --all
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test --all