### PR TITLE
release: v0.1.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to Floe are documented in this file.
 
+## v0.1.5
+
+- Refactored storage configuration and IO to use a shared storage client abstraction.
+- Split the entity runner into focused modules and centralized warning handling.
+- Added configurable row error formatting (json/csv/text) in reports.
+- Unified input resolution logic and reorganized run/config tests.
+- Improved warn-mode performance and added lazy scan paths for CSV/Parquet.
+- Added benchmark harness docs/scripts and example reports for v0.1.5.
+
 ## v0.1.4
 
 - Added delta accepted sink support with overwrite semantics (local storage only).

--- a/crates/floe-cli/Cargo.toml
+++ b/crates/floe-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "floe-cli"
-version = "0.1.4"
+version = "0.1.5"
 edition = "2021"
 description = "CLI for Floe, a YAML-driven technical ingestion tool."
 license = "MIT"
@@ -17,4 +17,4 @@ path = "src/main.rs"
 
 [dependencies]
 clap = { version = "4", features = ["derive"] }
-floe-core = { path = "../floe-core", version = "0.1.4" }
+floe-core = { path = "../floe-core", version = "0.1.5" }

--- a/crates/floe-core/Cargo.toml
+++ b/crates/floe-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "floe-core"
-version = "0.1.4"
+version = "0.1.5"
 edition = "2021"
 description = "Core library for Floe, a YAML-driven technical ingestion tool."
 license = "MIT"


### PR DESCRIPTION
## Summary
- bump floe-core and floe-cli to 0.1.5
- update changelog with v0.1.5 highlights

## Testing
- not run (version/changelog only)