### PR TITLE
fix(delta): implement overwrite via delta transactions

### DIFF
--- a/crates/floe-cli/src/output.rs
+++ b/crates/floe-cli/src/output.rs
@@ -232,6 +232,7 @@ mod tests {
                 accepted_rows: 8,
                 parts_written: 1,
                 part_files: vec!["part-00000.parquet".to_string()],
+                table_version: None,
             },
             results: report::ResultsTotals {
                 files_total: 1,

--- a/crates/floe-core/src/io/format.rs
+++ b/crates/floe-core/src/io/format.rs
@@ -37,6 +37,7 @@ pub enum ReadInput {
 pub struct AcceptedWriteOutput {
     pub parts_written: u64,
     pub part_files: Vec<String>,
+    pub table_version: Option<i64>,
 }
 
 pub trait InputAdapter: Send + Sync {

--- a/crates/floe-core/src/io/write/parquet.rs
+++ b/crates/floe-core/src/io/write/parquet.rs
@@ -123,6 +123,7 @@ impl AcceptedSinkAdapter for ParquetAcceptedAdapter {
         Ok(AcceptedWriteOutput {
             parts_written,
             part_files,
+            table_version: None,
         })
     }
 }

--- a/crates/floe-core/src/report/mod.rs
+++ b/crates/floe-core/src/report/mod.rs
@@ -123,6 +123,9 @@ pub struct AcceptedOutputSummary {
     #[serde(default)]
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub part_files: Vec<String>,
+    #[serde(default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub table_version: Option<i64>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -477,6 +480,7 @@ mod tests {
                 accepted_rows: 10,
                 parts_written: 1,
                 part_files: vec!["part-00000.parquet".to_string()],
+                table_version: None,
             },
             results: ResultsTotals {
                 files_total: 1,

--- a/crates/floe-core/src/run/entity/entity_report.rs
+++ b/crates/floe-core/src/run/entity/entity_report.rs
@@ -16,6 +16,7 @@ pub(super) struct RunReportContext<'a> {
     pub severity: report::Severity,
     pub accepted_parts_written: u64,
     pub accepted_part_files: Vec<String>,
+    pub accepted_table_version: Option<i64>,
 }
 
 pub(super) fn build_run_report(ctx: RunReportContext<'_>) -> report::RunReport {
@@ -74,6 +75,7 @@ pub(super) fn build_run_report(ctx: RunReportContext<'_>) -> report::RunReport {
             accepted_rows: ctx.totals.accepted_total,
             parts_written: ctx.accepted_parts_written,
             part_files: ctx.accepted_part_files,
+            table_version: ctx.accepted_table_version,
         },
         results: ctx.totals,
         files: ctx.file_reports,

--- a/crates/floe-core/src/run/entity/mod.rs
+++ b/crates/floe-core/src/run/entity/mod.rs
@@ -674,6 +674,7 @@ pub(super) fn run_entity(
     let accepted_target_uri = accepted_target.target_uri().to_string();
     let mut accepted_parts_written = 0;
     let mut accepted_part_files = Vec::new();
+    let mut accepted_table_version = None;
     if let Some(mut accepted_df) = accepted_accum {
         let output_stem = io::storage::paths::build_part_stem(0);
         let accepted_output = write_accepted_output(
@@ -688,6 +689,7 @@ pub(super) fn run_entity(
         )?;
         accepted_parts_written = accepted_output.parts_written;
         accepted_part_files = accepted_output.part_files;
+        accepted_table_version = accepted_output.table_version;
     }
     if accepted_parts_written > 0 {
         for file_report in &mut file_reports {
@@ -708,6 +710,7 @@ pub(super) fn run_entity(
         severity,
         accepted_parts_written,
         accepted_part_files,
+        accepted_table_version,
     });
 
     if let Some(report_dir) = &context.report_dir {

--- a/docs/sinks/delta.md
+++ b/docs/sinks/delta.md
@@ -17,5 +17,6 @@ entities:
 
 Semantics:
 - `sink.accepted.format: delta` writes a Delta table at `sink.accepted.path`.
-- Write mode is `overwrite` (the table at the path is replaced on each run).
+- Write mode is `overwrite` via Delta transactions (a new `_delta_log` version is
+  committed; history is preserved).
 - Local storage only (S3 is not supported yet for delta output).


### PR DESCRIPTION
## Summary
- commit delta overwrites via delta-rs transactions and preserve _delta_log history
- capture committed delta table version in accepted output summary
- extend delta sink docs and update tests to assert version increments

## Testing
- cargo fmt --all
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test --all