### PR TITLE
feat(storage): add adls list/download/upload (mvp)

### DIFF
--- a/crates/floe-core/Cargo.toml
+++ b/crates/floe-core/Cargo.toml
@@ -25,3 +25,8 @@ aws-config = "1"
 aws-sdk-s3 = "1"
 tempfile = "3"
 tokio = { version = "1", features = ["rt", "rt-multi-thread", "fs", "io-util"] }
+azure_core = "0.20"
+azure_identity = "0.20"
+azure_storage = "0.20"
+azure_storage_blobs = "0.20"
+futures = "0.3"

--- a/crates/floe-core/src/config/validate.rs
+++ b/crates/floe-core/src/config/validate.rs
@@ -88,14 +88,7 @@ fn validate_source(entity: &EntityConfig, storages: &StorageRegistry) -> FloeRes
         }
     }
 
-    if let Some(storage_type) = storages.definition_type(&storage_name) {
-        if storage_type == "adls" {
-            return Err(Box::new(ConfigError(format!(
-                "entity.name={} source.storage=adls is not implemented yet (list/get/put)",
-                entity.name
-            ))));
-        }
-    }
+    let _ = storages.definition_type(&storage_name);
 
     Ok(())
 }
@@ -142,27 +135,13 @@ fn validate_sink(entity: &EntityConfig, storages: &StorageRegistry) -> FloeResul
         }
     }
 
-    if let Some(storage_type) = storages.definition_type(&accepted_storage) {
-        if storage_type == "adls" {
-            return Err(Box::new(ConfigError(format!(
-                "entity.name={} sink.accepted.storage=adls is not implemented yet (list/get/put)",
-                entity.name
-            ))));
-        }
-    }
+    let _ = storages.definition_type(&accepted_storage);
 
     if let Some(rejected) = &entity.sink.rejected {
         let rejected_storage =
             storages.resolve_name(entity, "sink.rejected.storage", rejected.storage.as_deref())?;
         storages.validate_reference(entity, "sink.rejected.storage", &rejected_storage)?;
-        if let Some(storage_type) = storages.definition_type(&rejected_storage) {
-            if storage_type == "adls" {
-                return Err(Box::new(ConfigError(format!(
-                    "entity.name={} sink.rejected.storage=adls is not implemented yet (list/get/put)",
-                    entity.name
-                ))));
-            }
-        }
+        let _ = storages.definition_type(&rejected_storage);
     }
 
     Ok(())

--- a/crates/floe-core/src/io/storage/adls.rs
+++ b/crates/floe-core/src/io/storage/adls.rs
@@ -1,0 +1,217 @@
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use azure_identity::{DefaultAzureCredential, TokenCredentialOptions};
+use azure_storage::StorageCredentials;
+use azure_storage_blobs::prelude::{BlobServiceClient, ContainerClient};
+use futures::StreamExt;
+use tokio::runtime::Runtime;
+
+use crate::errors::StorageError;
+use crate::{config, FloeResult};
+
+use super::{planner, ObjectRef, StorageClient};
+
+pub struct AdlsClient {
+    account: String,
+    container: String,
+    prefix: String,
+    runtime: Runtime,
+    container_client: ContainerClient,
+}
+
+impl AdlsClient {
+    pub fn new(definition: &config::StorageDefinition) -> FloeResult<Self> {
+        let account = definition.account.clone().ok_or_else(|| {
+            Box::new(StorageError(format!(
+                "storage {} requires account for type adls",
+                definition.name
+            )))
+        })?;
+        let container = definition.container.clone().ok_or_else(|| {
+            Box::new(StorageError(format!(
+                "storage {} requires container for type adls",
+                definition.name
+            )))
+        })?;
+        let prefix = definition.prefix.clone().unwrap_or_default();
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .map_err(|err| Box::new(StorageError(format!("adls runtime init failed: {err}"))))?;
+        let credential = DefaultAzureCredential::create(TokenCredentialOptions::default())
+            .map_err(|err| Box::new(StorageError(format!("adls credential init failed: {err}"))))?;
+        let storage_credentials = StorageCredentials::token_credential(Arc::new(credential));
+        let service_client = BlobServiceClient::new(account.clone(), storage_credentials);
+        let container_client = service_client.container_client(container.clone());
+        Ok(Self {
+            account,
+            container,
+            prefix,
+            runtime,
+            container_client,
+        })
+    }
+
+    fn base_prefix(&self) -> String {
+        planner::normalize_separators(&self.prefix)
+    }
+
+    fn full_path(&self, path: &str) -> String {
+        let prefix = self.base_prefix();
+        let joined = planner::join_prefix(&prefix, &planner::normalize_separators(path));
+        joined.trim_start_matches('/').to_string()
+    }
+
+    fn format_abfs(&self, path: &str) -> String {
+        let trimmed = path.trim_start_matches('/');
+        if trimmed.is_empty() {
+            format!(
+                "abfs://{}@{}.dfs.core.windows.net",
+                self.container, self.account
+            )
+        } else {
+            format!(
+                "abfs://{}@{}.dfs.core.windows.net/{}",
+                self.container, self.account, trimmed
+            )
+        }
+    }
+}
+
+impl StorageClient for AdlsClient {
+    fn list(&self, prefix_or_path: &str) -> FloeResult<Vec<ObjectRef>> {
+        let prefix = self.full_path(prefix_or_path);
+        let container = self.container.clone();
+        let account = self.account.clone();
+        let client = self.container_client.clone();
+        self.runtime.block_on(async move {
+            let mut refs = Vec::new();
+            let mut stream = client.list_blobs().prefix(prefix.clone()).into_stream();
+            while let Some(resp) = stream.next().await {
+                let resp = resp.map_err(|err| {
+                    Box::new(StorageError(format!("adls list failed: {err}")))
+                        as Box<dyn std::error::Error + Send + Sync>
+                })?;
+                for blob in resp.blobs.blobs() {
+                    let key = blob.name.clone();
+                    let uri = if key.is_empty() {
+                        format!("abfs://{}@{}.dfs.core.windows.net", container, account)
+                    } else {
+                        format!(
+                            "abfs://{}@{}.dfs.core.windows.net/{}",
+                            container, account, key
+                        )
+                    };
+                    refs.push(ObjectRef {
+                        uri,
+                        key,
+                        last_modified: Some(blob.properties.last_modified.to_string()),
+                        size: Some(blob.properties.content_length),
+                    });
+                }
+            }
+            Ok(planner::stable_sort_refs(refs))
+        })
+    }
+
+    fn download_to_temp(&self, uri: &str, temp_dir: &Path) -> FloeResult<PathBuf> {
+        let key = uri
+            .split_once(".dfs.core.windows.net/")
+            .map(|(_, tail)| tail)
+            .unwrap_or("")
+            .trim_start_matches('/')
+            .to_string();
+        let key = if key.is_empty() {
+            return Err(Box::new(StorageError(
+                "adls download requires a blob path".to_string(),
+            )));
+        } else {
+            key
+        };
+        let dest = temp_dir.join(
+            Path::new(&key)
+                .file_name()
+                .and_then(|name| name.to_str())
+                .unwrap_or("object"),
+        );
+        let dest_clone = dest.clone();
+        let client = self.container_client.clone();
+        let key_clone = key.clone();
+        self.runtime.block_on(async move {
+            if let Some(parent) = dest_clone.parent() {
+                tokio::fs::create_dir_all(parent).await?;
+            }
+            let blob = client.blob_client(key_clone);
+            let mut stream = blob.get().into_stream();
+            let mut file = tokio::fs::File::create(&dest_clone).await?;
+            while let Some(chunk) = stream.next().await {
+                let resp = chunk.map_err(|err| {
+                    Box::new(StorageError(format!("adls download failed: {err}")))
+                        as Box<dyn std::error::Error + Send + Sync>
+                })?;
+                let bytes = resp.data.collect().await.map_err(|err| {
+                    Box::new(StorageError(format!("adls download read failed: {err}")))
+                        as Box<dyn std::error::Error + Send + Sync>
+                })?;
+                tokio::io::AsyncWriteExt::write_all(&mut file, &bytes).await?;
+            }
+            Ok::<(), Box<dyn std::error::Error + Send + Sync>>(())
+        })?;
+        Ok(dest)
+    }
+
+    fn upload_from_path(&self, local_path: &Path, uri: &str) -> FloeResult<()> {
+        let key = uri
+            .split_once(".dfs.core.windows.net/")
+            .map(|(_, tail)| tail)
+            .unwrap_or("")
+            .trim_start_matches('/')
+            .to_string();
+        if key.is_empty() {
+            return Err(Box::new(StorageError(
+                "adls upload requires a blob path".to_string(),
+            )));
+        }
+        let client = self.container_client.clone();
+        let path = local_path.to_path_buf();
+        self.runtime.block_on(async move {
+            let data = tokio::fs::read(path).await?;
+            let blob = client.blob_client(key);
+            blob.put_block_blob(data)
+                .content_type("application/octet-stream")
+                .into_future()
+                .await
+                .map_err(|err| {
+                    Box::new(StorageError(format!("adls upload failed: {err}")))
+                        as Box<dyn std::error::Error + Send + Sync>
+                })?;
+            Ok(())
+        })
+    }
+
+    fn resolve_uri(&self, path: &str) -> FloeResult<String> {
+        Ok(self.format_abfs(&self.full_path(path)))
+    }
+
+    fn delete(&self, uri: &str) -> FloeResult<()> {
+        let key = uri
+            .split_once(".dfs.core.windows.net/")
+            .map(|(_, tail)| tail)
+            .unwrap_or("")
+            .trim_start_matches('/')
+            .to_string();
+        if key.is_empty() {
+            return Ok(());
+        }
+        let client = self.container_client.clone();
+        self.runtime.block_on(async move {
+            let blob = client.blob_client(key);
+            blob.delete().into_future().await.map_err(|err| {
+                Box::new(StorageError(format!("adls delete failed: {err}")))
+                    as Box<dyn std::error::Error + Send + Sync>
+            })?;
+            Ok(())
+        })
+    }
+}

--- a/crates/floe-core/src/io/storage/mod.rs
+++ b/crates/floe-core/src/io/storage/mod.rs
@@ -3,6 +3,7 @@ use std::path::{Path, PathBuf};
 
 use crate::{config, ConfigError, FloeResult};
 
+pub mod adls;
 pub mod extensions;
 pub mod inputs;
 pub mod local;
@@ -61,11 +62,7 @@ impl CloudClient {
                     })?;
                     Box::new(s3::S3Client::new(bucket, definition.region.as_deref())?)
                 }
-                "adls" => {
-                    return Err(Box::new(ConfigError(
-                        "storage type adls is not implemented yet (list/get/put)".to_string(),
-                    )))
-                }
+                "adls" => Box::new(adls::AdlsClient::new(&definition)?),
                 other => {
                     return Err(Box::new(ConfigError(format!(
                         "storage type {} is unsupported",

--- a/crates/floe-core/tests/config/adls_validation.rs
+++ b/crates/floe-core/tests/config/adls_validation.rs
@@ -14,8 +14,8 @@ fn base_entity() -> config::EntityConfig {
         },
         sink: config::SinkConfig {
             accepted: config::SinkTarget {
-                format: "csv".to_string(),
-                path: "out.csv".to_string(),
+                format: "parquet".to_string(),
+                path: "out.parquet".to_string(),
                 storage: None,
                 options: None,
             },
@@ -88,14 +88,9 @@ fn adls_referenced_errors_until_implemented() {
     };
 
     config.entities[0].source.storage = Some("adls".to_string());
-    let err = floe_core::validate_config_for_tests(&config).expect_err("expected error");
-    assert!(err
-        .to_string()
-        .contains("source.storage=adls is not implemented"));
+    floe_core::validate_config_for_tests(&config).expect("valid config");
 
-    config.entities[0].source.storage = Some("local".to_string());
+    config.entities[0].source.storage = None;
     config.entities[0].sink.accepted.storage = Some("adls".to_string());
-    let err = floe_core::validate_config_for_tests(&config).expect_err("expected error");
-    let message = err.to_string();
-    assert!(!message.is_empty());
+    floe_core::validate_config_for_tests(&config).expect("valid config");
 }

--- a/crates/floe-core/tests/io_tests/storage/adls.rs
+++ b/crates/floe-core/tests/io_tests/storage/adls.rs
@@ -1,0 +1,34 @@
+use floe_core::io::storage::{filter_by_suffixes, join_prefix, stable_sort_refs, ObjectRef};
+
+#[test]
+fn join_prefix_normalizes() {
+    assert_eq!(join_prefix("prefix/", "/file.csv"), "prefix/file.csv");
+}
+
+#[test]
+fn adls_like_refs_sort_and_filter() {
+    let refs = vec![
+        ObjectRef {
+            uri: "abfs://cont@acct.dfs.core.windows.net/data/b.csv".to_string(),
+            key: "data/b.csv".to_string(),
+            last_modified: None,
+            size: None,
+        },
+        ObjectRef {
+            uri: "abfs://cont@acct.dfs.core.windows.net/data/a.csv".to_string(),
+            key: "data/a.csv".to_string(),
+            last_modified: None,
+            size: None,
+        },
+        ObjectRef {
+            uri: "abfs://cont@acct.dfs.core.windows.net/data/c.txt".to_string(),
+            key: "data/c.txt".to_string(),
+            last_modified: None,
+            size: None,
+        },
+    ];
+    let filtered = filter_by_suffixes(refs, &[".csv".to_string()]);
+    let sorted = stable_sort_refs(filtered);
+    let keys = sorted.into_iter().map(|obj| obj.key).collect::<Vec<_>>();
+    assert_eq!(keys, vec!["data/a.csv", "data/b.csv"]);
+}

--- a/crates/floe-core/tests/io_tests/storage/adls_integration.rs
+++ b/crates/floe-core/tests/io_tests/storage/adls_integration.rs
@@ -1,0 +1,29 @@
+use floe_core::config;
+use floe_core::io::storage::{adls::AdlsClient, StorageClient};
+use floe_core::FloeResult;
+use std::env;
+
+#[test]
+fn adls_list_optional() -> FloeResult<()> {
+    if env::var("FLOE_TEST_ADLS").ok().as_deref() != Some("1") {
+        return Ok(());
+    }
+    let account = env::var("AZURE_STORAGE_ACCOUNT").unwrap_or_default();
+    let container = env::var("AZURE_STORAGE_CONTAINER").unwrap_or_default();
+    if account.is_empty() || container.is_empty() {
+        return Ok(());
+    }
+    let definition = config::StorageDefinition {
+        name: "adls".to_string(),
+        fs_type: "adls".to_string(),
+        bucket: None,
+        region: None,
+        account: Some(account),
+        container: Some(container),
+        prefix: None,
+    };
+    let client = AdlsClient::new(&definition)?;
+    let refs = client.list("")?;
+    let _ = refs.len();
+    Ok(())
+}

--- a/crates/floe-core/tests/io_tests/storage/mod.rs
+++ b/crates/floe-core/tests/io_tests/storage/mod.rs
@@ -1,3 +1,5 @@
+pub mod adls;
+pub mod adls_integration;
 pub mod inputs;
 pub mod local;
 pub mod paths;

--- a/docs/storages/adls.md
+++ b/docs/storages/adls.md
@@ -33,7 +33,19 @@ Examples:
 - `abfs://raw@myaccount.dfs.core.windows.net/ingest/customers/customers.csv`
 - `abfs://raw@myaccount.dfs.core.windows.net/customers/customers.csv` (no prefix)
 
+## Authentication
+
+Floe relies on Azure's default credential chain. Set one of the supported env
+combinations, for example:
+
+```bash
+export AZURE_CLIENT_ID=...
+export AZURE_TENANT_ID=...
+export AZURE_CLIENT_SECRET=...
+```
+
+Managed identity, Azure CLI, and other default credential sources are also supported.
+
 ## Status
 
-The ADLS storage backend is **not implemented yet** (no list/get/put). Any config that
-references `type: adls` will fail fast with a clear error until the backend is added.
+MVP is implemented with temp download/upload (list/get/put) using Azure default credentials.


### PR DESCRIPTION
## Summary
- add ADLS storage client using Azure default credentials (list/download/upload)
- wire ADLS into StorageClient registry
- update validation to allow ADLS references
- add ADLS storage unit + optional integration tests
- update docs with auth notes

## Testing
- cargo fmt --all
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test -p floe-core --test config
- cargo test -p floe-core --test io_format --test io_read --test io_storage --test io_write --test run_entity --test run_checks --test run_schema --test run_report --test run_check_order --test run_normalize