### PR TITLE
fix(config): default source.cast_mode to strict

### DIFF
--- a/crates/floe-core/src/config/parse.rs
+++ b/crates/floe-core/src/config/parse.rs
@@ -250,7 +250,7 @@ fn parse_source(value: &Yaml) -> FloeResult<SourceConfig> {
         path: get_string(hash, "path", "source")?,
         storage: storage.or(filesystem),
         options,
-        cast_mode: opt_string(hash, "cast_mode", "source")?,
+        cast_mode: opt_string(hash, "cast_mode", "source")?.or(Some("strict".to_string())),
     })
 }
 

--- a/crates/floe-core/tests/unit/config/parse.rs
+++ b/crates/floe-core/tests/unit/config/parse.rs
@@ -45,6 +45,7 @@ entities:
     assert_eq!(config.report.as_ref().unwrap().path, "/tmp/reports");
     assert_eq!(config.entities.len(), 1);
     let entity = &config.entities[0];
+    assert_eq!(entity.source.cast_mode.as_deref(), Some("strict"));
     let options = entity.source.options.as_ref().expect("options");
     assert_eq!(options.header, Some(true));
     assert_eq!(options.separator.as_deref(), Some(";"));


### PR DESCRIPTION
Fixes #76.

Changes:
- Default `source.cast_mode` is now `strict` when omitted in config.
- Added unit assertion in config parsing test.

Validation:
- cargo fmt --all
- cargo clippy -p floe-core --tests -- -D warnings
- cargo test -p floe-core --test unit -- unit::config::parse::parse_config_loads_report_and_defaults
