### PR TITLE
feat(write): add shared file-part policy layer

### DIFF
--- a/crates/floe-core/src/io/write/mod.rs
+++ b/crates/floe-core/src/io/write/mod.rs
@@ -4,6 +4,7 @@ pub mod delta;
 pub mod iceberg;
 pub mod modes;
 pub mod parquet;
+pub mod parts;
 
 use std::path::{Path, PathBuf};
 

--- a/crates/floe-core/src/io/write/parquet.rs
+++ b/crates/floe-core/src/io/write/parquet.rs
@@ -7,6 +7,8 @@ use crate::io::format::{AcceptedSinkAdapter, AcceptedWriteOutput};
 use crate::io::storage::Target;
 use crate::{config, io, ConfigError, FloeResult};
 
+use super::parts;
+
 struct ParquetAcceptedAdapter;
 
 static PARQUET_ACCEPTED_ADAPTER: ParquetAcceptedAdapter = ParquetAcceptedAdapter;
@@ -56,15 +58,25 @@ impl AcceptedSinkAdapter for ParquetAcceptedAdapter {
         resolver: &config::StorageResolver,
         entity: &config::EntityConfig,
     ) -> FloeResult<AcceptedWriteOutput> {
-        let filename = io::storage::paths::build_output_filename(output_stem, "", "parquet");
+        let sample_filename = io::storage::paths::build_output_filename(output_stem, "", "parquet");
+        let mut part_allocator = parts::PartNameAllocator::from_next_index(0, "parquet");
         match target {
             Target::Local { base_path, .. } => {
-                clear_local_output_dir(base_path)?;
+                let base_path = Path::new(base_path);
+                parts::clear_local_part_files(base_path, "parquet")?;
+                part_allocator = parts::PartNameAllocator::from_local_path(base_path, "parquet")?;
             }
             Target::S3 {
                 storage, base_key, ..
             } => {
-                clear_s3_output_prefix(cloud, resolver, entity, storage, base_key, &filename)?;
+                clear_s3_output_prefix(
+                    cloud,
+                    resolver,
+                    entity,
+                    storage,
+                    base_key,
+                    &sample_filename,
+                )?;
             }
             Target::Gcs {
                 storage,
@@ -73,7 +85,13 @@ impl AcceptedSinkAdapter for ParquetAcceptedAdapter {
                 ..
             } => {
                 clear_gcs_output_prefix(
-                    cloud, resolver, entity, storage, bucket, base_key, &filename,
+                    cloud,
+                    resolver,
+                    entity,
+                    storage,
+                    bucket,
+                    base_key,
+                    &sample_filename,
                 )?;
             }
             Target::Adls {
@@ -84,7 +102,14 @@ impl AcceptedSinkAdapter for ParquetAcceptedAdapter {
                 ..
             } => {
                 clear_adls_output_prefix(
-                    cloud, resolver, entity, storage, container, account, base_path, &filename,
+                    cloud,
+                    resolver,
+                    entity,
+                    storage,
+                    container,
+                    account,
+                    base_path,
+                    &sample_filename,
                 )?;
             }
         }
@@ -104,13 +129,10 @@ impl AcceptedSinkAdapter for ParquetAcceptedAdapter {
             };
             let max_rows = std::cmp::max(1, max_size_per_file / avg_row_size) as usize;
             let mut offset = 0usize;
-            let mut part_index = 0usize;
             while offset < total_rows {
                 let len = std::cmp::min(max_rows, total_rows - offset);
                 let mut chunk = df.slice(offset as i64, len);
-                let part_stem = io::storage::paths::build_part_stem(part_index);
-                let part_filename =
-                    io::storage::paths::build_output_filename(&part_stem, "", "parquet");
+                let part_filename = part_allocator.allocate_next();
                 io::storage::output::write_output(
                     target,
                     io::storage::output::OutputPlacement::Directory,
@@ -125,14 +147,14 @@ impl AcceptedSinkAdapter for ParquetAcceptedAdapter {
                     part_files.push(part_filename);
                 }
                 parts_written += 1;
-                part_index += 1;
                 offset += len;
             }
         } else {
+            let part_filename = part_allocator.allocate_next();
             io::storage::output::write_output(
                 target,
                 io::storage::output::OutputPlacement::Directory,
-                &filename,
+                &part_filename,
                 temp_dir,
                 cloud,
                 resolver,
@@ -140,7 +162,7 @@ impl AcceptedSinkAdapter for ParquetAcceptedAdapter {
                 |path| write_parquet_to_path(df, path, options),
             )?;
             parts_written = 1;
-            part_files.push(filename);
+            part_files.push(part_filename);
         }
 
         Ok(AcceptedWriteOutput {
@@ -149,22 +171,6 @@ impl AcceptedSinkAdapter for ParquetAcceptedAdapter {
             table_version: None,
         })
     }
-}
-
-fn clear_local_output_dir(base_path: &str) -> FloeResult<()> {
-    let path = Path::new(base_path);
-    if path.as_os_str().is_empty() {
-        return Ok(());
-    }
-    if path.exists() {
-        if path.is_file() {
-            std::fs::remove_file(path)?;
-        } else {
-            std::fs::remove_dir_all(path)?;
-        }
-    }
-    std::fs::create_dir_all(path)?;
-    Ok(())
 }
 
 fn clear_s3_output_prefix(

--- a/crates/floe-core/src/io/write/parts.rs
+++ b/crates/floe-core/src/io/write/parts.rs
@@ -1,0 +1,121 @@
+use std::path::{Path, PathBuf};
+
+use crate::{io, FloeResult};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PartFile {
+    pub path: PathBuf,
+    pub file_name: String,
+    pub index: usize,
+}
+
+#[derive(Debug, Clone)]
+pub struct PartNameAllocator {
+    next_index: usize,
+    extension: String,
+}
+
+impl PartNameAllocator {
+    pub fn from_local_path(base_path: &Path, extension: &str) -> FloeResult<Self> {
+        Ok(Self {
+            next_index: next_local_part_index(base_path, extension)?,
+            extension: normalize_extension(extension),
+        })
+    }
+
+    pub fn from_next_index(next_index: usize, extension: &str) -> Self {
+        Self {
+            next_index,
+            extension: normalize_extension(extension),
+        }
+    }
+
+    pub fn allocate_next(&mut self) -> String {
+        let file_name = part_filename(self.next_index, &self.extension);
+        self.next_index += 1;
+        file_name
+    }
+}
+
+pub fn part_filename(index: usize, extension: &str) -> String {
+    let extension = normalize_extension(extension);
+    let stem = io::storage::paths::build_part_stem(index);
+    io::storage::paths::build_output_filename(&stem, "", &extension)
+}
+
+pub fn list_local_part_files(base_path: &Path, extension: &str) -> FloeResult<Vec<PartFile>> {
+    if base_path.as_os_str().is_empty() || !base_path.exists() || base_path.is_file() {
+        return Ok(Vec::new());
+    }
+
+    let extension = normalize_extension(extension);
+    let mut parts = Vec::new();
+    for entry in std::fs::read_dir(base_path)? {
+        let entry = entry?;
+        if !entry.file_type()?.is_file() {
+            continue;
+        }
+        let file_name = entry.file_name();
+        let Some(file_name) = file_name.to_str() else {
+            continue;
+        };
+        let Some(index) = parse_part_index(file_name, &extension) else {
+            continue;
+        };
+        parts.push(PartFile {
+            path: entry.path(),
+            file_name: file_name.to_string(),
+            index,
+        });
+    }
+    parts.sort_by(|left, right| {
+        left.index
+            .cmp(&right.index)
+            .then_with(|| left.file_name.cmp(&right.file_name))
+    });
+    Ok(parts)
+}
+
+pub fn next_local_part_index(base_path: &Path, extension: &str) -> FloeResult<usize> {
+    let part_files = list_local_part_files(base_path, extension)?;
+    Ok(part_files.last().map(|part| part.index + 1).unwrap_or(0))
+}
+
+pub fn next_local_part_filename(base_path: &Path, extension: &str) -> FloeResult<String> {
+    let next_index = next_local_part_index(base_path, extension)?;
+    Ok(part_filename(next_index, extension))
+}
+
+pub fn clear_local_part_files(base_path: &Path, extension: &str) -> FloeResult<usize> {
+    if base_path.as_os_str().is_empty() || !base_path.exists() {
+        return Ok(0);
+    }
+    if base_path.is_file() {
+        std::fs::remove_file(base_path)?;
+        std::fs::create_dir_all(base_path)?;
+        return Ok(0);
+    }
+
+    let part_files = list_local_part_files(base_path, extension)?;
+    for part_file in &part_files {
+        std::fs::remove_file(&part_file.path)?;
+    }
+    Ok(part_files.len())
+}
+
+fn parse_part_index(file_name: &str, extension: &str) -> Option<usize> {
+    let path = Path::new(file_name);
+    if path.extension()?.to_str()? != extension {
+        return None;
+    }
+    let stem = path.file_stem()?.to_str()?;
+    let digits = stem.strip_prefix("part-")?;
+    if digits.len() < 5 || !digits.bytes().all(|value| value.is_ascii_digit()) {
+        return None;
+    }
+    digits.parse::<usize>().ok()
+}
+
+fn normalize_extension(extension: &str) -> String {
+    extension.trim_start_matches('.').to_string()
+}

--- a/crates/floe-core/tests/unit/io/write/mod.rs
+++ b/crates/floe-core/tests/unit/io/write/mod.rs
@@ -1,2 +1,3 @@
 pub mod delta_write;
 pub mod object_store;
+pub mod parts;

--- a/crates/floe-core/tests/unit/io/write/parts.rs
+++ b/crates/floe-core/tests/unit/io/write/parts.rs
@@ -1,0 +1,76 @@
+use floe_core::io::write::parts::{
+    clear_local_part_files, list_local_part_files, next_local_part_filename, PartNameAllocator,
+};
+use floe_core::FloeResult;
+
+#[test]
+fn append_allocation_uses_next_available_part_index() -> FloeResult<()> {
+    let temp_dir = tempfile::TempDir::new()?;
+    let output_dir = temp_dir.path().join("accepted");
+    std::fs::create_dir_all(&output_dir)?;
+    std::fs::write(output_dir.join("part-00000.parquet"), b"p0")?;
+    std::fs::write(output_dir.join("part-00003.parquet"), b"p3")?;
+    std::fs::write(output_dir.join("part-00003.csv"), b"csv")?;
+    std::fs::write(output_dir.join("README.txt"), b"keep")?;
+
+    let parts = list_local_part_files(&output_dir, "parquet")?;
+    assert_eq!(parts.len(), 2);
+    assert_eq!(parts[0].file_name, "part-00000.parquet");
+    assert_eq!(parts[1].file_name, "part-00003.parquet");
+
+    assert_eq!(
+        next_local_part_filename(&output_dir, "parquet")?,
+        "part-00004.parquet"
+    );
+
+    let mut allocator = PartNameAllocator::from_local_path(&output_dir, "parquet")?;
+    let first_allocated = allocator.allocate_next();
+    assert_eq!(first_allocated, "part-00004.parquet");
+    std::fs::write(output_dir.join(&first_allocated), b"p4")?;
+    assert_eq!(allocator.allocate_next(), "part-00005.parquet");
+
+    Ok(())
+}
+
+#[test]
+fn overwrite_cleanup_deletes_existing_part_files() -> FloeResult<()> {
+    let temp_dir = tempfile::TempDir::new()?;
+    let output_dir = temp_dir.path().join("accepted");
+    std::fs::create_dir_all(&output_dir)?;
+    std::fs::write(output_dir.join("part-00000.parquet"), b"p0")?;
+    std::fs::write(output_dir.join("part-00001.parquet"), b"p1")?;
+
+    let removed = clear_local_part_files(&output_dir, "parquet")?;
+    assert_eq!(removed, 2);
+    assert!(!output_dir.join("part-00000.parquet").exists());
+    assert!(!output_dir.join("part-00001.parquet").exists());
+    assert!(list_local_part_files(&output_dir, "parquet")?.is_empty());
+
+    Ok(())
+}
+
+#[test]
+fn overwrite_cleanup_preserves_non_part_files() -> FloeResult<()> {
+    let temp_dir = tempfile::TempDir::new()?;
+    let output_dir = temp_dir.path().join("accepted");
+    std::fs::create_dir_all(output_dir.join("_delta_log"))?;
+
+    std::fs::write(output_dir.join("part-00000.parquet"), b"p0")?;
+    std::fs::write(output_dir.join("part-00001.parquet"), b"p1")?;
+    std::fs::write(output_dir.join("part-00001.csv"), b"csv")?;
+    std::fs::write(output_dir.join("part-abcde.parquet"), b"invalid-part-name")?;
+    std::fs::write(output_dir.join("manifest.parquet"), b"manifest")?;
+    std::fs::write(output_dir.join("_delta_log/00000.json"), b"log")?;
+
+    let removed = clear_local_part_files(&output_dir, "parquet")?;
+    assert_eq!(removed, 2);
+
+    assert!(!output_dir.join("part-00000.parquet").exists());
+    assert!(!output_dir.join("part-00001.parquet").exists());
+    assert!(output_dir.join("part-00001.csv").exists());
+    assert!(output_dir.join("part-abcde.parquet").exists());
+    assert!(output_dir.join("manifest.parquet").exists());
+    assert!(output_dir.join("_delta_log/00000.json").exists());
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary
This PR adds a shared file-part write policy module for local file-oriented datasets and wires it into parquet accepted writes for local overwrite flows.

The new policy layer provides reusable helpers to:
- list and identify existing `part-xxxxx.<ext>` files
- allocate collision-safe next part names from existing files
- clear only part files during overwrite cleanup

## Root Cause and User Impact
Before this change, parquet local overwrite used directory-level deletion (`remove_dir_all`), which removed everything under the dataset path instead of only part files. That made write-mode semantics less reusable across writers and risked deleting non-part artifacts.

Users would see overwrite behavior coupled to format-specific cleanup logic, and append-ready part allocation logic was not centralized.

## Fix
- Added `crates/floe-core/src/io/write/parts.rs` as a shared core module.
- Added APIs for:
  - listing local part files with part-index parsing
  - computing next part index/name deterministically
  - allocating sequential part names via `PartNameAllocator`
  - clearing only matching part files for overwrite
- Exported the module from `io::write`.
- Updated parquet accepted writer to:
  - use shared local part cleanup (part-only cleanup)
  - use shared part allocation for output filenames
  - keep cloud behavior unchanged in this PR

## Behavior Impact
- Local parquet overwrite now deletes only `part-xxxxx.parquet` files under the target dataset directory.
- Non-part files (including different extensions and auxiliary files) are preserved.
- Part naming remains deterministic (`part-00000`, `part-00001`, ...) and append-safe allocator behavior is now available for immediate consumption.
- Delta behavior is unchanged.
- Rejected layout is unchanged.

## Tests
Added unit tests under `crates/floe-core/tests/unit/io/write/parts.rs`:
- append-style allocation continues from max existing part index without collisions
- overwrite cleanup deletes prior part files
- overwrite cleanup does not delete non-part files

Validation run:
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all`

## Follow-up Notes
- Hook `append` mode runtime support to this shared policy in a follow-up PR.
- Extend part policy usage to rejected CSV dataset writes when rejected layout migration lands.
- Consider cloud-part cleanup/selection policy unification in the same layer once append is implemented for cloud-backed file sinks.
