### PR TITLE
chore(release): cut v0.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to Floe are documented in this file.
 
+## v0.2.2
+
+- Added Dagster orchestrator connector (`orchestrators/dagster-floe`) with:
+  - validate plan ingestion
+  - NDJSON run event parsing
+  - local and Docker runner integration examples/tests.
+- Introduced accepted write-mode scaffolding and design groundwork:
+  - `WriteMode` in config model (default overwrite behavior retained)
+  - accepted writer abstraction/module split for future append support
+  - design note: `docs/design/write_modes.md`.
+- Release workflow hardening:
+  - build Linux AMD64 artifacts with `cross` to improve glibc compatibility.
+
 ## v0.2.1
 
 - Added official Docker image packaging and GHCR publishing on version tags.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3013,7 +3013,7 @@ dependencies = [
 
 [[package]]
 name = "floe-cli"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "assert_cmd",
  "clap",
@@ -3026,7 +3026,7 @@ dependencies = [
 
 [[package]]
 name = "floe-core"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "aws-config",
  "aws-sdk-s3",

--- a/crates/floe-cli/Cargo.toml
+++ b/crates/floe-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "floe-cli"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2021"
 description = "CLI for Floe, a YAML-driven technical ingestion tool."
 license = "MIT"
@@ -17,7 +17,7 @@ path = "src/main.rs"
 
 [dependencies]
 clap = { version = "4", features = ["derive"] }
-floe-core = { path = "../floe-core", version = "0.2.1" }
+floe-core = { path = "../floe-core", version = "0.2.2" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 

--- a/crates/floe-core/Cargo.toml
+++ b/crates/floe-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "floe-core"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2021"
 description = "Core library for Floe, a YAML-driven technical ingestion tool."
 license = "MIT"


### PR DESCRIPTION
## Summary
- bump crate versions to `0.2.2`
  - `crates/floe-core/Cargo.toml`
  - `crates/floe-cli/Cargo.toml`
  - `Cargo.lock`
- add `v0.2.2` changelog entry with merged features/fixes since `v0.2.1`

## Included in v0.2.2
- Dagster connector integration (`orchestrators/dagster-floe`)
- accepted write-mode scaffolding + design note (`docs/design/write_modes.md`)
- release workflow fix for Linux AMD64 glibc compatibility via `cross`

## Validation
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all`

## Note
- Updated GitHub release notes for `v0.2.1` (previously empty)
