### PR TITLE
feat(config): add gcs storage definition and uri resolution

### DIFF
--- a/config.schema.yaml
+++ b/config.schema.yaml
@@ -276,10 +276,14 @@ $defs:
         type: string
       type:
         type: string
-        enum: [local, s3]
+        enum: [local, s3, adls, gcs]
       bucket:
         type: string
       region:
+        type: string
+      account:
+        type: string
+      container:
         type: string
       prefix:
         type: string

--- a/crates/floe-core/src/io/storage/mod.rs
+++ b/crates/floe-core/src/io/storage/mod.rs
@@ -63,6 +63,12 @@ impl CloudClient {
                     Box::new(s3::S3Client::new(bucket, definition.region.as_deref())?)
                 }
                 "adls" => Box::new(adls::AdlsClient::new(&definition)?),
+                "gcs" => {
+                    return Err(Box::new(ConfigError(format!(
+                        "storage {} type gcs is not implemented yet (list/get/put)",
+                        definition.name
+                    ))));
+                }
                 other => {
                     return Err(Box::new(ConfigError(format!(
                         "storage type {} is unsupported",

--- a/crates/floe-core/tests/config.rs
+++ b/crates/floe-core/tests/config.rs
@@ -4,6 +4,10 @@ mod adls_storage;
 mod adls_validation;
 #[path = "config/config_validation.rs"]
 mod config_validation;
+#[path = "config/gcs_storage.rs"]
+mod gcs_storage;
+#[path = "config/gcs_validation.rs"]
+mod gcs_validation;
 #[path = "config/parse.rs"]
 mod parse;
 #[path = "config/templating.rs"]

--- a/crates/floe-core/tests/config/gcs_storage.rs
+++ b/crates/floe-core/tests/config/gcs_storage.rs
@@ -1,0 +1,151 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use floe_core::config::{RootConfig, StorageResolver};
+use floe_core::load_config;
+
+fn write_temp_config(contents: &str) -> PathBuf {
+    let mut path = std::env::temp_dir();
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_nanos())
+        .unwrap_or(0);
+    path.push(format!("floe-config-{nanos}.yml"));
+    fs::write(&path, contents).expect("write temp config");
+    path
+}
+
+fn load_temp_config(contents: &str) -> (PathBuf, RootConfig) {
+    let path = write_temp_config(contents);
+    let config = load_config(&path).expect("parse config");
+    (path, config)
+}
+
+fn resolver_from(yaml: &str) -> StorageResolver {
+    let (path, config) = load_temp_config(yaml);
+    StorageResolver::new(&config, Path::new(&path)).expect("storage resolver")
+}
+
+#[test]
+fn gcs_uri_with_prefix_is_resolved() {
+    let yaml = r#"
+version: "0.1"
+storages:
+  default: gcs_raw
+  definitions:
+    - name: gcs_raw
+      type: gcs
+      bucket: my-bucket
+      prefix: data/root
+entities:
+  - name: "customer"
+    source:
+      format: "csv"
+      path: "in/customers.csv"
+    sink:
+      accepted:
+        format: "parquet"
+        path: "out/customers"
+    policy:
+      severity: "warn"
+    schema:
+      columns:
+        - name: "id"
+          type: "string"
+          nullable: false
+"#;
+    let resolver = resolver_from(yaml);
+    let resolved = resolver
+        .resolve_path(
+            "customer",
+            "source.path",
+            Some("gcs_raw"),
+            "incoming/customers.csv",
+        )
+        .expect("resolve");
+    assert_eq!(
+        resolved.uri,
+        "gs://my-bucket/data/root/incoming/customers.csv"
+    );
+    assert!(resolved.local_path.is_none());
+}
+
+#[test]
+fn gcs_uri_without_prefix_is_resolved() {
+    let yaml = r#"
+version: "0.1"
+storages:
+  default: gcs_raw
+  definitions:
+    - name: gcs_raw
+      type: gcs
+      bucket: my-bucket
+entities:
+  - name: "customer"
+    source:
+      format: "csv"
+      path: "in/customers.csv"
+    sink:
+      accepted:
+        format: "parquet"
+        path: "out/customers"
+    policy:
+      severity: "warn"
+    schema:
+      columns:
+        - name: "id"
+          type: "string"
+          nullable: false
+"#;
+    let resolver = resolver_from(yaml);
+    let resolved = resolver
+        .resolve_path(
+            "customer",
+            "source.path",
+            Some("gcs_raw"),
+            "/incoming/customers.csv",
+        )
+        .expect("resolve");
+    assert_eq!(resolved.uri, "gs://my-bucket/incoming/customers.csv");
+}
+
+#[test]
+fn gcs_uri_allows_explicit_bucket_path() {
+    let yaml = r#"
+version: "0.1"
+storages:
+  default: gcs_raw
+  definitions:
+    - name: gcs_raw
+      type: gcs
+      bucket: my-bucket
+      prefix: data/root
+entities:
+  - name: "customer"
+    source:
+      format: "csv"
+      path: "in/customers.csv"
+    sink:
+      accepted:
+        format: "parquet"
+        path: "out/customers"
+    policy:
+      severity: "warn"
+    schema:
+      columns:
+        - name: "id"
+          type: "string"
+          nullable: false
+"#;
+    let resolver = resolver_from(yaml);
+    let resolved = resolver
+        .resolve_path(
+            "customer",
+            "source.path",
+            Some("gcs_raw"),
+            "gs://my-bucket/explicit.csv",
+        )
+        .expect("resolve");
+    assert_eq!(resolved.uri, "gs://my-bucket/explicit.csv");
+}

--- a/crates/floe-core/tests/config/gcs_validation.rs
+++ b/crates/floe-core/tests/config/gcs_validation.rs
@@ -1,0 +1,85 @@
+use std::fs;
+use std::path::PathBuf;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use floe_core::{validate, ValidateOptions};
+
+fn write_temp_config(contents: &str) -> PathBuf {
+    let mut path = std::env::temp_dir();
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_nanos())
+        .unwrap_or(0);
+    path.push(format!("floe-config-{nanos}.yml"));
+    fs::write(&path, contents).expect("write temp config");
+    path
+}
+
+#[test]
+fn gcs_definition_requires_bucket() {
+    let yaml = r#"
+version: "0.1"
+storages:
+  default: gcs_raw
+  definitions:
+    - name: gcs_raw
+      type: gcs
+entities:
+  - name: "customer"
+    source:
+      format: "csv"
+      path: "in/customers.csv"
+    sink:
+      accepted:
+        format: "parquet"
+        path: "out/customers"
+    policy:
+      severity: "warn"
+    schema:
+      columns:
+        - name: "id"
+          type: "string"
+          nullable: false
+"#;
+    let path = write_temp_config(yaml);
+    let err = validate(&path, ValidateOptions::default()).expect_err("should fail");
+    let message = err.to_string();
+    assert!(message.contains("requires bucket for type gcs"));
+}
+
+#[test]
+fn gcs_storage_reference_is_not_supported_yet() {
+    let yaml = r#"
+version: "0.1"
+storages:
+  default: gcs_raw
+  definitions:
+    - name: gcs_raw
+      type: gcs
+      bucket: my-bucket
+entities:
+  - name: "customer"
+    source:
+      format: "csv"
+      path: "in/customers.csv"
+      storage: gcs_raw
+    sink:
+      accepted:
+        format: "parquet"
+        path: "out/customers"
+    policy:
+      severity: "warn"
+    schema:
+      columns:
+        - name: "id"
+          type: "string"
+          nullable: false
+"#;
+    let path = write_temp_config(yaml);
+    let err = validate(&path, ValidateOptions::default()).expect_err("should fail");
+    let message = err.to_string();
+    assert!(message.contains("entity.name=customer"));
+    assert!(message.contains("source.storage=gcs_raw"));
+    assert!(message.contains("gcs"));
+    assert!(message.contains("not implemented yet"));
+}

--- a/docs/storages/gcs.md
+++ b/docs/storages/gcs.md
@@ -1,0 +1,34 @@
+# GCS storage (planned)
+
+GCS is a first-class storage definition in the config, but the client is **not implemented yet**.
+You can use it today for validation and URI resolution in reports; actual IO will be added in a later phase.
+
+## Config
+
+```yaml
+storages:
+  default: gcs_raw
+  definitions:
+    - name: gcs_raw
+      type: gcs
+      bucket: my-bucket
+      prefix: data/incoming
+```
+
+## Canonical URI
+
+Floe resolves paths to canonical GCS URIs:
+
+```
+gs://<bucket>/<prefix>/<path>
+```
+
+Examples:
+
+- `bucket=my-bucket`, `prefix=data`, `path=customers.csv` → `gs://my-bucket/data/customers.csv`
+- `bucket=my-bucket`, no prefix, `path=customers.csv` → `gs://my-bucket/customers.csv`
+
+## Auth (planned)
+
+GCS auth will follow the standard Google ADC (Application Default Credentials) chain.
+This will be documented once list/download/upload are implemented.


### PR DESCRIPTION
## Summary
- allow gcs storage definitions in config validation and schema
- resolve canonical gs:// URIs for gcs storage paths
- add gcs config docs and tests for uri/validation


## Testing
- cargo fmt --all
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test --all