### PR TITLE
chore(release): v0.1.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to Floe are documented in this file.
 
+## v0.1.6
+
+- Added JSON array input mode alongside NDJSON, with config validation updates.
+- Added entity-level accepted output with part files and cleared stale S3 outputs.
+- Enforced validation order (file → row → entity) and fixed unique checks by rechunking.
+- Expanded and reorganized core test suites (grouped modules) and improved CI test caching.
+
 ## v0.1.5
 
 - Refactored storage configuration and IO to use a shared storage client abstraction.

--- a/crates/floe-cli/Cargo.toml
+++ b/crates/floe-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "floe-cli"
-version = "0.1.5"
+version = "0.1.6"
 edition = "2021"
 description = "CLI for Floe, a YAML-driven technical ingestion tool."
 license = "MIT"
@@ -17,4 +17,4 @@ path = "src/main.rs"
 
 [dependencies]
 clap = { version = "4", features = ["derive"] }
-floe-core = { path = "../floe-core", version = "0.1.5" }
+floe-core = { path = "../floe-core", version = "0.1.6" }

--- a/crates/floe-core/Cargo.toml
+++ b/crates/floe-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "floe-core"
-version = "0.1.5"
+version = "0.1.6"
 edition = "2021"
 description = "Core library for Floe, a YAML-driven technical ingestion tool."
 license = "MIT"


### PR DESCRIPTION
## Summary
- Bump floe-core and floe-cli to v0.1.6
- Update floe-cli dependency on floe-core to 0.1.6
- Add v0.1.6 changelog entry

## Notes
- No code changes beyond release metadata.