### PR TITLE
[codex] fix delta nullability on append

### DIFF
--- a/crates/floe-core/src/io/write/delta.rs
+++ b/crates/floe-core/src/io/write/delta.rs
@@ -6,6 +6,7 @@ use deltalake::arrow::array::{
     Int64Array, Int8Array, NullArray, StringArray, Time64NanosecondArray,
     TimestampMicrosecondArray, UInt16Array, UInt32Array, UInt64Array, UInt8Array,
 };
+use deltalake::arrow::datatypes::{Field, Schema};
 use deltalake::arrow::record_batch::RecordBatch;
 use deltalake::protocol::SaveMode;
 use deltalake::table::builder::DeltaTableBuilder;
@@ -34,7 +35,7 @@ pub fn write_delta_table(
     if let Target::Local { base_path, .. } = target {
         std::fs::create_dir_all(Path::new(base_path))?;
     }
-    let batch = dataframe_to_record_batch(df)?;
+    let batch = dataframe_to_record_batch(df, entity)?;
     let store = object_store::delta_store_config(target, resolver, entity)?;
     let table_url = store.table_url;
     let storage_options = store.storage_options;
@@ -95,16 +96,55 @@ impl AcceptedSinkAdapter for DeltaAcceptedAdapter {
     }
 }
 
-fn dataframe_to_record_batch(df: &DataFrame) -> FloeResult<RecordBatch> {
-    let mut columns = Vec::with_capacity(df.width());
-    for column in df.get_columns() {
-        let series = column.as_materialized_series();
-        let name = series.name().to_string();
-        let array = series_to_arrow_array(series)?;
-        columns.push((name, array));
+fn dataframe_to_record_batch(
+    df: &DataFrame,
+    entity: &config::EntityConfig,
+) -> FloeResult<RecordBatch> {
+    if entity.schema.columns.is_empty() {
+        let mut fields = Vec::with_capacity(df.width());
+        let mut arrays = Vec::with_capacity(df.width());
+        for column in df.get_columns() {
+            let series = column.as_materialized_series();
+            let name = series.name().to_string();
+            let array = series_to_arrow_array(series)?;
+            let nullable = array.null_count() > 0;
+            fields.push(Field::new(name, array.data_type().clone(), nullable));
+            arrays.push(array);
+        }
+        let schema = Arc::new(Schema::new(fields));
+        return RecordBatch::try_new(schema, arrays).map_err(|err| {
+            Box::new(RunError(format!("delta record batch build failed: {err}")))
+                as Box<dyn std::error::Error + Send + Sync>
+        });
     }
-    Ok(RecordBatch::try_from_iter(columns)
-        .map_err(|err| Box::new(RunError(format!("delta record batch build failed: {err}"))))?)
+
+    let mut fields = Vec::with_capacity(entity.schema.columns.len());
+    let mut arrays = Vec::with_capacity(entity.schema.columns.len());
+    for column in &entity.schema.columns {
+        let series = df
+            .column(column.name.as_str())
+            .map_err(|err| Box::new(RunError(format!("delta column lookup failed: {err}"))))?;
+        let series = series.as_materialized_series();
+        let array = series_to_arrow_array(series)?;
+        let nullable = column.nullable.unwrap_or(true);
+        if !nullable && array.null_count() > 0 {
+            return Err(Box::new(RunError(format!(
+                "delta write rejected nulls for non-nullable column {}",
+                column.name
+            ))));
+        }
+        fields.push(Field::new(
+            column.name.clone(),
+            array.data_type().clone(),
+            nullable,
+        ));
+        arrays.push(array);
+    }
+    let schema = Arc::new(Schema::new(fields));
+    RecordBatch::try_new(schema, arrays).map_err(|err| {
+        Box::new(RunError(format!("delta record batch build failed: {err}")))
+            as Box<dyn std::error::Error + Send + Sync>
+    })
 }
 
 fn save_mode_for_write_mode(mode: config::WriteMode) -> SaveMode {

--- a/crates/floe-core/tests/unit/io/write/delta_write.rs
+++ b/crates/floe-core/tests/unit/io/write/delta_write.rs
@@ -16,7 +16,7 @@ fn write_delta_table_overwrite() -> FloeResult<()> {
     let config = empty_root_config();
     let resolver = config::StorageResolver::from_path(&config, temp_dir.path())?;
     let target = resolve_local_target(&resolver, &table_path)?;
-    let entity = build_entity(&table_path, config::WriteMode::Overwrite);
+    let entity = build_entity(&table_path, config::WriteMode::Overwrite, Vec::new());
     let version1 = write_delta_table(
         &mut df,
         &target,
@@ -66,7 +66,7 @@ fn write_delta_table_append() -> FloeResult<()> {
     let config = empty_root_config();
     let resolver = config::StorageResolver::from_path(&config, temp_dir.path())?;
     let target = resolve_local_target(&resolver, &table_path)?;
-    let entity = build_entity(&table_path, config::WriteMode::Append);
+    let entity = build_entity(&table_path, config::WriteMode::Append, Vec::new());
 
     let mut df_first = df!(
         "id" => &[1i64, 2, 3],
@@ -107,6 +107,111 @@ fn write_delta_table_append() -> FloeResult<()> {
     Ok(())
 }
 
+#[test]
+fn delta_append_allows_nulls_for_nullable_columns() -> FloeResult<()> {
+    let temp_dir = tempfile::TempDir::new()?;
+    let table_path = temp_dir.path().join("delta_table");
+    let config = empty_root_config();
+    let resolver = config::StorageResolver::from_path(&config, temp_dir.path())?;
+    let target = resolve_local_target(&resolver, &table_path)?;
+    let entity = build_entity(
+        &table_path,
+        config::WriteMode::Append,
+        vec![
+            column("id", "int64", Some(false)),
+            column("name", "string", Some(true)),
+        ],
+    );
+
+    let mut df_first = df!(
+        "id" => &[1i64, 2, 3],
+        "name" => &["a", "b", "c"]
+    )?;
+    write_delta_table(
+        &mut df_first,
+        &target,
+        &resolver,
+        &entity,
+        config::WriteMode::Append,
+    )?;
+
+    let mut df_second = df!(
+        "id" => &[4i64, 5],
+        "name" => &[Some("d"), None]
+    )?;
+    write_delta_table(
+        &mut df_second,
+        &target,
+        &resolver,
+        &entity,
+        config::WriteMode::Append,
+    )?;
+
+    let runtime = runtime()?;
+    let table = open_table(&runtime, &table_path)?;
+    assert_eq!(row_count(&table)?, df_first.height() + df_second.height());
+
+    let schema_fields = table
+        .snapshot()?
+        .schema()
+        .fields()
+        .map(|field| (field.name.clone(), field.nullable))
+        .collect::<Vec<_>>();
+    assert!(schema_fields
+        .iter()
+        .any(|(name, nullable)| { name == "name" && *nullable }));
+
+    Ok(())
+}
+
+#[test]
+fn delta_append_rejects_nulls_for_non_nullable_columns() -> FloeResult<()> {
+    let temp_dir = tempfile::TempDir::new()?;
+    let table_path = temp_dir.path().join("delta_table");
+    let config = empty_root_config();
+    let resolver = config::StorageResolver::from_path(&config, temp_dir.path())?;
+    let target = resolve_local_target(&resolver, &table_path)?;
+    let entity = build_entity(
+        &table_path,
+        config::WriteMode::Append,
+        vec![
+            column("id", "int64", Some(false)),
+            column("name", "string", Some(false)),
+        ],
+    );
+
+    let mut df_first = df!(
+        "id" => &[1i64, 2],
+        "name" => &["a", "b"]
+    )?;
+    write_delta_table(
+        &mut df_first,
+        &target,
+        &resolver,
+        &entity,
+        config::WriteMode::Append,
+    )?;
+
+    let mut df_second = df!(
+        "id" => &[3i64, 4],
+        "name" => &[Some("c"), None]
+    )?;
+    let append_result = write_delta_table(
+        &mut df_second,
+        &target,
+        &resolver,
+        &entity,
+        config::WriteMode::Append,
+    );
+    assert!(append_result.is_err());
+
+    let runtime = runtime()?;
+    let table = open_table(&runtime, &table_path)?;
+    assert_eq!(row_count(&table)?, df_first.height());
+
+    Ok(())
+}
+
 fn empty_root_config() -> config::RootConfig {
     config::RootConfig {
         version: "0.1".to_string(),
@@ -132,7 +237,11 @@ fn resolve_local_target(
     Target::from_resolved(&resolved)
 }
 
-fn build_entity(table_path: &Path, write_mode: config::WriteMode) -> config::EntityConfig {
+fn build_entity(
+    table_path: &Path,
+    write_mode: config::WriteMode,
+    columns: Vec<config::ColumnConfig>,
+) -> config::EntityConfig {
     config::EntityConfig {
         name: "orders".to_string(),
         metadata: None,
@@ -162,8 +271,17 @@ fn build_entity(table_path: &Path, write_mode: config::WriteMode) -> config::Ent
         schema: config::SchemaConfig {
             normalize_columns: None,
             mismatch: None,
-            columns: Vec::new(),
+            columns,
         },
+    }
+}
+
+fn column(name: &str, column_type: &str, nullable: Option<bool>) -> config::ColumnConfig {
+    config::ColumnConfig {
+        name: name.to_string(),
+        column_type: column_type.to_string(),
+        nullable,
+        unique: None,
     }
 }
 


### PR DESCRIPTION
## Summary
Fix Delta append failures by ensuring the RecordBatch schema nullability matches the config schema instead of the first write’s inferred nullability. This preserves nullable columns across table creation and appends while still rejecting nulls for non-nullable columns.

## Issue
Delta tables created from a first batch without nulls would infer `nullable = false` for those columns. Later appends that contained nulls would fail even when the config schema allowed nulls.

## Root cause
The Delta writer built RecordBatch schemas directly from Arrow arrays, letting nullability be inferred from data in the first batch rather than from `entity.schema.columns[].nullable`.

## Fix
The Delta writer now constructs RecordBatch schemas using the config schema when provided, setting each field’s nullability explicitly from `ColumnConfig.nullable` (defaulting to nullable when unspecified). When the config marks a column as non-nullable, the writer rejects any batch containing nulls for that column. If no schema is provided, it preserves the prior behavior by deriving nullability from the data.

## Tests
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all`

New tests:
- Create a table where a column is nullable but first batch has no nulls, then append a batch with nulls and assert success.
- Ensure a non-nullable column still fails when appending nulls.
