### PR TITLE
feat(validate): add --output json plan for orchestration

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,12 @@ floe --version
 floe validate -c example/config.yml
 ```
 
+Automation / orchestrators (single JSON object on stdout):
+
+```bash
+floe validate -c example/config.yml --output json
+```
+
 ### Run
 
 ```bash

--- a/crates/floe-cli/src/main.rs
+++ b/crates/floe-cli/src/main.rs
@@ -6,6 +6,7 @@ use floe_core::{
 use std::io::Write;
 
 use crate::logging::LogFormat;
+use crate::validate_output::ValidateOutputFormat;
 
 const VERSION: &str = env!("FLOE_VERSION");
 const ROOT_LONG_ABOUT: &str = concat!(
@@ -63,6 +64,7 @@ const VALIDATE_LONG_ABOUT: &str = concat!(
 
 mod logging;
 mod output;
+mod validate_output;
 
 #[derive(Parser, Debug)]
 #[command(
@@ -88,6 +90,14 @@ enum Command {
             help = "Comma-separated list of entity names"
         )]
         entities: Vec<String>,
+        #[arg(
+            long,
+            alias = "format",
+            value_enum,
+            default_value_t = ValidateOutputFormat::Text,
+            help = "Output format for validate (text|json)"
+        )]
+        output: ValidateOutputFormat,
     },
     #[command(about = "Run the ingestion pipeline", long_about = RUN_LONG_ABOUT)]
     Run {
@@ -123,39 +133,110 @@ fn main() -> FloeResult<()> {
     let cli = Cli::parse();
 
     match cli.command {
-        Command::Validate { config, entities } => {
-            let config_location = resolve_config_location(&config)?;
-            let options = ValidateOptions { entities };
-            validate_with_base(&config_location.path, config_location.base.clone(), options)?;
-            let config = load_config(&config_location.path)?;
-            println!("Config valid: {}", config_location.display);
-            println!("Version: {}", config.version);
-            println!(
-                "Report: {}",
-                config
-                    .report
-                    .as_ref()
-                    .map(|report| report.path.as_str())
-                    .unwrap_or("(disabled)")
-            );
-            println!("Entities: {}", config.entities.len());
-            for entity in &config.entities {
-                println!("Entity: {}", entity.name);
-                println!(
-                    "  Source: {} ({})",
-                    entity.source.format, entity.source.path
-                );
-                println!(
-                    "  Sink accepted: {} ({})",
-                    entity.sink.accepted.format, entity.sink.accepted.path
-                );
-                if let Some(rejected) = &entity.sink.rejected {
-                    println!("  Sink rejected: {} ({})", rejected.format, rejected.path);
+        Command::Validate {
+            config,
+            entities,
+            output,
+        } => {
+            let config_location = match resolve_config_location(&config) {
+                Ok(location) => location,
+                Err(err) => {
+                    match output {
+                        ValidateOutputFormat::Json => {
+                            let json =
+                                validate_output::build_invalid_json(&config, None, err.as_ref());
+                            let mut out = std::io::stdout().lock();
+                            let _ = writeln!(out, "{json}");
+                            let _ = out.flush();
+                        }
+                        ValidateOutputFormat::Text => {
+                            let mut err_out = std::io::stderr().lock();
+                            let _ = writeln!(err_out, "Error: {err}");
+                            let _ = err_out.flush();
+                        }
+                    }
+                    std::process::exit(1);
                 }
-                println!("  Severity: {}", entity.policy.severity);
+            };
+
+            let options = ValidateOptions {
+                entities: entities.clone(),
+            };
+
+            let validation_result =
+                validate_with_base(&config_location.path, config_location.base.clone(), options);
+
+            match output {
+                ValidateOutputFormat::Text => match validation_result {
+                    Ok(()) => {
+                        let config = load_config(&config_location.path)?;
+                        println!("Config valid: {}", config_location.display);
+                        println!("Version: {}", config.version);
+                        println!(
+                            "Report: {}",
+                            config
+                                .report
+                                .as_ref()
+                                .map(|report| report.path.as_str())
+                                .unwrap_or("(disabled)")
+                        );
+                        println!("Entities: {}", config.entities.len());
+                        for entity in &config.entities {
+                            println!("Entity: {}", entity.name);
+                            println!(
+                                "  Source: {} ({})",
+                                entity.source.format, entity.source.path
+                            );
+                            println!(
+                                "  Sink accepted: {} ({})",
+                                entity.sink.accepted.format, entity.sink.accepted.path
+                            );
+                            if let Some(rejected) = &entity.sink.rejected {
+                                println!(
+                                    "  Sink rejected: {} ({})",
+                                    rejected.format, rejected.path
+                                );
+                            }
+                            println!("  Severity: {}", entity.policy.severity);
+                        }
+                        println!("Next: floe run -c {}", config_location.display);
+                        let _ = std::io::stdout().lock().flush();
+                        Ok(())
+                    }
+                    Err(err) => {
+                        let mut err_out = std::io::stderr().lock();
+                        let _ = writeln!(err_out, "Error: {err}");
+                        let _ = err_out.flush();
+                        std::process::exit(1);
+                    }
+                },
+                ValidateOutputFormat::Json => match validation_result {
+                    Ok(()) => {
+                        let config = load_config(&config_location.path)?;
+                        let json = validate_output::build_valid_json(
+                            &config_location,
+                            &config,
+                            &entities,
+                        )?;
+                        let mut out = std::io::stdout().lock();
+                        let _ = writeln!(out, "{json}");
+                        let _ = out.flush();
+                        Ok(())
+                    }
+                    Err(err) => {
+                        let config = load_config(&config_location.path).ok();
+                        let json = validate_output::build_invalid_json(
+                            &config_location.display,
+                            config.as_ref().map(|config| config.version.as_str()),
+                            err.as_ref(),
+                        );
+                        let mut out = std::io::stdout().lock();
+                        let _ = writeln!(out, "{json}");
+                        let _ = out.flush();
+                        std::process::exit(1);
+                    }
+                },
             }
-            println!("Next: floe run -c {}", config_location.display);
-            Ok(())
         }
         Command::Run {
             config,

--- a/crates/floe-cli/src/validate_output.rs
+++ b/crates/floe-cli/src/validate_output.rs
@@ -1,0 +1,496 @@
+use clap::ValueEnum;
+use floe_core::config::{RootConfig, StorageResolver};
+use floe_core::{ConfigLocation, FloeResult};
+use serde::Serialize;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+#[derive(ValueEnum, Clone, Debug, PartialEq, Eq)]
+pub enum ValidateOutputFormat {
+    Text,
+    Json,
+}
+
+#[derive(Serialize)]
+struct ValidateJsonOutput {
+    schema: &'static str,
+    floe_version: &'static str,
+    spec_version: Option<String>,
+    generated_at_ts_ms: u64,
+    config: ConfigInfo,
+    valid: bool,
+    errors: Vec<PlanIssue>,
+    warnings: Vec<PlanIssue>,
+    plan: Option<ValidatePlan>,
+}
+
+#[derive(Serialize)]
+struct ConfigInfo {
+    uri: String,
+    resolved_uri: Option<String>,
+    checksum: Option<String>,
+}
+
+#[derive(Serialize)]
+struct PlanIssue {
+    level: &'static str,
+    code: &'static str,
+    message: String,
+    path: Option<String>,
+    entity: Option<String>,
+    hint: Option<String>,
+}
+
+#[derive(Serialize)]
+struct ValidatePlan {
+    report: ReportPlan,
+    domains: Vec<DomainPlan>,
+    entities: Vec<EntityPlan>,
+}
+
+#[derive(Serialize)]
+struct ReportPlan {
+    base_uri: String,
+    storage: String,
+    resolved: bool,
+}
+
+#[derive(Serialize)]
+struct DomainPlan {
+    name: String,
+    incoming_dir: String,
+    resolved_incoming_dir: Option<String>,
+}
+
+#[derive(Serialize)]
+struct EntityPlan {
+    name: String,
+    domain: Option<String>,
+    metadata: Option<EntityMetadataPlan>,
+    key: Vec<String>,
+    group_name: Option<String>,
+    policy: PolicyPlan,
+    source: SourcePlan,
+    sinks: SinksPlan,
+    schema: SchemaPlan,
+}
+
+#[derive(Serialize)]
+struct EntityMetadataPlan {
+    data_product: Option<String>,
+    domain: Option<String>,
+    owner: Option<String>,
+    description: Option<String>,
+    tags: Option<Vec<String>>,
+}
+
+#[derive(Serialize)]
+struct PolicyPlan {
+    severity: String,
+}
+
+#[derive(Serialize)]
+struct SourcePlan {
+    format: String,
+    storage: String,
+    path: String,
+    uri: String,
+    resolved: bool,
+    cast_mode: Option<String>,
+    options: Option<SourceOptionsPlan>,
+}
+
+#[derive(Serialize)]
+struct SourceOptionsPlan {
+    header: Option<bool>,
+    separator: Option<String>,
+    encoding: Option<String>,
+    null_values: Option<Vec<String>>,
+    recursive: Option<bool>,
+    glob: Option<String>,
+    json_mode: Option<String>,
+}
+
+#[derive(Serialize)]
+struct SinksPlan {
+    accepted: SinkPlan,
+    rejected: Option<SinkPlan>,
+    archive: Option<ArchivePlan>,
+}
+
+#[derive(Serialize)]
+struct SinkPlan {
+    format: String,
+    storage: String,
+    path: String,
+    uri: String,
+    resolved: bool,
+    options: Option<SinkOptionsPlan>,
+}
+
+#[derive(Serialize)]
+struct SinkOptionsPlan {
+    compression: Option<String>,
+    row_group_size: Option<u64>,
+    max_size_per_file: Option<u64>,
+}
+
+#[derive(Serialize)]
+struct ArchivePlan {
+    storage: String,
+    path: String,
+    uri: String,
+    resolved: bool,
+}
+
+#[derive(Serialize)]
+struct SchemaPlan {
+    normalize_columns: Option<NormalizeColumnsPlan>,
+    mismatch: Option<MismatchPlan>,
+    columns: Vec<ColumnPlan>,
+}
+
+#[derive(Serialize)]
+struct NormalizeColumnsPlan {
+    enabled: Option<bool>,
+    strategy: Option<String>,
+}
+
+#[derive(Serialize)]
+struct MismatchPlan {
+    missing_columns: Option<String>,
+    extra_columns: Option<String>,
+}
+
+#[derive(Serialize)]
+struct ColumnPlan {
+    name: String,
+    column_type: String,
+    nullable: Option<bool>,
+    unique: Option<bool>,
+}
+
+pub fn build_valid_json(
+    config_location: &ConfigLocation,
+    config: &RootConfig,
+    selected_entities: &[String],
+) -> FloeResult<String> {
+    let now_ms = now_ts_ms();
+    let resolver = StorageResolver::new(config, config_location.base.clone())?;
+
+    let report = config
+        .report
+        .as_ref()
+        .expect("report has a default value during parsing");
+    let report_resolved = resolver.resolve_report_path(report.storage.as_deref(), &report.path);
+    let report_plan = match report_resolved {
+        Ok(resolved) => ReportPlan {
+            base_uri: resolved.uri,
+            storage: resolved.storage,
+            resolved: true,
+        },
+        Err(_) => ReportPlan {
+            base_uri: report.path.clone(),
+            storage: report
+                .storage
+                .clone()
+                .unwrap_or_else(|| resolver.default_storage_name().to_string()),
+            resolved: false,
+        },
+    };
+
+    let entities: Vec<_> = if selected_entities.is_empty() {
+        config.entities.iter().collect()
+    } else {
+        config
+            .entities
+            .iter()
+            .filter(|entity| selected_entities.iter().any(|name| name == &entity.name))
+            .collect()
+    };
+
+    let mut entity_plans = Vec::with_capacity(entities.len());
+    for entity in entities {
+        let source_path = resolve_or_raw(
+            &resolver,
+            &entity.name,
+            "source.path",
+            entity.source.storage.as_deref(),
+            &entity.source.path,
+        );
+        let accepted_path = resolve_or_raw(
+            &resolver,
+            &entity.name,
+            "sink.accepted.path",
+            entity.sink.accepted.storage.as_deref(),
+            &entity.sink.accepted.path,
+        );
+        let rejected_plan = entity.sink.rejected.as_ref().map(|rejected| {
+            let rejected_path = resolve_or_raw(
+                &resolver,
+                &entity.name,
+                "sink.rejected.path",
+                rejected.storage.as_deref(),
+                &rejected.path,
+            );
+            SinkPlan {
+                format: rejected.format.clone(),
+                storage: rejected_path.storage,
+                path: rejected.path.clone(),
+                uri: rejected_path.uri,
+                resolved: rejected_path.resolved,
+                options: rejected.options.as_ref().map(|options| SinkOptionsPlan {
+                    compression: options.compression.clone(),
+                    row_group_size: options.row_group_size,
+                    max_size_per_file: options.max_size_per_file,
+                }),
+            }
+        });
+
+        let archive_plan = entity.sink.archive.as_ref().map(|archive| {
+            let storage_override = archive
+                .storage
+                .as_deref()
+                .or(entity.source.storage.as_deref());
+            let archive_path = resolve_or_raw(
+                &resolver,
+                &entity.name,
+                "sink.archive.path",
+                storage_override,
+                &archive.path,
+            );
+            ArchivePlan {
+                storage: archive_path.storage,
+                path: archive.path.clone(),
+                uri: archive_path.uri,
+                resolved: archive_path.resolved,
+            }
+        });
+
+        let metadata = entity.metadata.as_ref().map(|metadata| EntityMetadataPlan {
+            data_product: metadata.data_product.clone(),
+            domain: metadata.domain.clone(),
+            owner: metadata.owner.clone(),
+            description: metadata.description.clone(),
+            tags: metadata.tags.clone(),
+        });
+
+        let (key, group_name) = entity
+            .domain
+            .as_ref()
+            .map(|domain| {
+                (
+                    vec![domain.clone(), entity.name.clone()],
+                    Some(domain.clone()),
+                )
+            })
+            .unwrap_or_else(|| (vec![entity.name.clone()], Some("floe".to_string())));
+
+        entity_plans.push(EntityPlan {
+            name: entity.name.clone(),
+            domain: entity.domain.clone(),
+            metadata,
+            key,
+            group_name,
+            policy: PolicyPlan {
+                severity: entity.policy.severity.clone(),
+            },
+            source: SourcePlan {
+                format: entity.source.format.clone(),
+                storage: source_path.storage,
+                path: entity.source.path.clone(),
+                uri: source_path.uri,
+                resolved: source_path.resolved,
+                cast_mode: entity.source.cast_mode.clone(),
+                options: entity
+                    .source
+                    .options
+                    .as_ref()
+                    .map(|options| SourceOptionsPlan {
+                        header: options.header,
+                        separator: options.separator.clone(),
+                        encoding: options.encoding.clone(),
+                        null_values: options.null_values.clone(),
+                        recursive: options.recursive,
+                        glob: options.glob.clone(),
+                        json_mode: options.json_mode.clone(),
+                    }),
+            },
+            sinks: SinksPlan {
+                accepted: SinkPlan {
+                    format: entity.sink.accepted.format.clone(),
+                    storage: accepted_path.storage,
+                    path: entity.sink.accepted.path.clone(),
+                    uri: accepted_path.uri,
+                    resolved: accepted_path.resolved,
+                    options: entity
+                        .sink
+                        .accepted
+                        .options
+                        .as_ref()
+                        .map(|options| SinkOptionsPlan {
+                            compression: options.compression.clone(),
+                            row_group_size: options.row_group_size,
+                            max_size_per_file: options.max_size_per_file,
+                        }),
+                },
+                rejected: rejected_plan,
+                archive: archive_plan,
+            },
+            schema: SchemaPlan {
+                normalize_columns: entity.schema.normalize_columns.as_ref().map(|normalize| {
+                    NormalizeColumnsPlan {
+                        enabled: normalize.enabled,
+                        strategy: normalize.strategy.clone(),
+                    }
+                }),
+                mismatch: entity
+                    .schema
+                    .mismatch
+                    .as_ref()
+                    .map(|mismatch| MismatchPlan {
+                        missing_columns: mismatch.missing_columns.clone(),
+                        extra_columns: mismatch.extra_columns.clone(),
+                    }),
+                columns: entity
+                    .schema
+                    .columns
+                    .iter()
+                    .map(|column| ColumnPlan {
+                        name: column.name.clone(),
+                        column_type: column.column_type.clone(),
+                        nullable: column.nullable,
+                        unique: column.unique,
+                    })
+                    .collect(),
+            },
+        });
+    }
+
+    let output = ValidateJsonOutput {
+        schema: "floe.plan.v1",
+        floe_version: env!("FLOE_VERSION"),
+        spec_version: Some(config.version.clone()),
+        generated_at_ts_ms: now_ms,
+        config: ConfigInfo {
+            uri: config_location.display.clone(),
+            resolved_uri: Some(config_location.display.clone()),
+            checksum: None,
+        },
+        valid: true,
+        errors: Vec::new(),
+        warnings: Vec::new(),
+        plan: Some(ValidatePlan {
+            report: report_plan,
+            domains: config
+                .domains
+                .iter()
+                .map(|domain| DomainPlan {
+                    name: domain.name.clone(),
+                    incoming_dir: domain.incoming_dir.clone(),
+                    resolved_incoming_dir: domain.resolved_incoming_dir.clone(),
+                })
+                .collect(),
+            entities: entity_plans,
+        }),
+    };
+
+    Ok(serde_json::to_string(&output)?)
+}
+
+pub fn build_invalid_json(
+    config_uri: &str,
+    spec_version: Option<&str>,
+    err: &dyn std::error::Error,
+) -> String {
+    let message = err.to_string();
+    let output = ValidateJsonOutput {
+        schema: "floe.plan.v1",
+        floe_version: env!("FLOE_VERSION"),
+        spec_version: spec_version.map(|value| value.to_string()),
+        generated_at_ts_ms: now_ts_ms(),
+        config: ConfigInfo {
+            uri: config_uri.to_string(),
+            resolved_uri: Some(config_uri.to_string()),
+            checksum: None,
+        },
+        valid: false,
+        errors: vec![PlanIssue {
+            level: "error",
+            code: "CONFIG_INVALID",
+            message: message.clone(),
+            path: best_effort_path(&message),
+            entity: best_effort_entity(&message),
+            hint: None,
+        }],
+        warnings: Vec::new(),
+        plan: None,
+    };
+
+    serde_json::to_string(&output).unwrap_or_else(|_| {
+        format!(
+            "{{\"schema\":\"floe.plan.v1\",\"valid\":false,\"errors\":[{{\"level\":\"error\",\"code\":\"CONFIG_INVALID\",\"message\":{}}}]}}",
+            serde_json::to_string(&message).unwrap_or_else(|_| "\"config invalid\"".to_string())
+        )
+    })
+}
+
+struct ResolvedOrRaw {
+    storage: String,
+    uri: String,
+    resolved: bool,
+}
+
+fn resolve_or_raw(
+    resolver: &StorageResolver,
+    entity_name: &str,
+    field: &str,
+    storage_name: Option<&str>,
+    raw_path: &str,
+) -> ResolvedOrRaw {
+    match resolver.resolve_path(entity_name, field, storage_name, raw_path) {
+        Ok(resolved) => ResolvedOrRaw {
+            storage: resolved.storage,
+            uri: resolved.uri,
+            resolved: true,
+        },
+        Err(_) => ResolvedOrRaw {
+            storage: storage_name
+                .map(|value| value.to_string())
+                .unwrap_or_else(|| resolver.default_storage_name().to_string()),
+            uri: raw_path.to_string(),
+            resolved: false,
+        },
+    }
+}
+
+fn best_effort_entity(message: &str) -> Option<String> {
+    let marker = "entity.name=";
+    let start = message.find(marker)? + marker.len();
+    let rest = &message[start..];
+    let end = rest
+        .find(|ch: char| ch.is_whitespace() || ch == ',' || ch == ')')
+        .unwrap_or(rest.len());
+    let value = rest[..end].trim();
+    if value.is_empty() {
+        None
+    } else {
+        Some(value.to_string())
+    }
+}
+
+fn best_effort_path(message: &str) -> Option<String> {
+    if let Some(pos) = message.find("unknown field ") {
+        return Some(message[pos + "unknown field ".len()..].trim().to_string());
+    }
+    if message.starts_with("entities list is empty") {
+        return Some("root.entities".to_string());
+    }
+    None
+}
+
+fn now_ts_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_millis() as u64)
+        .unwrap_or(0)
+}

--- a/crates/floe-cli/tests/fixtures/invalid_config.yml
+++ b/crates/floe-cli/tests/fixtures/invalid_config.yml
@@ -1,0 +1,3 @@
+version: "0.2"
+entities: []
+

--- a/crates/floe-cli/tests/validate_output.rs
+++ b/crates/floe-cli/tests/validate_output.rs
@@ -1,0 +1,65 @@
+use assert_cmd::Command;
+use predicates::prelude::*;
+use std::path::PathBuf;
+
+const PLAN_SCHEMA: &str = "floe.plan.v1";
+
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../..")
+}
+
+#[test]
+fn validate_output_json_is_single_json_object() {
+    let config_path = repo_root().join("example/config.yml");
+
+    let mut cmd = Command::new(assert_cmd::cargo::cargo_bin!("floe"));
+    let assert = cmd
+        .args(["validate", "-c"])
+        .arg(&config_path)
+        .args(["--output", "json"])
+        .assert()
+        .success();
+
+    let stdout = String::from_utf8_lossy(&assert.get_output().stdout);
+    let value: serde_json::Value =
+        serde_json::from_str(stdout.trim()).expect("stdout should be a single JSON object");
+    assert_eq!(value["schema"], PLAN_SCHEMA);
+    assert_eq!(value["valid"], true);
+    assert!(value["plan"].is_object());
+}
+
+#[test]
+fn validate_default_output_is_human_text() {
+    let config_path = repo_root().join("example/config.yml");
+
+    let mut cmd = Command::new(assert_cmd::cargo::cargo_bin!("floe"));
+    cmd.args(["validate", "-c"])
+        .arg(&config_path)
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Config valid:"))
+        .stdout(predicate::str::contains("Next: floe run"));
+}
+
+#[test]
+fn validate_invalid_config_json_sets_valid_false_and_exit_1() {
+    let fixture_path =
+        PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/invalid_config.yml");
+
+    let mut cmd = Command::new(assert_cmd::cargo::cargo_bin!("floe"));
+    let assert = cmd
+        .args(["validate", "-c"])
+        .arg(&fixture_path)
+        .args(["--output", "json"])
+        .assert()
+        .failure();
+
+    let stdout = String::from_utf8_lossy(&assert.get_output().stdout);
+    let value: serde_json::Value =
+        serde_json::from_str(stdout.trim()).expect("stdout should be JSON even when invalid");
+    assert_eq!(value["schema"], PLAN_SCHEMA);
+    assert_eq!(value["valid"], false);
+    assert!(value["errors"].is_array());
+    assert!(!value["errors"].as_array().unwrap().is_empty());
+    assert!(value["plan"].is_null());
+}

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -2,8 +2,9 @@
 
 ## Commands
 
-- `floe validate -c <config> [--entities <name[,name...]>]`
+- `floe validate -c <config> [--entities <name[,name...]>] [--output text|json]`
   - Validate YAML config and exit with non-zero code on errors.
+  - `--output json` prints a single JSON object to stdout (for orchestrators / automation).
 
 - `floe run -c <config> [--run-id <id>] [--entities <name[,name...]>]`
   - Execute ingestion using the config.
@@ -14,6 +15,7 @@
 
 - Validate the sample config:
   - `floe validate -c example/config.yml --entities customer`
+  - `floe validate -c example/config.yml --output json`
 
 - Run with default paths from the config:
   - `floe run -c example/config.yml --entities customer`


### PR DESCRIPTION
Adds `floe validate --output json` to emit a single machine-readable JSON plan (schema `floe.plan.v1`) for orchestrators, while keeping the existing text summary as default.

Changes
- CLI: new `--output text|json` (alias `--format`) on `floe validate`
- JSON contract: stdout is exactly one JSON object; includes `valid`, `errors`, and `plan` (`plan=null` when invalid)
- Plan includes resolved canonical URIs via core `StorageResolver` (local/s3/gcs/adls)
- Tests: integration-style CLI tests for JSON output, default text output, and invalid config fixture
- Docs: README + docs/cli.md updated with `--output json` example