### PR TITLE
Release v0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to Floe are documented in this file.
 
+## v0.2.1
+
+- Added official Docker image packaging and GHCR publishing on version tags.
+- Documentation: Docker usage added to installation guide and summary.
+- Added machine-readable run event logs (json/text) behind `--log-format`.
+- Fixes: `metadata.project` optional, CSV empty fields treated as null by default, default `cast_mode=strict`.
+
 ## v0.2.0
 
 - Cloud storage registry with local/S3/ADLS/GCS support (canonical URIs).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2981,7 +2981,7 @@ dependencies = [
 
 [[package]]
 name = "floe-cli"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "clap",
  "floe-core",
@@ -2990,7 +2990,7 @@ dependencies = [
 
 [[package]]
 name = "floe-core"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "aws-config",
  "aws-sdk-s3",

--- a/crates/floe-cli/Cargo.toml
+++ b/crates/floe-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "floe-cli"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 description = "CLI for Floe, a YAML-driven technical ingestion tool."
 license = "MIT"
@@ -17,5 +17,5 @@ path = "src/main.rs"
 
 [dependencies]
 clap = { version = "4", features = ["derive"] }
-floe-core = { path = "../floe-core", version = "0.2.0" }
+floe-core = { path = "../floe-core", version = "0.2.1" }
 serde_json = "1"

--- a/crates/floe-core/Cargo.toml
+++ b/crates/floe-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "floe-core"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 description = "Core library for Floe, a YAML-driven technical ingestion tool."
 license = "MIT"


### PR DESCRIPTION
Release v0.2.1

Changes:
- Version bump: floe-core + floe-cli -> 0.2.1
- Changelog updated

Notes:
- Docker/GHCR publishing is included in main (see #81); this PR is only the patch release bump.