### PR TITLE
feat(storage): add gcs list/download/upload (mvp)

### DIFF
--- a/crates/floe-core/Cargo.toml
+++ b/crates/floe-core/Cargo.toml
@@ -23,6 +23,7 @@ time = { version = "0.3", features = ["formatting"] }
 glob = "0.3"
 aws-config = "1"
 aws-sdk-s3 = "1"
+google-cloud-storage = { package = "gcloud-storage", version = "1.2.0" }
 tempfile = "3"
 tokio = { version = "1", features = ["rt", "rt-multi-thread", "fs", "io-util"] }
 azure_core = "0.20"

--- a/crates/floe-core/src/config/validate.rs
+++ b/crates/floe-core/src/config/validate.rs
@@ -60,15 +60,6 @@ fn validate_source(entity: &EntityConfig, storages: &StorageRegistry) -> FloeRes
     let storage_name =
         storages.resolve_name(entity, "source.storage", entity.source.storage.as_deref())?;
     storages.validate_reference(entity, "source.storage", &storage_name)?;
-    if let Some(storage_type) = storages.definition_type(&storage_name) {
-        if storage_type == "gcs" {
-            return Err(Box::new(ConfigError(format!(
-                "entity.name={} source.storage={} uses gcs which is not implemented yet (list/get/put)",
-                entity.name, storage_name
-            ))));
-        }
-    }
-
     if entity.source.format == "json" {
         let options = entity.source.options.as_ref();
         let mode = options
@@ -132,14 +123,6 @@ fn validate_sink(entity: &EntityConfig, storages: &StorageRegistry) -> FloeResul
         entity.sink.accepted.storage.as_deref(),
     )?;
     storages.validate_reference(entity, "sink.accepted.storage", &accepted_storage)?;
-    if let Some(storage_type) = storages.definition_type(&accepted_storage) {
-        if storage_type == "gcs" {
-            return Err(Box::new(ConfigError(format!(
-                "entity.name={} sink.accepted.storage={} uses gcs which is not implemented yet (list/get/put)",
-                entity.name, accepted_storage
-            ))));
-        }
-    }
     if entity.sink.accepted.format == "delta" {
         if let Some(storage_type) = storages.definition_type(&accepted_storage) {
             if storage_type != "local" && storage_type != "s3" {
@@ -157,14 +140,6 @@ fn validate_sink(entity: &EntityConfig, storages: &StorageRegistry) -> FloeResul
         let rejected_storage =
             storages.resolve_name(entity, "sink.rejected.storage", rejected.storage.as_deref())?;
         storages.validate_reference(entity, "sink.rejected.storage", &rejected_storage)?;
-        if let Some(storage_type) = storages.definition_type(&rejected_storage) {
-            if storage_type == "gcs" {
-                return Err(Box::new(ConfigError(format!(
-                    "entity.name={} sink.rejected.storage={} uses gcs which is not implemented yet (list/get/put)",
-                    entity.name, rejected_storage
-                ))));
-            }
-        }
     }
 
     Ok(())

--- a/crates/floe-core/src/io/storage/gcs.rs
+++ b/crates/floe-core/src/io/storage/gcs.rs
@@ -1,0 +1,265 @@
+use std::collections::hash_map::DefaultHasher;
+use std::hash::{Hash, Hasher};
+use std::path::{Path, PathBuf};
+
+use google_cloud_storage::client::{Client, ClientConfig};
+use google_cloud_storage::http::objects::delete::DeleteObjectRequest;
+use google_cloud_storage::http::objects::download::Range;
+use google_cloud_storage::http::objects::get::GetObjectRequest;
+use google_cloud_storage::http::objects::list::ListObjectsRequest;
+use google_cloud_storage::http::objects::upload::{Media, UploadObjectRequest, UploadType};
+use tokio::runtime::Runtime;
+
+use crate::errors::{RunError, StorageError};
+use crate::{ConfigError, FloeResult};
+
+use super::{planner, ObjectRef, StorageClient};
+
+pub struct GcsClient {
+    bucket: String,
+    client: Client,
+    runtime: Runtime,
+}
+
+impl GcsClient {
+    pub fn new(bucket: String) -> FloeResult<Self> {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .map_err(|err| Box::new(StorageError(format!("gcs runtime init failed: {err}"))))?;
+        let client = runtime.block_on(async {
+            let config = ClientConfig::default()
+                .with_auth()
+                .await
+                .map_err(|err| Box::new(StorageError(format!("gcs auth init failed: {err}"))))?;
+            Ok::<_, Box<dyn std::error::Error + Send + Sync>>(Client::new(config))
+        })?;
+        Ok(Self {
+            bucket,
+            client,
+            runtime,
+        })
+    }
+
+    fn bucket(&self) -> &str {
+        self.bucket.as_str()
+    }
+}
+
+impl StorageClient for GcsClient {
+    fn list(&self, prefix_or_path: &str) -> FloeResult<Vec<ObjectRef>> {
+        let bucket = self.bucket().to_string();
+        let prefix = prefix_or_path.trim_start_matches('/').to_string();
+        let client = self.client.clone();
+        self.runtime.block_on(async move {
+            let mut refs = Vec::new();
+            let mut page_token = None;
+            loop {
+                let request = ListObjectsRequest {
+                    bucket: bucket.clone(),
+                    prefix: if prefix.is_empty() {
+                        None
+                    } else {
+                        Some(prefix.clone())
+                    },
+                    page_token,
+                    ..Default::default()
+                };
+                let response = client.list_objects(&request).await.map_err(|err| {
+                    Box::new(StorageError(format!(
+                        "gcs list objects failed for bucket {}: {err}",
+                        bucket
+                    ))) as Box<dyn std::error::Error + Send + Sync>
+                })?;
+                if let Some(items) = response.items {
+                    for object in items {
+                        let key = object.name.clone();
+                        let uri = format_gcs_uri(&bucket, &key);
+                        refs.push(ObjectRef {
+                            uri,
+                            key,
+                            last_modified: object.updated.map(|value| value.to_string()),
+                            size: Some(object.size as u64),
+                        });
+                    }
+                }
+                match response.next_page_token {
+                    Some(token) if !token.is_empty() => {
+                        page_token = Some(token);
+                    }
+                    _ => break,
+                }
+            }
+            Ok(planner::stable_sort_refs(refs))
+        })
+    }
+
+    fn download_to_temp(&self, uri: &str, temp_dir: &Path) -> FloeResult<PathBuf> {
+        let location = parse_gcs_uri(uri)?;
+        let bucket = location.bucket;
+        let key = location.key;
+        let dest = temp_path_for_key(temp_dir, &key);
+        let dest_clone = dest.clone();
+        let client = self.client.clone();
+        self.runtime.block_on(async move {
+            let data = client
+                .download_object(
+                    &GetObjectRequest {
+                        bucket,
+                        object: key,
+                        ..Default::default()
+                    },
+                    &Range::default(),
+                )
+                .await
+                .map_err(|err| {
+                    Box::new(StorageError(format!("gcs download failed: {err}")))
+                        as Box<dyn std::error::Error + Send + Sync>
+                })?;
+            if let Some(parent) = dest_clone.parent() {
+                tokio::fs::create_dir_all(parent).await?;
+            }
+            tokio::fs::write(&dest_clone, data).await?;
+            Ok::<(), Box<dyn std::error::Error + Send + Sync>>(())
+        })?;
+        Ok(dest)
+    }
+
+    fn upload_from_path(&self, local_path: &Path, uri: &str) -> FloeResult<()> {
+        let location = parse_gcs_uri(uri)?;
+        let path = local_path.to_path_buf();
+        let client = self.client.clone();
+        self.runtime.block_on(async move {
+            let data = tokio::fs::read(path).await?;
+            let upload_type = UploadType::Simple(Media::new(location.key.clone()));
+            let request = UploadObjectRequest {
+                bucket: location.bucket,
+                ..Default::default()
+            };
+            client
+                .upload_object(&request, data, &upload_type)
+                .await
+                .map_err(|err| {
+                    Box::new(StorageError(format!("gcs upload failed: {err}")))
+                        as Box<dyn std::error::Error + Send + Sync>
+                })?;
+            Ok(())
+        })
+    }
+
+    fn resolve_uri(&self, path: &str) -> FloeResult<String> {
+        Ok(format_gcs_uri(self.bucket(), path.trim_start_matches('/')))
+    }
+
+    fn delete(&self, uri: &str) -> FloeResult<()> {
+        let location = parse_gcs_uri(uri)?;
+        let client = self.client.clone();
+        self.runtime.block_on(async move {
+            client
+                .delete_object(&DeleteObjectRequest {
+                    bucket: location.bucket,
+                    object: location.key,
+                    ..Default::default()
+                })
+                .await
+                .map_err(|err| {
+                    Box::new(StorageError(format!("gcs delete failed: {err}")))
+                        as Box<dyn std::error::Error + Send + Sync>
+                })?;
+            Ok(())
+        })
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GcsLocation {
+    pub bucket: String,
+    pub key: String,
+}
+
+pub fn parse_gcs_uri(uri: &str) -> FloeResult<GcsLocation> {
+    let stripped = uri.strip_prefix("gs://").ok_or_else(|| {
+        Box::new(ConfigError(format!("expected gcs uri, got {}", uri)))
+            as Box<dyn std::error::Error + Send + Sync>
+    })?;
+    let mut parts = stripped.splitn(2, '/');
+    let bucket = parts.next().unwrap_or("").to_string();
+    if bucket.is_empty() {
+        return Err(Box::new(ConfigError(format!(
+            "missing bucket in gcs uri: {}",
+            uri
+        ))));
+    }
+    let key = parts.next().unwrap_or("").to_string();
+    Ok(GcsLocation { bucket, key })
+}
+
+pub fn format_gcs_uri(bucket: &str, key: &str) -> String {
+    if key.is_empty() {
+        format!("gs://{}", bucket)
+    } else {
+        format!("gs://{}/{}", bucket, key)
+    }
+}
+
+pub fn temp_path_for_key(temp_dir: &Path, key: &str) -> PathBuf {
+    let mut hasher = DefaultHasher::new();
+    key.hash(&mut hasher);
+    let hash = hasher.finish();
+    let name = super::s3::file_name_from_key(key).unwrap_or_else(|| "object".to_string());
+    let sanitized = sanitize_filename(&name);
+    temp_dir.join(format!("{hash:016x}_{sanitized}"))
+}
+
+fn sanitize_filename(name: &str) -> String {
+    name.chars()
+        .map(|ch| {
+            if ch.is_ascii_alphanumeric() || matches!(ch, '.' | '-' | '_') {
+                ch
+            } else {
+                '_'
+            }
+        })
+        .collect()
+}
+
+pub fn build_input_files(
+    client: &dyn StorageClient,
+    bucket: &str,
+    prefix: &str,
+    adapter: &dyn crate::io::format::InputAdapter,
+    temp_dir: &Path,
+    entity: &crate::config::EntityConfig,
+    storage: &str,
+) -> FloeResult<Vec<crate::io::format::InputFile>> {
+    let suffixes = adapter.suffixes()?;
+    let list_refs = client.list(prefix)?;
+    let filtered = planner::filter_by_suffixes(list_refs, &suffixes);
+    let filtered = planner::stable_sort_refs(filtered);
+    if filtered.is_empty() {
+        return Err(Box::new(RunError(format!(
+            "entity.name={} source.storage={} no input objects matched (bucket={}, prefix={}, suffixes={})",
+            entity.name,
+            storage,
+            bucket,
+            prefix,
+            suffixes.join(",")
+        ))));
+    }
+    let mut inputs = Vec::with_capacity(filtered.len());
+    for object in filtered {
+        let local_path = client.download_to_temp(&object.uri, temp_dir)?;
+        let source_name =
+            super::s3::file_name_from_key(&object.key).unwrap_or_else(|| entity.name.clone());
+        let source_stem =
+            super::s3::file_stem_from_name(&source_name).unwrap_or_else(|| entity.name.clone());
+        let source_uri = object.uri;
+        inputs.push(crate::io::format::InputFile {
+            source_uri,
+            source_local_path: local_path,
+            source_name,
+            source_stem,
+        });
+    }
+    Ok(inputs)
+}

--- a/crates/floe-core/src/io/storage/object_store.rs
+++ b/crates/floe-core/src/io/storage/object_store.rs
@@ -53,5 +53,13 @@ pub fn delta_store_config(
                 storage_options,
             })
         }
+        Target::Adls { .. } => Err(Box::new(ConfigError(format!(
+            "entity.name={} delta tables are not supported on adls yet",
+            entity.name
+        )))),
+        Target::Gcs { .. } => Err(Box::new(ConfigError(format!(
+            "entity.name={} delta tables are not supported on gcs yet",
+            entity.name
+        )))),
     }
 }

--- a/crates/floe-core/src/io/storage/target.rs
+++ b/crates/floe-core/src/io/storage/target.rs
@@ -1,4 +1,4 @@
-use crate::{config, io, FloeResult};
+use crate::{config, io, ConfigError, FloeResult};
 
 #[derive(Debug, Clone)]
 pub enum Target {
@@ -8,6 +8,19 @@ pub enum Target {
         base_path: String,
     },
     S3 {
+        storage: String,
+        uri: String,
+        bucket: String,
+        base_key: String,
+    },
+    Adls {
+        storage: String,
+        uri: String,
+        account: String,
+        container: String,
+        base_path: String,
+    },
+    Gcs {
         storage: String,
         uri: String,
         bucket: String,
@@ -24,24 +37,55 @@ impl Target {
                 base_path: path.display().to_string(),
             });
         }
-        let location = io::storage::s3::parse_s3_uri(&resolved.uri)?;
-        Ok(Target::S3 {
-            storage: resolved.storage.clone(),
-            uri: resolved.uri.clone(),
-            bucket: location.bucket,
-            base_key: location.key,
-        })
+        if resolved.uri.starts_with("s3://") {
+            let location = io::storage::s3::parse_s3_uri(&resolved.uri)?;
+            return Ok(Target::S3 {
+                storage: resolved.storage.clone(),
+                uri: resolved.uri.clone(),
+                bucket: location.bucket,
+                base_key: location.key,
+            });
+        }
+        if resolved.uri.starts_with("abfs://") {
+            let location = io::storage::adls::parse_adls_uri(&resolved.uri)?;
+            return Ok(Target::Adls {
+                storage: resolved.storage.clone(),
+                uri: resolved.uri.clone(),
+                account: location.account,
+                container: location.container,
+                base_path: location.path,
+            });
+        }
+        if resolved.uri.starts_with("gs://") {
+            let location = io::storage::gcs::parse_gcs_uri(&resolved.uri)?;
+            return Ok(Target::Gcs {
+                storage: resolved.storage.clone(),
+                uri: resolved.uri.clone(),
+                bucket: location.bucket,
+                base_key: location.key,
+            });
+        }
+        Err(Box::new(ConfigError(format!(
+            "unsupported storage uri: {}",
+            resolved.uri
+        ))))
     }
 
     pub fn storage(&self) -> &str {
         match self {
-            Target::Local { storage, .. } | Target::S3 { storage, .. } => storage.as_str(),
+            Target::Local { storage, .. }
+            | Target::S3 { storage, .. }
+            | Target::Adls { storage, .. }
+            | Target::Gcs { storage, .. } => storage.as_str(),
         }
     }
 
     pub fn target_uri(&self) -> &str {
         match self {
-            Target::Local { uri, .. } | Target::S3 { uri, .. } => uri.as_str(),
+            Target::Local { uri, .. }
+            | Target::S3 { uri, .. }
+            | Target::Adls { uri, .. }
+            | Target::Gcs { uri, .. } => uri.as_str(),
         }
     }
 
@@ -51,6 +95,28 @@ impl Target {
                 bucket, base_key, ..
             } => Some((bucket.as_str(), base_key.as_str())),
             Target::Local { .. } => None,
+            Target::Adls { .. } | Target::Gcs { .. } => None,
+        }
+    }
+
+    pub fn gcs_parts(&self) -> Option<(&str, &str)> {
+        match self {
+            Target::Gcs {
+                bucket, base_key, ..
+            } => Some((bucket.as_str(), base_key.as_str())),
+            Target::Local { .. } | Target::S3 { .. } | Target::Adls { .. } => None,
+        }
+    }
+
+    pub fn adls_parts(&self) -> Option<(&str, &str, &str)> {
+        match self {
+            Target::Adls {
+                container,
+                account,
+                base_path,
+                ..
+            } => Some((container.as_str(), account.as_str(), base_path.as_str())),
+            Target::Local { .. } | Target::S3 { .. } | Target::Gcs { .. } => None,
         }
     }
 }

--- a/crates/floe-core/tests/config/gcs_validation.rs
+++ b/crates/floe-core/tests/config/gcs_validation.rs
@@ -48,7 +48,7 @@ entities:
 }
 
 #[test]
-fn gcs_storage_reference_is_not_supported_yet() {
+fn gcs_storage_reference_is_supported() {
     let yaml = r#"
 version: "0.1"
 storages:
@@ -76,10 +76,5 @@ entities:
           nullable: false
 "#;
     let path = write_temp_config(yaml);
-    let err = validate(&path, ValidateOptions::default()).expect_err("should fail");
-    let message = err.to_string();
-    assert!(message.contains("entity.name=customer"));
-    assert!(message.contains("source.storage=gcs_raw"));
-    assert!(message.contains("gcs"));
-    assert!(message.contains("not implemented yet"));
+    validate(&path, ValidateOptions::default()).expect("should validate");
 }

--- a/crates/floe-core/tests/io_tests/storage/gcs.rs
+++ b/crates/floe-core/tests/io_tests/storage/gcs.rs
@@ -1,0 +1,15 @@
+use floe_core::io::storage::gcs::{format_gcs_uri, parse_gcs_uri};
+use floe_core::FloeResult;
+
+#[test]
+fn parse_gcs_uri_extracts_bucket_and_key() -> FloeResult<()> {
+    let location = parse_gcs_uri("gs://my-bucket/data/file.csv")?;
+    assert_eq!(location.bucket, "my-bucket");
+    assert_eq!(location.key, "data/file.csv");
+    Ok(())
+}
+
+#[test]
+fn format_gcs_uri_handles_empty_key() {
+    assert_eq!(format_gcs_uri("my-bucket", ""), "gs://my-bucket");
+}

--- a/crates/floe-core/tests/io_tests/storage/mod.rs
+++ b/crates/floe-core/tests/io_tests/storage/mod.rs
@@ -1,5 +1,6 @@
 pub mod adls;
 pub mod adls_integration;
+pub mod gcs;
 pub mod inputs;
 pub mod local;
 pub mod paths;

--- a/crates/floe-core/tests/io_tests/storage/target.rs
+++ b/crates/floe-core/tests/io_tests/storage/target.rs
@@ -30,5 +30,39 @@ fn target_from_resolved_s3() -> FloeResult<()> {
     assert!(matches!(target, Target::S3 { .. }));
     assert_eq!(target.target_uri(), resolved.uri);
     assert_eq!(target.s3_parts(), Some(("bucket", "path/file.csv")));
+    assert!(target.gcs_parts().is_none());
+    assert!(target.adls_parts().is_none());
+    Ok(())
+}
+
+#[test]
+fn target_from_resolved_gcs() -> FloeResult<()> {
+    let resolved = ResolvedPath {
+        storage: "gcs_raw".to_string(),
+        uri: "gs://bucket/path/file.csv".to_string(),
+        local_path: None,
+    };
+    let target = Target::from_resolved(&resolved)?;
+    assert!(matches!(target, Target::Gcs { .. }));
+    assert_eq!(target.target_uri(), resolved.uri);
+    assert_eq!(target.gcs_parts(), Some(("bucket", "path/file.csv")));
+    assert!(target.s3_parts().is_none());
+    assert!(target.adls_parts().is_none());
+    Ok(())
+}
+
+#[test]
+fn target_from_resolved_adls() -> FloeResult<()> {
+    let resolved = ResolvedPath {
+        storage: "adls_raw".to_string(),
+        uri: "abfs://cont@acct.dfs.core.windows.net/data/file.csv".to_string(),
+        local_path: None,
+    };
+    let target = Target::from_resolved(&resolved)?;
+    assert!(matches!(target, Target::Adls { .. }));
+    assert_eq!(target.target_uri(), resolved.uri);
+    assert_eq!(target.adls_parts(), Some(("cont", "acct", "data/file.csv")));
+    assert!(target.s3_parts().is_none());
+    assert!(target.gcs_parts().is_none());
     Ok(())
 }

--- a/docs/storages/gcs.md
+++ b/docs/storages/gcs.md
@@ -1,7 +1,7 @@
-# GCS storage (planned)
+# GCS storage (MVP)
 
-GCS is a first-class storage definition in the config, but the client is **not implemented yet**.
-You can use it today for validation and URI resolution in reports; actual IO will be added in a later phase.
+GCS is supported for list/download/upload using the Google Application Default
+Credentials chain. This MVP uses temp downloads/uploads (no streaming).
 
 ## Config
 
@@ -28,7 +28,19 @@ Examples:
 - `bucket=my-bucket`, `prefix=data`, `path=customers.csv` → `gs://my-bucket/data/customers.csv`
 - `bucket=my-bucket`, no prefix, `path=customers.csv` → `gs://my-bucket/customers.csv`
 
-## Auth (planned)
+## Auth
+
+The client uses Application Default Credentials. For local development, set
+`GOOGLE_APPLICATION_CREDENTIALS` to a service account JSON file path:
+
+```bash
+export GOOGLE_APPLICATION_CREDENTIALS="/path/to/service-account.json"
+```
+
+## Limitations
+
+- IO uses temp download/upload (no streaming).
+- Only file-based formats (csv/parquet/json) are supported.
 
 GCS auth will follow the standard Google ADC (Application Default Credentials) chain.
 This will be documented once list/download/upload are implemented.


### PR DESCRIPTION
## Summary
-implement GCS storage client (list/download/upload/delete) using ADC
-add GCS target handling, remote outputs, and temp downloads
-update parquet cleanup for GCS/ADLS and delta unsupported checks
-add storage tests for GCS + target parsing
-update GCS docs with auth + MVP limitations

## Testing
-cargo fmt --all\
-cargo clippy --all-targets --all-features -- -D warnings
-cargo test --all