### PR TITLE
feat(delta): enable adls delta writes via object_store

### DIFF
--- a/crates/floe-core/Cargo.toml
+++ b/crates/floe-core/Cargo.toml
@@ -15,7 +15,7 @@ path = "src/lib.rs"
 [dependencies]
 yaml-rust2 = "0.11"
 polars = { version = "0.52.0", features = ["csv", "parquet", "lazy", "timezones", "dtype-date", "dtype-datetime", "dtype-time", "polars-ops", "is_unique", "is_first_distinct"] }
-deltalake = { version = "0.30.1", features = ["datafusion", "s3"] }
+deltalake = { version = "0.30.1", features = ["datafusion", "s3", "azure"] }
 url = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/crates/floe-core/src/config/validate.rs
+++ b/crates/floe-core/src/config/validate.rs
@@ -125,9 +125,9 @@ fn validate_sink(entity: &EntityConfig, storages: &StorageRegistry) -> FloeResul
     storages.validate_reference(entity, "sink.accepted.storage", &accepted_storage)?;
     if entity.sink.accepted.format == "delta" {
         if let Some(storage_type) = storages.definition_type(&accepted_storage) {
-            if storage_type != "local" && storage_type != "s3" {
+            if storage_type != "local" && storage_type != "s3" && storage_type != "adls" {
                 return Err(Box::new(ConfigError(format!(
-                    "entity.name={} sink.accepted.format=delta is only supported on local or s3 storage (got {})",
+                    "entity.name={} sink.accepted.format=delta is only supported on local, s3, or adls storage (got {})",
                     entity.name, storage_type
                 ))));
             }

--- a/crates/floe-core/tests/io_tests/write/object_store.rs
+++ b/crates/floe-core/tests/io_tests/write/object_store.rs
@@ -125,3 +125,81 @@ fn delta_store_config_builds_local_url() -> FloeResult<()> {
     assert_eq!(store.table_url.scheme(), "file");
     Ok(())
 }
+
+#[test]
+fn delta_store_config_builds_adls_url_and_options() -> FloeResult<()> {
+    let config = config::RootConfig {
+        version: "0.1".to_string(),
+        metadata: None,
+        storages: Some(config::StoragesConfig {
+            default: Some("adls_raw".to_string()),
+            definitions: vec![config::StorageDefinition {
+                name: "adls_raw".to_string(),
+                fs_type: "adls".to_string(),
+                bucket: None,
+                region: None,
+                account: Some("account".to_string()),
+                container: Some("container".to_string()),
+                prefix: Some("data".to_string()),
+            }],
+        }),
+        env: None,
+        domains: Vec::new(),
+        report: None,
+        entities: Vec::new(),
+    };
+    let resolver = config::StorageResolver::new(&config, std::path::Path::new("."))?;
+    let resolved = resolver.resolve_path("orders", "sink.accepted.path", None, "delta/orders")?;
+    let target = Target::from_resolved(&resolved)?;
+    let entity = config::EntityConfig {
+        name: "orders".to_string(),
+        metadata: None,
+        domain: None,
+        source: config::SourceConfig {
+            format: "csv".to_string(),
+            path: "in".to_string(),
+            storage: None,
+            options: None,
+            cast_mode: None,
+        },
+        sink: config::SinkConfig {
+            accepted: config::SinkTarget {
+                format: "delta".to_string(),
+                path: "delta/orders".to_string(),
+                storage: None,
+                options: None,
+            },
+            rejected: None,
+            archive: None,
+        },
+        policy: config::PolicyConfig {
+            severity: "warn".to_string(),
+        },
+        schema: config::SchemaConfig {
+            normalize_columns: None,
+            mismatch: None,
+            columns: Vec::new(),
+        },
+    };
+
+    let store = delta_store_config(&target, &resolver, &entity)?;
+    assert_eq!(
+        store.table_url.as_str(),
+        "abfs://container@account.dfs.core.windows.net/data/delta/orders"
+    );
+    assert_eq!(
+        store
+            .storage_options
+            .get("azure_storage_account_name")
+            .map(String::as_str),
+        Some("account")
+    );
+    assert_eq!(
+        store
+            .storage_options
+            .get("azure_container_name")
+            .map(String::as_str),
+        Some("container")
+    );
+    Ok(())
+}

--- a/docs/sinks/delta.md
+++ b/docs/sinks/delta.md
@@ -1,6 +1,6 @@
 # Delta Sink (Accepted Output)
 
-Floe can write accepted output as a Delta Lake table on local or S3 storage.
+Floe can write accepted output as a Delta Lake table on local, S3, or ADLS storage.
 
 Example:
 ```yaml
@@ -19,8 +19,14 @@ Semantics:
 - `sink.accepted.format: delta` writes a Delta table at `sink.accepted.path`.
 - Write mode is `overwrite` via Delta transactions (a new `_delta_log` version is
   committed; history is preserved).
-- Local and S3 storage are supported for delta output.
+- Local, S3, and ADLS storage are supported for delta output.
 
 S3 notes:
 - Delta writes go directly through the object_store backend (no temp download/upload).
 - Credentials come from the standard AWS environment/provider chain.
+
+ADLS notes:
+- Delta writes go directly through the object_store backend (no temp download/upload).
+- Authentication uses Azure env-based credentials (e.g., `AZURE_STORAGE_ACCOUNT_KEY`,
+  `AZURE_STORAGE_SAS_KEY`, or Azure AD token variables). The storage account and
+  container are taken from the storage definition and table URI.


### PR DESCRIPTION
## Summary
- enable Delta ADLS support by adding Azure object_store config
- allow delta sink on adls in config validation
- add delta object_store test for adls
- document ADLS delta auth notes

## Testing
- cargo fmt --all
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test --all