### PR TITLE
feat(config): add adls storage definition and uri resolution

### DIFF
--- a/crates/floe-core/src/config/parse.rs
+++ b/crates/floe-core/src/config/parse.rs
@@ -379,13 +379,23 @@ fn parse_storage_definition(value: &Yaml) -> FloeResult<StorageDefinition> {
     validate_known_keys(
         hash,
         "storages.definitions",
-        &["name", "type", "bucket", "region", "prefix"],
+        &[
+            "name",
+            "type",
+            "bucket",
+            "region",
+            "account",
+            "container",
+            "prefix",
+        ],
     )?;
     Ok(StorageDefinition {
         name: get_string(hash, "name", "storages.definitions")?,
         fs_type: get_string(hash, "type", "storages.definitions")?,
         bucket: opt_string(hash, "bucket", "storages.definitions")?,
         region: opt_string(hash, "region", "storages.definitions")?,
+        account: opt_string(hash, "account", "storages.definitions")?,
+        container: opt_string(hash, "container", "storages.definitions")?,
         prefix: opt_string(hash, "prefix", "storages.definitions")?,
     })
 }

--- a/crates/floe-core/src/config/types.rs
+++ b/crates/floe-core/src/config/types.rs
@@ -190,6 +190,8 @@ pub struct StorageDefinition {
     pub fs_type: String,
     pub bucket: Option<String>,
     pub region: Option<String>,
+    pub account: Option<String>,
+    pub container: Option<String>,
     pub prefix: Option<String>,
 }
 

--- a/crates/floe-core/src/io/storage/mod.rs
+++ b/crates/floe-core/src/io/storage/mod.rs
@@ -61,6 +61,11 @@ impl CloudClient {
                     })?;
                     Box::new(s3::S3Client::new(bucket, definition.region.as_deref())?)
                 }
+                "adls" => {
+                    return Err(Box::new(ConfigError(
+                        "storage type adls is not implemented yet (list/get/put)".to_string(),
+                    )))
+                }
                 other => {
                     return Err(Box::new(ConfigError(format!(
                         "storage type {} is unsupported",

--- a/crates/floe-core/src/lib.rs
+++ b/crates/floe-core/src/lib.rs
@@ -49,3 +49,7 @@ pub fn validate(config_path: &Path, options: ValidateOptions) -> FloeResult<()> 
 pub fn load_config(config_path: &Path) -> FloeResult<config::RootConfig> {
     config::parse_config(config_path)
 }
+
+pub fn validate_config_for_tests(config: &config::RootConfig) -> FloeResult<()> {
+    config::validate_config(config)
+}

--- a/crates/floe-core/tests/config.rs
+++ b/crates/floe-core/tests/config.rs
@@ -1,3 +1,7 @@
+#[path = "config/adls_storage.rs"]
+mod adls_storage;
+#[path = "config/adls_validation.rs"]
+mod adls_validation;
 #[path = "config/config_validation.rs"]
 mod config_validation;
 #[path = "config/parse.rs"]

--- a/crates/floe-core/tests/config/adls_storage.rs
+++ b/crates/floe-core/tests/config/adls_storage.rs
@@ -1,0 +1,65 @@
+use floe_core::config;
+use floe_core::config::StorageResolver;
+use floe_core::FloeResult;
+
+fn base_root() -> config::RootConfig {
+    config::RootConfig {
+        version: "0.1".to_string(),
+        metadata: None,
+        storages: None,
+        env: None,
+        domains: Vec::new(),
+        report: None,
+        entities: Vec::new(),
+    }
+}
+
+#[test]
+fn adls_uri_with_prefix_is_built() -> FloeResult<()> {
+    let mut config = base_root();
+    config.storages = Some(config::StoragesConfig {
+        default: Some("adls".to_string()),
+        definitions: vec![config::StorageDefinition {
+            name: "adls".to_string(),
+            fs_type: "adls".to_string(),
+            bucket: None,
+            region: None,
+            account: Some("acct".to_string()),
+            container: Some("cont".to_string()),
+            prefix: Some("prefix".to_string()),
+        }],
+    });
+
+    let resolver = StorageResolver::new(&config, std::path::Path::new("."))?;
+    let resolved = resolver.resolve_path("entity", "source.storage", None, "data/file.csv")?;
+    assert_eq!(
+        resolved.uri,
+        "abfs://cont@acct.dfs.core.windows.net/prefix/data/file.csv"
+    );
+    Ok(())
+}
+
+#[test]
+fn adls_uri_without_prefix_is_built() -> FloeResult<()> {
+    let mut config = base_root();
+    config.storages = Some(config::StoragesConfig {
+        default: Some("adls".to_string()),
+        definitions: vec![config::StorageDefinition {
+            name: "adls".to_string(),
+            fs_type: "adls".to_string(),
+            bucket: None,
+            region: None,
+            account: Some("acct".to_string()),
+            container: Some("cont".to_string()),
+            prefix: None,
+        }],
+    });
+
+    let resolver = StorageResolver::new(&config, std::path::Path::new("."))?;
+    let resolved = resolver.resolve_path("entity", "source.storage", None, "data/file.csv")?;
+    assert_eq!(
+        resolved.uri,
+        "abfs://cont@acct.dfs.core.windows.net/data/file.csv"
+    );
+    Ok(())
+}

--- a/crates/floe-core/tests/config/adls_validation.rs
+++ b/crates/floe-core/tests/config/adls_validation.rs
@@ -1,0 +1,101 @@
+use floe_core::config;
+
+fn base_entity() -> config::EntityConfig {
+    config::EntityConfig {
+        name: "customer".to_string(),
+        metadata: None,
+        domain: None,
+        source: config::SourceConfig {
+            format: "csv".to_string(),
+            path: "in.csv".to_string(),
+            storage: None,
+            options: None,
+            cast_mode: None,
+        },
+        sink: config::SinkConfig {
+            accepted: config::SinkTarget {
+                format: "csv".to_string(),
+                path: "out.csv".to_string(),
+                storage: None,
+                options: None,
+            },
+            rejected: None,
+            archive: None,
+        },
+        policy: config::PolicyConfig {
+            severity: "warn".to_string(),
+        },
+        schema: config::SchemaConfig {
+            normalize_columns: None,
+            mismatch: None,
+            columns: Vec::new(),
+        },
+    }
+}
+
+#[test]
+fn adls_missing_required_fields_errors() {
+    let mut config = config::RootConfig {
+        version: "0.1".to_string(),
+        metadata: None,
+        storages: Some(config::StoragesConfig {
+            default: Some("adls".to_string()),
+            definitions: vec![config::StorageDefinition {
+                name: "adls".to_string(),
+                fs_type: "adls".to_string(),
+                bucket: None,
+                region: None,
+                account: None,
+                container: None,
+                prefix: None,
+            }],
+        }),
+        env: None,
+        domains: Vec::new(),
+        report: None,
+        entities: vec![base_entity()],
+    };
+
+    let err = floe_core::validate_config_for_tests(&config).expect_err("expected error");
+    assert!(err.to_string().contains("requires account"));
+
+    config.storages.as_mut().unwrap().definitions[0].account = Some("acct".to_string());
+    let err = floe_core::validate_config_for_tests(&config).expect_err("expected error");
+    assert!(err.to_string().contains("requires container"));
+}
+
+#[test]
+fn adls_referenced_errors_until_implemented() {
+    let mut config = config::RootConfig {
+        version: "0.1".to_string(),
+        metadata: None,
+        storages: Some(config::StoragesConfig {
+            default: Some("adls".to_string()),
+            definitions: vec![config::StorageDefinition {
+                name: "adls".to_string(),
+                fs_type: "adls".to_string(),
+                bucket: None,
+                region: None,
+                account: Some("acct".to_string()),
+                container: Some("cont".to_string()),
+                prefix: None,
+            }],
+        }),
+        env: None,
+        domains: Vec::new(),
+        report: None,
+        entities: vec![base_entity()],
+    };
+
+    config.entities[0].source.storage = Some("adls".to_string());
+    let err = floe_core::validate_config_for_tests(&config).expect_err("expected error");
+    assert!(err
+        .to_string()
+        .contains("source.storage=adls is not implemented"));
+
+    config.entities[0].source.storage = Some("local".to_string());
+    config.entities[0].sink.accepted.storage = Some("adls".to_string());
+    let err = floe_core::validate_config_for_tests(&config).expect_err("expected error");
+    let message = err.to_string();
+    assert!(!message.is_empty());
+}

--- a/crates/floe-core/tests/io_tests/write/object_store.rs
+++ b/crates/floe-core/tests/io_tests/write/object_store.rs
@@ -13,6 +13,8 @@ fn sample_config() -> config::RootConfig {
                 fs_type: "s3".to_string(),
                 bucket: Some("my-bucket".to_string()),
                 region: Some("eu-west-1".to_string()),
+                account: None,
+                container: None,
                 prefix: Some("data".to_string()),
             }],
         }),

--- a/docs/storages/adls.md
+++ b/docs/storages/adls.md
@@ -1,0 +1,39 @@
+# ADLS Storage (planned)
+
+Floe supports configuring ADLS storage definitions but the backend is not implemented yet.
+This file documents the intended configuration and canonical URI format.
+
+## Config fields
+
+```yaml
+storages:
+  default: adls_raw
+  definitions:
+    - name: adls_raw
+      type: adls
+      account: myaccount
+      container: raw
+      prefix: ingest
+```
+
+Required:
+- `account`
+- `container`
+
+Optional:
+- `prefix` (default empty)
+
+## Canonical URI format
+
+```
+abfs://<container>@<account>.dfs.core.windows.net/<prefix>/<path>
+```
+
+Examples:
+- `abfs://raw@myaccount.dfs.core.windows.net/ingest/customers/customers.csv`
+- `abfs://raw@myaccount.dfs.core.windows.net/customers/customers.csv` (no prefix)
+
+## Status
+
+The ADLS storage backend is **not implemented yet** (no list/get/put). Any config that
+references `type: adls` will fail fast with a clear error until the backend is added.


### PR DESCRIPTION
## Summary
- add adls storage fields (account/container) and validation
- add abfs URI resolution in storage resolver
- fail fast when adls storage is referenced (backend not implemented yet)
- add docs stub for ADLS config

## Testing
- cargo fmt --all
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test -p floe-core --test config
- cargo test -p floe-core --test io_format --test io_read --test io_storage --test io_write --test run_entity --test run_checks --test run_schema --test run_report --test run_check_order --test run_normalize