### PR TITLE
refactor(validation): enforce file->row->entity order

### DIFF
--- a/crates/floe-core/src/checks/mod.rs
+++ b/crates/floe-core/src/checks/mod.rs
@@ -9,9 +9,11 @@ use std::collections::HashMap;
 use crate::{ConfigError, FloeResult};
 
 pub use cast::{cast_mismatch_counts, cast_mismatch_errors};
-pub use mismatch::{apply_schema_mismatch, MismatchOutcome};
+pub use mismatch::{
+    apply_mismatch_plan, apply_schema_mismatch, plan_schema_mismatch, MismatchOutcome,
+};
 pub use not_null::{not_null_counts, not_null_errors};
-pub use unique::{unique_counts, unique_errors};
+pub use unique::{unique_counts, unique_errors, UniqueTracker};
 
 pub type ColumnIndex = HashMap<String, usize>;
 

--- a/crates/floe-core/src/io/read/json.rs
+++ b/crates/floe-core/src/io/read/json.rs
@@ -1,4 +1,5 @@
 use std::collections::{BTreeMap, HashSet};
+use std::io::BufRead;
 use std::path::Path;
 
 use polars::prelude::{DataFrame, NamedFrom, Series};
@@ -94,9 +95,79 @@ pub fn read_ndjson_file(input_path: &Path) -> Result<DataFrame, JsonReadError> {
     })
 }
 
+pub fn read_ndjson_columns(input_path: &Path) -> Result<Vec<String>, JsonReadError> {
+    let file = std::fs::File::open(input_path).map_err(|err| JsonReadError {
+        rule: "json_parse_error".to_string(),
+        message: format!("failed to read json at {}: {err}", input_path.display()),
+    })?;
+    let reader = std::io::BufReader::new(file);
+    let mut first_error: Option<JsonReadError> = None;
+
+    for (idx, line) in reader.lines().enumerate() {
+        let line = line.map_err(|err| JsonReadError {
+            rule: "json_parse_error".to_string(),
+            message: format!("failed to read json at {}: {err}", input_path.display()),
+        })?;
+        let line = line.trim();
+        if line.is_empty() {
+            continue;
+        }
+        match serde_json::from_str::<Value>(line) {
+            Ok(value) => {
+                let object = value.as_object().ok_or_else(|| JsonReadError {
+                    rule: "json_parse_error".to_string(),
+                    message: format!("expected json object at line {}", idx + 1),
+                })?;
+                let mut keys = Vec::with_capacity(object.len());
+                for (key, value) in object {
+                    if value.is_object() || value.is_array() {
+                        return Err(JsonReadError {
+                            rule: "json_unsupported_value".to_string(),
+                            message: format!(
+                                "nested json values are not supported (line {}, key {})",
+                                idx + 1,
+                                key
+                            ),
+                        });
+                    }
+                    keys.push(key.clone());
+                }
+                keys.sort();
+                return Ok(keys);
+            }
+            Err(err) => {
+                if first_error.is_none() {
+                    first_error = Some(JsonReadError {
+                        rule: "json_parse_error".to_string(),
+                        message: format!("json parse error at line {}: {err}", idx + 1),
+                    });
+                }
+                continue;
+            }
+        }
+    }
+
+    Err(first_error.unwrap_or_else(|| JsonReadError {
+        rule: "json_parse_error".to_string(),
+        message: format!("no json objects found in {}", input_path.display()),
+    }))
+}
+
 impl InputAdapter for JsonInputAdapter {
     fn format(&self) -> &'static str {
         "json"
+    }
+
+    fn read_input_columns(
+        &self,
+        _entity: &config::EntityConfig,
+        input_file: &InputFile,
+        _columns: &[config::ColumnConfig],
+    ) -> Result<Vec<String>, FileReadError> {
+        read_ndjson_columns(&input_file.source_local_path).map_err(|err| FileReadError {
+            rule: err.rule,
+            message: err.message,
+        })
     }
 
     fn read_inputs(

--- a/crates/floe-core/src/io/storage/inputs.rs
+++ b/crates/floe-core/src/io/storage/inputs.rs
@@ -138,6 +138,15 @@ mod tests {
             Ok(vec![".csv".to_string()])
         }
 
+        fn read_input_columns(
+            &self,
+            _entity: &config::EntityConfig,
+            _input_file: &io::format::InputFile,
+            _columns: &[config::ColumnConfig],
+        ) -> Result<Vec<String>, io::format::FileReadError> {
+            Ok(vec!["id".to_string()])
+        }
+
         fn read_inputs(
             &self,
             _entity: &config::EntityConfig,

--- a/crates/floe-core/src/run/file.rs
+++ b/crates/floe-core/src/run/file.rs
@@ -2,10 +2,6 @@ use polars::prelude::DataFrame;
 
 use crate::{check, config, io, FloeResult};
 
-use io::format::{InputAdapter, InputFile, ReadInput};
-
-pub(super) type ValidationCollect = io::format::ValidationCollect;
-
 pub(super) fn required_columns(columns: &[config::ColumnConfig]) -> Vec<String> {
     columns
         .iter()
@@ -14,17 +10,7 @@ pub(super) fn required_columns(columns: &[config::ColumnConfig]) -> Vec<String> 
         .collect()
 }
 
-pub(super) fn read_inputs(
-    adapter: &dyn InputAdapter,
-    entity: &config::EntityConfig,
-    files: &[InputFile],
-    columns: &[config::ColumnConfig],
-    normalize_strategy: Option<&str>,
-    collect_raw: bool,
-) -> FloeResult<Vec<ReadInput>> {
-    adapter.read_inputs(entity, files, columns, normalize_strategy, collect_raw)
-}
-pub(super) fn collect_errors(
+pub(super) fn collect_row_errors(
     raw_df: &DataFrame,
     typed_df: &DataFrame,
     required_cols: &[String],
@@ -32,9 +18,8 @@ pub(super) fn collect_errors(
     track_cast_errors: bool,
     raw_indices: &check::ColumnIndex,
     typed_indices: &check::ColumnIndex,
-    formatter: &dyn check::RowErrorFormatter,
-) -> FloeResult<ValidationCollect> {
-    io::format::collect_errors(
+) -> FloeResult<Vec<Vec<check::RowError>>> {
+    io::format::collect_row_errors(
         raw_df,
         typed_df,
         required_cols,
@@ -42,6 +27,5 @@ pub(super) fn collect_errors(
         track_cast_errors,
         raw_indices,
         typed_indices,
-        formatter,
     )
 }

--- a/crates/floe-core/tests/run_check_order.rs
+++ b/crates/floe-core/tests/run_check_order.rs
@@ -1,0 +1,172 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use floe_core::report::{FileStatus, MismatchAction, RuleName};
+use floe_core::{run, RunOptions};
+use polars::prelude::{ParquetReader, SerReader};
+
+fn temp_dir(prefix: &str) -> PathBuf {
+    let mut path = std::env::temp_dir();
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_nanos())
+        .unwrap_or(0);
+    path.push(format!("{prefix}-{nanos}"));
+    fs::create_dir_all(&path).expect("create temp dir");
+    path
+}
+
+fn write_csv(dir: &Path, name: &str, contents: &str) -> PathBuf {
+    let path = dir.join(name);
+    fs::write(&path, contents).expect("write csv");
+    path
+}
+
+fn write_config(dir: &Path, contents: &str) -> PathBuf {
+    let path = dir.join("config.yml");
+    fs::write(&path, contents).expect("write config");
+    path
+}
+
+fn run_config(path: &Path) -> floe_core::RunOutcome {
+    run(
+        path,
+        RunOptions {
+            run_id: Some("test-run".to_string()),
+            entities: Vec::new(),
+        },
+    )
+    .expect("run config")
+}
+
+#[test]
+fn unique_across_files_rejects_duplicates() {
+    let root = temp_dir("floe-unique-entity");
+    let input_dir = root.join("in");
+    let accepted_dir = root.join("out/accepted");
+    let rejected_dir = root.join("out/rejected");
+    let report_dir = root.join("report");
+    fs::create_dir_all(&input_dir).expect("create input dir");
+    write_csv(&input_dir, "a.csv", "id;name\n1;alice\n2;bob\n");
+    write_csv(&input_dir, "b.csv", "id;name\n2;carol\n3;dave\n");
+
+    let yaml = format!(
+        r#"version: "0.1"
+report:
+  path: "{report_dir}"
+entities:
+  - name: "orders"
+    source:
+      format: "csv"
+      path: "{input_dir}"
+    sink:
+      accepted:
+        format: "parquet"
+        path: "{accepted_dir}"
+      rejected:
+        format: "csv"
+        path: "{rejected_dir}"
+    policy:
+      severity: "reject"
+    schema:
+      columns:
+        - name: "id"
+          type: "string"
+          unique: true
+        - name: "name"
+          type: "string"
+"#,
+        report_dir = report_dir.display(),
+        input_dir = input_dir.display(),
+        accepted_dir = accepted_dir.display(),
+        rejected_dir = rejected_dir.display(),
+    );
+    let config_path = write_config(&root, &yaml);
+
+    let outcome = run_config(&config_path);
+    let report = &outcome.entity_outcomes[0].report;
+    let file_a = report
+        .files
+        .iter()
+        .find(|file| file.input_file.ends_with("a.csv"))
+        .expect("file a");
+    let file_b = report
+        .files
+        .iter()
+        .find(|file| file.input_file.ends_with("b.csv"))
+        .expect("file b");
+    assert_eq!(file_a.status, FileStatus::Success);
+    assert_eq!(file_b.status, FileStatus::Rejected);
+    assert!(file_b
+        .validation
+        .rules
+        .iter()
+        .any(|rule| rule.rule == RuleName::Unique));
+
+    let accepted_path = accepted_dir.join("b.parquet");
+    let file = std::fs::File::open(&accepted_path).expect("open accepted parquet");
+    let df = ParquetReader::new(file)
+        .finish()
+        .expect("read accepted parquet");
+    assert_eq!(df.height(), 1);
+
+    let rejected_path = rejected_dir.join("b_rejected.csv");
+    let rejected_contents = fs::read_to_string(&rejected_path).expect("read rejected csv");
+    assert!(rejected_contents.contains("__floe_errors"));
+    assert!(rejected_contents.contains("unique"));
+}
+
+#[test]
+fn mismatch_rejects_before_row_checks() {
+    let root = temp_dir("floe-mismatch-precheck");
+    let input_dir = root.join("in");
+    let accepted_dir = root.join("out/accepted");
+    let rejected_dir = root.join("out/rejected");
+    let report_dir = root.join("report");
+    fs::create_dir_all(&input_dir).expect("create input dir");
+    write_csv(&input_dir, "input.csv", "id\n1\n");
+
+    let yaml = format!(
+        r#"version: "0.1"
+report:
+  path: "{report_dir}"
+entities:
+  - name: "customer"
+    source:
+      format: "csv"
+      path: "{input_dir}"
+    sink:
+      accepted:
+        format: "parquet"
+        path: "{accepted_dir}"
+      rejected:
+        format: "csv"
+        path: "{rejected_dir}"
+    policy:
+      severity: "reject"
+    schema:
+      mismatch:
+        missing_columns: "reject_file"
+      columns:
+        - name: "id"
+          type: "string"
+        - name: "name"
+          type: "string"
+"#,
+        report_dir = report_dir.display(),
+        input_dir = input_dir.display(),
+        accepted_dir = accepted_dir.display(),
+        rejected_dir = rejected_dir.display(),
+    );
+    let config_path = write_config(&root, &yaml);
+
+    let outcome = run_config(&config_path);
+    let file = &outcome.entity_outcomes[0].report.files[0];
+    assert_eq!(file.status, FileStatus::Rejected);
+    assert_eq!(file.mismatch.mismatch_action, MismatchAction::RejectedFile);
+
+    let rejected_path = rejected_dir.join("input.csv");
+    let rejected_contents = fs::read_to_string(&rejected_path).expect("read rejected csv");
+    assert!(!rejected_contents.contains("__floe_errors"));
+}

--- a/docs/checks.md
+++ b/docs/checks.md
@@ -2,6 +2,8 @@
 
 This document describes the validation checks implemented in Floe, the supported
 column types for casting, and how `policy.severity` applies to each check.
+For the full execution order (file-level vs row-level vs entity-level), see
+`docs/how-it-works.md`.
 
 ## Checks
 
@@ -19,7 +21,7 @@ column types for casting, and how `policy.severity` applies to each check.
 - **Logic**: the first occurrence is accepted; any later duplicate values are flagged.
 - **Notes**:
   - Null values are ignored (they do not count as duplicates).
-  - Applies independently per column.
+  - Applies independently per column, across all input files in the entity.
 
 ### cast_error (type mismatch)
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -173,3 +173,4 @@ ignored):
 - `time`: `time`
 
 For more details about checks and severity behavior, see `docs/checks.md`.
+Execution order and pipeline phases are documented in `docs/how-it-works.md`.

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -1,0 +1,57 @@
+# How Floe Works
+
+This document describes the canonical ingestion pipeline Floe uses for each
+entity. The order is deterministic and is reflected in reports.
+
+## Pipeline phases
+
+### A) Entity planning (entity-level)
+
+1. Resolve input files/objects (local directory/glob or storage prefix).
+2. Resolve storage targets for accepted/rejected/report outputs.
+3. Prepare output directories if needed.
+
+### B) File-level prechecks (per file)
+
+Floe inspects only the file header/schema before reading full data:
+
+- **CSV**: header row (or the first row for headerless CSV).
+- **Parquet**: schema metadata.
+- **NDJSON**: the first valid JSON object line.
+
+Then it applies the schema mismatch policy:
+
+- Missing columns: `fill_nulls` or `reject_file`
+- Extra columns: `ignore` or `reject_file`
+
+If `reject_file` is triggered, the file is rejected/aborted according to
+`policy.severity`, and **row-level validation does not run** for that file.
+
+### C) Row-level validation (per file)
+
+For files that passed prechecks:
+
+1. Read full data into a dataframe.
+2. Apply casts (`cast_mode`).
+3. Apply `not_null` checks.
+4. Build per-row error lists and counters.
+
+### D) Entity-level uniqueness (across files)
+
+After row-level validation, uniqueness is evaluated across the **entire entity**
+in file order. The first occurrence is accepted; later duplicates are flagged.
+This is the only entity-level check in v0.1/v0.2.
+
+## Severity behavior
+
+- **warn**: keep rows, emit warnings and error reports.
+- **reject**: reject rows with violations; write rejected output.
+- **abort**: abort the file when violations occur.
+
+## Report mapping
+
+- `files[].mismatch`: file-level precheck outcome (missing/extra + action).
+- `files[].validation`: row-level + entity-level checks (cast/not_null/unique).
+- `results`: totals aggregated across files and checks.
+
+See `docs/report.md` for the report schema and `docs/checks.md` for rule details.


### PR DESCRIPTION
## Summary
- introduce header/schema-only prechecks and plan/apply mismatch handling
- enforce row-level cast/not_null before entity-level unique across files
- add entity-level unique tracker and new check-order tests
- document pipeline order in docs/how-it-works.md and update checks/config docs

## Testing
- cargo fmt --all
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test --all