### PR TITLE
fix(release): unblock cross build for linux/arm64 (openssl)

### DIFF
--- a/Cross.toml
+++ b/Cross.toml
@@ -1,0 +1,10 @@
+[target.aarch64-unknown-linux-gnu]
+# Needed for deps that rely on `native-tls` / `openssl-sys` when cross compiling.
+# Without this, the release workflow fails when building the linux/arm64 binary.
+pre-build = [
+  "dpkg --add-architecture arm64",
+  "apt-get update",
+  "apt-get install -y --no-install-recommends pkg-config libssl-dev:arm64 ca-certificates",
+  "rm -rf /var/lib/apt/lists/*",
+]
+


### PR DESCRIPTION
The tag release workflow builds `aarch64-unknown-linux-gnu` via `cross`, but it fails because `openssl-sys` (via `native-tls`) can’t find `openssl.pc` for the target.

This adds a `Cross.toml` pre-build step for `aarch64-unknown-linux-gnu` to install the required OpenSSL dev package for arm64 inside the cross container.

No runtime behavior changes; release-only build fix.