### PR TITLE
docs: add v0.2 support matrix and storage setup guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,26 +119,27 @@ Checks and policy details: [docs/checks.md](docs/checks.md)
 ## Supported formats
 
 Inputs:
-- CSV (local and S3)
-- Parquet (local and S3)
-- NDJSON (local and S3)
+- CSV (local + S3/ADLS/GCS via temp download)
+- JSON (array/ndjson; local + S3/ADLS/GCS via temp download)
+- Parquet (local only)
 
 Outputs:
-- Accepted: Parquet, Delta
-- Rejected: CSV
+- Accepted: Parquet (local + cloud via temp upload), Delta (local + cloud via object_store)
+- Rejected: CSV (local + cloud via temp upload)
+- Reports: JSON (local only)
 
 Sink details:
 - Options: [docs/sinks/options.md](docs/sinks/options.md)
 - Delta: [docs/sinks/delta.md](docs/sinks/delta.md)
 - Iceberg: [docs/sinks/iceberg.md](docs/sinks/iceberg.md)
+- Support matrix: [docs/support-matrix.md](docs/support-matrix.md)
 
 ## Cloud integration and storages
 
 Floe resolves all paths through a storage registry in the config. By default,
 paths use `local://`. To use cloud storage, define a storage (with credentials
-or bucket info) and reference it on `source`/`sink`. Currently only S3 is
-implemented; Google Cloud Storage, Azure Data Lake Storage, and `dbfs://`
-(Databricks) are on the roadmap.
+or bucket info) and reference it on `source`/`sink`. S3, ADLS, and GCS are
+implemented; `dbfs://` (Databricks) is on the roadmap.
 
 Example (S3 storage):
 
@@ -160,7 +161,10 @@ entities:
       path: raw/customer/
 ```
 
-Storage guide: [docs/storages/s3.md](docs/storages/s3.md)
+Storage guides:
+- [docs/storages/s3.md](docs/storages/s3.md)
+- [docs/storages/adls.md](docs/storages/adls.md)
+- [docs/storages/gcs.md](docs/storages/gcs.md)
 
 ## Roadmap (near term)
 

--- a/docs/storages/adls.md
+++ b/docs/storages/adls.md
@@ -1,7 +1,7 @@
-# ADLS Storage (planned)
+# ADLS Storage (MVP)
 
-Floe supports configuring ADLS storage definitions but the backend is not implemented yet.
-This file documents the intended configuration and canonical URI format.
+ADLS (Gen2) storage is supported for list/download/upload using Azure's default
+credential chain. This MVP uses temp downloads/uploads for file IO.
 
 ## Config fields
 
@@ -46,6 +46,15 @@ export AZURE_CLIENT_SECRET=...
 
 Managed identity, Azure CLI, and other default credential sources are also supported.
 
-## Status
+## Supported behavior
 
-MVP is implemented with temp download/upload (list/get/put) using Azure default credentials.
+- Inputs: CSV and JSON (array/ndjson) via prefix listing + suffix filtering.
+- Outputs:
+  - Accepted parquet: temp local write then upload.
+  - Accepted delta: direct object_store writes (no temp upload).
+  - Rejected CSV: temp local write then upload.
+
+## Limitations
+
+- Source path is treated as a prefix (no glob patterns).
+- Parquet input is local-only.

--- a/docs/storages/gcs.md
+++ b/docs/storages/gcs.md
@@ -39,8 +39,7 @@ export GOOGLE_APPLICATION_CREDENTIALS="/path/to/service-account.json"
 
 ## Limitations
 
-- IO uses temp download/upload (no streaming).
-- Only file-based formats (csv/parquet/json) are supported.
-
-GCS auth will follow the standard Google ADC (Application Default Credentials) chain.
-This will be documented once list/download/upload are implemented.
+- IO uses temp download/upload (no streaming) for file formats.
+- Source path is treated as a prefix (no glob patterns).
+- Parquet input is local-only.
+- Accepted Delta uses direct object_store writes (no temp upload).

--- a/docs/storages/s3.md
+++ b/docs/storages/s3.md
@@ -1,6 +1,6 @@
 # S3 Storage (MVP)
 
-This document describes the minimal S3 support in Floe (F-103).
+This document describes current S3 support in Floe.
 
 ## Requirements
 
@@ -29,7 +29,9 @@ storages:
 entities:
   - name: customers
     source:
-      format: csv
+      format: json
+      options:
+        json_mode: array
       path: inbound/customers
       storage: s3_raw
     sink:
@@ -55,11 +57,18 @@ Resolved S3 URIs are formed as:
 s3://<bucket>/<prefix>/<path>
 ```
 
-## MVP limitations
+## Supported behavior
 
-- Source supports CSV only.
+- Inputs: CSV and JSON (array/ndjson) via prefix listing + suffix filtering.
+- Outputs:
+  - Accepted parquet: temp local write then upload.
+  - Accepted delta: direct object_store writes (no temp upload).
+  - Rejected CSV: temp local write then upload.
+
+## Limitations
+
 - Source path is treated as a prefix (no S3 glob patterns).
-- Only suffix filtering by format is applied (for CSV, `.csv`).
+- Only suffix filtering by format is applied (e.g., `.csv`, `.json`, `.jsonl`).
 - Recursive listing behavior is not configurable yet (S3 prefix lists are
   effectively recursive).
-- S3 archive targets are not supported in this MVP.
+- Parquet input is local-only.

--- a/docs/support-matrix.md
+++ b/docs/support-matrix.md
@@ -1,0 +1,72 @@
+# Floe v0.2 Support Matrix
+
+This matrix reflects **current behavior** in the codebase (not aspirational).
+Cloud storage uses temp download/upload for file IO, while Delta uses direct
+object_store transactions.
+
+## Inputs
+
+| Format | Local | S3 | ADLS | GCS | Notes |
+|---|---|---|---|---|---|
+| CSV | ✅ | ✅ (temp) | ✅ (temp) | ✅ (temp) | Suffix filter `.csv` |
+| JSON (array) | ✅ | ✅ (temp) | ✅ (temp) | ✅ (temp) | `source.options.json_mode=array` (default) |
+| JSON (ndjson) | ✅ | ✅ (temp) | ✅ (temp) | ✅ (temp) | `source.options.json_mode=ndjson` |
+| Parquet | ✅ | ❌ | ❌ | ❌ | Input parquet is local-only |
+
+Notes:
+- Cloud inputs are resolved by **prefix listing** + suffix filtering, then downloaded to temp files.
+- Globs and recursive options apply to local inputs only.
+- JSON file extensions accepted: `.json`, `.jsonl`, `.ndjson`, `.djson` (case-insensitive).
+- Nested JSON values (objects/arrays) are rejected.
+
+## Outputs
+
+| Output | Local | S3 | ADLS | GCS | Notes |
+|---|---|---|---|---|---|
+| Accepted: Parquet | ✅ | ✅ (temp) | ✅ (temp) | ✅ (temp) | Writes `part-00000.parquet` etc. |
+| Accepted: Delta | ✅ | ✅ (object_store) | ✅ (object_store) | ✅ (object_store) | Transactional `_delta_log` |
+| Rejected: CSV | ✅ | ✅ (temp) | ✅ (temp) | ✅ (temp) | Per-file rejected output |
+| Reports: JSON | ✅ | ❌ | ❌ | ❌ | `report.path` is local-only |
+
+Notes:
+- Parquet outputs to cloud are written locally then uploaded.
+- Delta outputs to cloud are **direct** via object_store (no temp upload).
+
+## Cloud storage behavior
+
+- Storage paths resolve to canonical URIs:
+  - S3: `s3://<bucket>/<prefix>/<path>`
+  - ADLS: `abfs://<container>@<account>.dfs.core.windows.net/<prefix>/<path>`
+  - GCS: `gs://<bucket>/<prefix>/<path>`
+- Prefix listing is stable and lexicographically sorted.
+- No glob support for S3/ADLS/GCS inputs (prefix only).
+
+## Config keys (storage)
+
+```yaml
+storages:
+  default: local
+  definitions:
+    - name: local
+      type: local
+    - name: s3_raw
+      type: s3
+      bucket: my-bucket
+      region: eu-west-1
+      prefix: data
+    - name: adls_raw
+      type: adls
+      account: myaccount
+      container: raw
+      prefix: ingest
+    - name: gcs_raw
+      type: gcs
+      bucket: my-bucket
+      prefix: data
+```
+
+Storage references:
+- `entities[].source.storage`
+- `entities[].sink.accepted.storage`
+- `entities[].sink.rejected.storage`
+


### PR DESCRIPTION
## Summary
- add v0.2 support matrix covering formats, storages, and sink behavior
- refresh S3/ADLS/GCS storage docs to match current capabilities
- update README supported formats and storage references

## Testing
- cargo fmt --all
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test --all