### PR TITLE
chore(release): fast multi-arch GHCR publish from prebuilt binaries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,12 +45,34 @@ jobs:
   docker:
     name: Publish Docker image (GHCR)
     runs-on: ubuntu-latest
-    needs: meta
+    needs: [meta, build]
     if: ${{ needs.meta.outputs.on_main == 'true' && (github.event_name != 'workflow_dispatch' || inputs.dry_run == false) }}
     env:
       VERSION: ${{ needs.meta.outputs.version }}
     steps:
       - uses: actions/checkout@v4
+
+      - name: Download build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: dist
+          pattern: dist-*
+          merge-multiple: true
+
+      - name: Prepare docker binaries
+        shell: bash
+        run: |
+          set -euo pipefail
+          version="${VERSION}"
+          mkdir -p dist/docker/linux/amd64 dist/docker/linux/arm64
+
+          tar -C dist/docker/linux/amd64 -xzf "dist/floe-v${version}-x86_64-unknown-linux-gnu.tar.gz" floe
+          tar -C dist/docker/linux/arm64 -xzf "dist/floe-v${version}-aarch64-unknown-linux-gnu.tar.gz" floe
+
+          chmod +x dist/docker/linux/amd64/floe dist/docker/linux/arm64/floe
+
+      - name: Sanity check linux/amd64 binary
+        run: ./dist/docker/linux/amd64/floe --help > /dev/null
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
@@ -69,7 +91,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: .
-          file: ./Dockerfile
+          file: ./Dockerfile.release
           platforms: linux/amd64,linux/arm64
           push: true
           tags: |
@@ -140,10 +162,16 @@ jobs:
         include:
           - os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
+            use_cross: false
+          - os: ubuntu-latest
+            target: aarch64-unknown-linux-gnu
+            use_cross: true
           - os: macos-latest
             target: x86_64-apple-darwin
+            use_cross: false
           - os: macos-latest
             target: aarch64-apple-darwin
+            use_cross: false
     env:
       VERSION: ${{ needs.meta.outputs.version }}
     steps:
@@ -151,10 +179,20 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: ${{ matrix.target }}
+      - name: Install cross
+        if: ${{ matrix.use_cross }}
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cross
       - name: Set Cargo versions from tag
         run: bash .github/scripts/set_versions.sh "${VERSION}"
       - name: Build floe
-        run: cargo build -p floe-cli --release --target ${{ matrix.target }}
+        run: |
+          if [ "${{ matrix.use_cross }}" = "true" ]; then
+            cross build -p floe-cli --release --target ${{ matrix.target }}
+          else
+            cargo build -p floe-cli --release --target ${{ matrix.target }}
+          fi
       - name: Package binary
         shell: bash
         run: |

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -1,0 +1,18 @@
+FROM debian:bookworm-slim
+
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends ca-certificates \
+  && rm -rf /var/lib/apt/lists/*
+
+RUN useradd --create-home --uid 10001 floe
+
+WORKDIR /work
+
+ARG TARGETARCH
+COPY dist/docker/linux/${TARGETARCH}/floe /usr/local/bin/floe
+RUN chmod +x /usr/local/bin/floe
+
+USER floe
+ENTRYPOINT ["floe"]
+CMD ["--help"]
+


### PR DESCRIPTION
Fixes the slow (hours-long) GHCR multi-arch build caused by compiling Rust under QEMU inside the Docker build.

**What changed**
- Extends the existing `build` job to also build `aarch64-unknown-linux-gnu` (Linux arm64) using `cross` on Ubuntu.
- Adds `Dockerfile.release` that only *packages prebuilt binaries* (no Rust compilation).
- Updates the `docker` job to download the `build` artifacts, extract the linux amd64/arm64 binaries into `dist/docker/linux/<arch>/floe`, then build/push a multi-arch image from `Dockerfile.release`.

**Result**
- Docker publish no longer runs `cargo build` inside the Docker build.
- Multi-arch image (linux/amd64 + linux/arm64) is still published as:
  - `ghcr.io/<owner>/floe:<version>`
  - `ghcr.io/<owner>/floe:latest`