### PR TITLE
chore: prepare v0.1.4 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to Floe are documented in this file.
 
+## v0.1.4
+
+- Added delta accepted sink support with overwrite semantics (local filesystem only).
+- Added iceberg accepted sink configuration stub with a clear not-implemented error.
+- Added `sink.accepted.options` for parquet compression and row group sizing.
+
 ## v0.1.3
 
 - Added a format registry with adapter traits for inputs and sinks.

--- a/crates/floe-cli/Cargo.toml
+++ b/crates/floe-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "floe-cli"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2021"
 description = "CLI for Floe, a YAML-driven technical ingestion tool."
 license = "MIT"
@@ -17,4 +17,4 @@ path = "src/main.rs"
 
 [dependencies]
 clap = { version = "4", features = ["derive"] }
-floe-core = { path = "../floe-core", version = "0.1.3" }
+floe-core = { path = "../floe-core", version = "0.1.4" }

--- a/crates/floe-core/Cargo.toml
+++ b/crates/floe-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "floe-core"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2021"
 description = "Core library for Floe, a YAML-driven technical ingestion tool."
 license = "MIT"


### PR DESCRIPTION
## Summary
- bump crate versions to 0.1.4
- update floe-core dependency version in CLI
- add v0.1.4 changelog entries

## Testing
- not run (version/changelog only)
