### PR TITLE
chore: prepare v0.1.3 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to Floe are documented in this file.
 
+## v0.1.3
+
+- Added a format registry with adapter traits for inputs and sinks.
+- Centralized file extension handling for local/S3 resolution.
+- Expanded input format scaffolding (Parquet/JSON readers) and IO dispatch.
+- Run pipeline refactor to use format adapters and shared IO helpers.
+
 ## v0.1.2
 
 - Config validation now rejects unknown fields and adds broader negative test coverage.

--- a/crates/floe-cli/Cargo.toml
+++ b/crates/floe-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "floe-cli"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 description = "CLI for Floe, a YAML-driven technical ingestion tool."
 license = "MIT"
@@ -17,4 +17,4 @@ path = "src/main.rs"
 
 [dependencies]
 clap = { version = "4", features = ["derive"] }
-floe-core = { path = "../floe-core", version = "0.1.2" }
+floe-core = { path = "../floe-core", version = "0.1.3" }

--- a/crates/floe-core/Cargo.toml
+++ b/crates/floe-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "floe-core"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 description = "Core library for Floe, a YAML-driven technical ingestion tool."
 license = "MIT"


### PR DESCRIPTION
Prepare v0.1.3 release metadata.
- update CHANGELOG with v0.1.3 highlights
- bump floe-core and floe-cli versions to 0.1.3
- update floe-cli dependency on floe-core