### PR TITLE
feat(write): add iceberg sink config and filesystem-catalog MVP

### DIFF
--- a/crates/floe-core/src/config/validate.rs
+++ b/crates/floe-core/src/config/validate.rs
@@ -95,6 +95,12 @@ fn validate_source(entity: &EntityConfig, filesystems: &FilesystemRegistry) -> F
 
 fn validate_sink(entity: &EntityConfig, filesystems: &FilesystemRegistry) -> FloeResult<()> {
     format::ensure_accepted_sink_format(&entity.name, entity.sink.accepted.format.as_str())?;
+    if entity.sink.accepted.format == "iceberg" {
+        return Err(Box::new(ConfigError(format!(
+            "entity.name={} sink.accepted.format=iceberg is not supported yet (filesystem catalog writer not implemented)",
+            entity.name
+        ))));
+    }
 
     if entity.policy.severity == "reject" && entity.sink.rejected.is_none() {
         return Err(Box::new(ConfigError(format!(

--- a/crates/floe-core/src/io/format.rs
+++ b/crates/floe-core/src/io/format.rs
@@ -201,6 +201,7 @@ pub fn accepted_sink_adapter(format: &str) -> FloeResult<&'static dyn AcceptedSi
     match format {
         "parquet" => Ok(io::write::parquet::parquet_accepted_adapter()),
         "delta" => Ok(io::write::delta::delta_accepted_adapter()),
+        "iceberg" => Ok(io::write::iceberg::iceberg_accepted_adapter()),
         _ => Err(Box::new(unsupported_format_error(
             FormatKind::SinkAccepted,
             format,

--- a/crates/floe-core/src/io/write/iceberg.rs
+++ b/crates/floe-core/src/io/write/iceberg.rs
@@ -1,0 +1,33 @@
+use std::collections::HashMap;
+use std::path::Path;
+
+use polars::prelude::DataFrame;
+
+use crate::io::format::{AcceptedSinkAdapter, StorageTarget};
+use crate::{config, io, ConfigError, FloeResult};
+
+struct IcebergAcceptedAdapter;
+
+static ICEBERG_ACCEPTED_ADAPTER: IcebergAcceptedAdapter = IcebergAcceptedAdapter;
+
+pub(crate) fn iceberg_accepted_adapter() -> &'static dyn AcceptedSinkAdapter {
+    &ICEBERG_ACCEPTED_ADAPTER
+}
+
+impl AcceptedSinkAdapter for IcebergAcceptedAdapter {
+    fn write_accepted(
+        &self,
+        _target: &StorageTarget,
+        _df: &mut DataFrame,
+        _source_stem: &str,
+        _temp_dir: Option<&Path>,
+        _s3_clients: &mut HashMap<String, io::fs::s3::S3Client>,
+        _resolver: &config::FilesystemResolver,
+        entity: &config::EntityConfig,
+    ) -> FloeResult<String> {
+        Err(Box::new(ConfigError(format!(
+            "entity.name={} sink.accepted.format=iceberg is not supported yet (filesystem catalog writer not implemented)",
+            entity.name
+        ))))
+    }
+}

--- a/crates/floe-core/src/io/write/mod.rs
+++ b/crates/floe-core/src/io/write/mod.rs
@@ -1,5 +1,6 @@
 pub mod csv;
 pub mod delta;
+pub mod iceberg;
 pub mod parquet;
 
 use std::path::{Path, PathBuf};
@@ -51,7 +52,6 @@ pub fn archive_input(source_path: &Path, archive_dir: &Path) -> FloeResult<PathB
     }
     Ok(destination)
 }
-
 fn build_reject_errors_path(base_path: &str, source_stem: &str) -> PathBuf {
     let base = Path::new(base_path);
     let dir = if base.extension().is_some() {

--- a/crates/floe-core/tests/config_validation.rs
+++ b/crates/floe-core/tests/config_validation.rs
@@ -325,6 +325,34 @@ fn rejected_format_errors() {
 }
 
 #[test]
+fn iceberg_accepted_format_errors() {
+    let entity = r#"  - name: "customer"
+    source:
+      format: "csv"
+      path: "/tmp/input"
+    sink:
+      accepted:
+        format: "iceberg"
+        path: "/tmp/out"
+    policy:
+      severity: "warn"
+    schema:
+      columns:
+        - name: "customer_id"
+          type: "string"
+"#;
+    let yaml = base_config(entity);
+    assert_validation_error(
+        &yaml,
+        &[
+            "entity.name=customer",
+            "sink.accepted.format=iceberg",
+            "not supported yet",
+        ],
+    );
+}
+
+#[test]
 fn unknown_root_field_errors() {
     let yaml = r#"version: "0.1"
 report:

--- a/docs/config.md
+++ b/docs/config.md
@@ -110,7 +110,8 @@ Free-form entity metadata. Supported keys: `data_product`, `domain`, `owner`,
 ### `sink` (required)
 
 - `accepted` (required)
-  - `format`: `parquet` (v0.1). `delta` reserved for later.
+  - `format`: `parquet` or `delta` (local). `iceberg` is recognized but not
+    implemented yet.
   - `path`: output directory for accepted records.
 - `rejected` (required when `policy.severity: reject`)
   - `format`: `csv` (v0.1).

--- a/docs/sinks/iceberg.md
+++ b/docs/sinks/iceberg.md
@@ -1,0 +1,41 @@
+# Iceberg sink (accepted output)
+
+Floe recognizes `sink.accepted.format: iceberg`, but it does not yet write
+Iceberg tables. The CLI fails fast with a clear error so configs remain
+forward-compatible.
+
+## Filesystem catalog model
+
+- Table identity: `sink.accepted.path` (table root directory).
+- Metadata lives under `<path>/metadata/` (filesystem catalog layout).
+- No external catalog integration in v0.2.
+
+## Example config
+
+```yaml
+entities:
+  - name: "customer"
+    source:
+      format: "csv"
+      path: "/data/in/customers.csv"
+    sink:
+      accepted:
+        format: "iceberg"
+        path: "/data/out/customer_iceberg"
+    policy:
+      severity: "warn"
+    schema:
+      columns:
+        - name: "customer_id"
+          type: "string"
+```
+
+## Limitations (v0.2)
+
+- Writer not implemented; `floe validate` and `floe run` return a clear error.
+- Only local filesystem catalog is planned; cloud catalogs are not supported yet.
+
+## Next steps
+
+- Implement a filesystem catalog writer (metadata + data files).
+- Map Floe schema types to Iceberg types and handle overwrite semantics.


### PR DESCRIPTION
## Summary
- register iceberg accepted sink and return a clear not-implemented error
- add validation coverage and update config docs
- add filesystem-catalog design doc for the iceberg sink

## Testing
- cargo fmt --all
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test --all
