### PR TITLE
[codex] append unique checks across runs

### DIFF
--- a/crates/floe-core/src/checks/unique.rs
+++ b/crates/floe-core/src/checks/unique.rs
@@ -165,6 +165,48 @@ impl UniqueTracker {
         self.seen.is_empty()
     }
 
+    pub fn seed_from_df(
+        &mut self,
+        df: &DataFrame,
+        columns: &[config::ColumnConfig],
+    ) -> FloeResult<()> {
+        if df.height() == 0 || self.seen.is_empty() {
+            return Ok(());
+        }
+        let unique_columns: Vec<&config::ColumnConfig> = columns
+            .iter()
+            .filter(|col| col.unique == Some(true))
+            .collect();
+        if unique_columns.is_empty() {
+            return Ok(());
+        }
+
+        for column in unique_columns {
+            let series = df.column(&column.name).map_err(|err| {
+                Box::new(RunError(format!(
+                    "unique column {} not found: {err}",
+                    column.name
+                )))
+            })?;
+            let series = series.as_materialized_series().rechunk();
+            let seen = self.seen.get_mut(&column.name).ok_or_else(|| {
+                Box::new(RunError(format!(
+                    "unique column {} not tracked",
+                    column.name
+                )))
+            })?;
+            for value in series.iter() {
+                let key = match unique_key(value) {
+                    Some(key) => key,
+                    None => continue,
+                };
+                seen.insert(key);
+            }
+        }
+
+        Ok(())
+    }
+
     pub fn apply(
         &mut self,
         df: &DataFrame,

--- a/crates/floe-core/src/io/write/modes.rs
+++ b/crates/floe-core/src/io/write/modes.rs
@@ -1,10 +1,7 @@
-use crate::{config, ConfigError, FloeResult};
+use crate::{config, FloeResult};
 
 pub fn ensure_mode_supported(mode: config::WriteMode) -> FloeResult<()> {
     match mode {
-        config::WriteMode::Overwrite => Ok(()),
-        config::WriteMode::Append => Err(Box::new(ConfigError(
-            "sink.write_mode=append is not supported yet".to_string(),
-        ))),
+        config::WriteMode::Overwrite | config::WriteMode::Append => Ok(()),
     }
 }

--- a/crates/floe-core/src/run/entity/mod.rs
+++ b/crates/floe-core/src/run/entity/mod.rs
@@ -19,6 +19,7 @@ use io::storage::Target;
 mod precheck;
 mod process;
 mod resolve;
+mod unique_existing;
 pub(crate) use resolve::ResolvedEntityTargets;
 
 use crate::report::entity::{build_run_report, RunReportContext};
@@ -172,6 +173,17 @@ pub(super) fn run_entity(
 
     let mut accepted_accum: Vec<DataFrame> = Vec::new();
     let mut unique_tracker = check::UniqueTracker::new(&normalized_columns);
+    unique_existing::seed_unique_tracker_for_append(
+        &mut unique_tracker,
+        write_mode,
+        entity.sink.accepted.format.as_str(),
+        &accepted_target,
+        temp_dir.as_ref().map(|dir| dir.path()),
+        cloud,
+        &context.storage_resolver,
+        entity,
+        &normalized_columns,
+    )?;
 
     // Phase B: row-level validation + entity-level accumulation.
     for prechecked in prechecked_inputs {

--- a/crates/floe-core/src/run/entity/unique_existing.rs
+++ b/crates/floe-core/src/run/entity/unique_existing.rs
@@ -1,0 +1,277 @@
+use std::path::Path;
+
+use deltalake::table::builder::DeltaTableBuilder;
+
+use crate::errors::{RunError, StorageError};
+use crate::io::read::parquet::read_parquet_lazy;
+use crate::io::storage::{object_store, Target};
+use crate::io::write::parts;
+use crate::{check, config, io, ConfigError, FloeResult};
+
+#[allow(clippy::too_many_arguments)]
+pub fn seed_unique_tracker_for_append(
+    unique_tracker: &mut check::UniqueTracker,
+    write_mode: config::WriteMode,
+    accepted_format: &str,
+    target: &Target,
+    temp_dir: Option<&Path>,
+    cloud: &mut io::storage::CloudClient,
+    resolver: &config::StorageResolver,
+    entity: &config::EntityConfig,
+    columns: &[config::ColumnConfig],
+) -> FloeResult<()> {
+    if write_mode != config::WriteMode::Append || unique_tracker.is_empty() {
+        return Ok(());
+    }
+    let unique_columns = unique_column_names(columns);
+    if unique_columns.is_empty() {
+        return Ok(());
+    }
+    match accepted_format {
+        "parquet" => seed_from_parquet(
+            unique_tracker,
+            target,
+            temp_dir,
+            cloud,
+            resolver,
+            entity,
+            columns,
+            &unique_columns,
+        ),
+        "delta" => seed_from_delta(
+            unique_tracker,
+            target,
+            temp_dir,
+            cloud,
+            resolver,
+            entity,
+            columns,
+            &unique_columns,
+        ),
+        _ => Ok(()),
+    }
+}
+
+fn unique_column_names(columns: &[config::ColumnConfig]) -> Vec<String> {
+    columns
+        .iter()
+        .filter(|col| col.unique == Some(true))
+        .map(|col| col.name.clone())
+        .collect()
+}
+
+fn seed_from_parquet(
+    unique_tracker: &mut check::UniqueTracker,
+    target: &Target,
+    temp_dir: Option<&Path>,
+    cloud: &mut io::storage::CloudClient,
+    resolver: &config::StorageResolver,
+    entity: &config::EntityConfig,
+    columns: &[config::ColumnConfig],
+    unique_columns: &[String],
+) -> FloeResult<()> {
+    match target {
+        Target::Local { base_path, .. } => {
+            let base_path = Path::new(base_path);
+            let part_files = parts::list_local_part_files(base_path, "parquet")?;
+            for part in part_files {
+                seed_from_parquet_path(unique_tracker, &part.path, columns, unique_columns)?;
+            }
+        }
+        Target::S3 {
+            storage, base_key, ..
+        } => {
+            let list_prefix = s3_list_prefix(entity, base_key)?;
+            let temp_dir = temp_dir.ok_or_else(|| {
+                Box::new(StorageError(format!(
+                    "entity.name={} missing temp dir for s3 parquet read",
+                    entity.name
+                )))
+            })?;
+            let client = cloud.client_for(resolver, storage, entity)?;
+            let objects = client.list(&list_prefix)?;
+            for object in objects {
+                if !is_part_parquet_key(&object.key) {
+                    continue;
+                }
+                let local_path = client.download_to_temp(&object.uri, temp_dir)?;
+                seed_from_parquet_path(unique_tracker, &local_path, columns, unique_columns)?;
+            }
+        }
+        Target::Gcs {
+            storage,
+            bucket,
+            base_key,
+            ..
+        } => {
+            let list_prefix = gcs_list_prefix(entity, bucket, base_key)?;
+            let temp_dir = temp_dir.ok_or_else(|| {
+                Box::new(StorageError(format!(
+                    "entity.name={} missing temp dir for gcs parquet read",
+                    entity.name
+                )))
+            })?;
+            let client = cloud.client_for(resolver, storage, entity)?;
+            let objects = client.list(&list_prefix)?;
+            for object in objects {
+                if !is_part_parquet_key(&object.key) {
+                    continue;
+                }
+                let local_path = client.download_to_temp(&object.uri, temp_dir)?;
+                seed_from_parquet_path(unique_tracker, &local_path, columns, unique_columns)?;
+            }
+        }
+        Target::Adls {
+            storage,
+            container,
+            account,
+            base_path,
+            ..
+        } => {
+            let list_prefix = adls_list_prefix(entity, container, account, base_path)?;
+            let temp_dir = temp_dir.ok_or_else(|| {
+                Box::new(StorageError(format!(
+                    "entity.name={} missing temp dir for adls parquet read",
+                    entity.name
+                )))
+            })?;
+            let client = cloud.client_for(resolver, storage, entity)?;
+            let objects = client.list(&list_prefix)?;
+            for object in objects {
+                if !is_part_parquet_key(&object.key) {
+                    continue;
+                }
+                let local_path = client.download_to_temp(&object.uri, temp_dir)?;
+                seed_from_parquet_path(unique_tracker, &local_path, columns, unique_columns)?;
+            }
+        }
+    }
+    Ok(())
+}
+
+fn seed_from_parquet_path(
+    unique_tracker: &mut check::UniqueTracker,
+    path: &Path,
+    columns: &[config::ColumnConfig],
+    unique_columns: &[String],
+) -> FloeResult<()> {
+    let df = read_parquet_lazy(path, Some(unique_columns))?;
+    unique_tracker.seed_from_df(&df, columns)?;
+    Ok(())
+}
+
+fn seed_from_delta(
+    unique_tracker: &mut check::UniqueTracker,
+    target: &Target,
+    temp_dir: Option<&Path>,
+    cloud: &mut io::storage::CloudClient,
+    resolver: &config::StorageResolver,
+    entity: &config::EntityConfig,
+    columns: &[config::ColumnConfig],
+    unique_columns: &[String],
+) -> FloeResult<()> {
+    let store = object_store::delta_store_config(target, resolver, entity)?;
+    let table_url = store.table_url;
+    let storage_options = store.storage_options;
+    let builder = DeltaTableBuilder::from_url(table_url.clone())
+        .map_err(|err| Box::new(RunError(format!("delta builder failed: {err}"))))?
+        .with_storage_options(storage_options.clone());
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .map_err(|err| Box::new(RunError(format!("delta runtime init failed: {err}"))))?;
+    let table = runtime.block_on(async move { builder.load().await });
+    let table = match table {
+        Ok(table) => table,
+        Err(err) => match err {
+            deltalake::DeltaTableError::NotATable(_) => return Ok(()),
+            other => return Err(Box::new(RunError(format!("delta load failed: {other}")))),
+        },
+    };
+    let file_uris = table
+        .get_file_uris()
+        .map_err(|err| Box::new(RunError(format!("delta list files failed: {err}"))))?
+        .collect::<Vec<_>>();
+    for uri in file_uris {
+        let local_path = match target {
+            Target::Local { .. } => Path::new(&uri).to_path_buf(),
+            Target::S3 { storage, .. }
+            | Target::Gcs { storage, .. }
+            | Target::Adls { storage, .. } => {
+                let temp_dir = temp_dir.ok_or_else(|| {
+                    Box::new(StorageError(format!(
+                        "entity.name={} missing temp dir for delta read",
+                        entity.name
+                    )))
+                })?;
+                let client = cloud.client_for(resolver, storage, entity)?;
+                client.download_to_temp(&uri, temp_dir)?
+            }
+        };
+        seed_from_parquet_path(unique_tracker, &local_path, columns, unique_columns)?;
+    }
+
+    Ok(())
+}
+
+fn is_part_parquet_key(key: &str) -> bool {
+    let Some(file_name) = Path::new(key).file_name().and_then(|name| name.to_str()) else {
+        return false;
+    };
+    let path = Path::new(file_name);
+    if path.extension().and_then(|ext| ext.to_str()) != Some("parquet") {
+        return false;
+    }
+    let Some(stem) = path.file_stem().and_then(|stem| stem.to_str()) else {
+        return false;
+    };
+    let Some(digits) = stem.strip_prefix("part-") else {
+        return false;
+    };
+    if digits.len() < 5 || !digits.bytes().all(|value| value.is_ascii_digit()) {
+        return false;
+    }
+    true
+}
+
+fn s3_list_prefix(entity: &config::EntityConfig, base_key: &str) -> FloeResult<String> {
+    let prefix = base_key.trim_matches('/');
+    if prefix.is_empty() {
+        return Err(Box::new(ConfigError(format!(
+            "entity.name={} sink.accepted.path must not be bucket root for s3 parquet outputs",
+            entity.name
+        ))));
+    }
+    Ok(format!("{prefix}/"))
+}
+
+fn gcs_list_prefix(
+    entity: &config::EntityConfig,
+    bucket: &str,
+    base_key: &str,
+) -> FloeResult<String> {
+    let prefix = base_key.trim_matches('/');
+    if prefix.is_empty() {
+        return Err(Box::new(ConfigError(format!(
+            "entity.name={} sink.accepted.path must not be bucket root for gcs parquet outputs (bucket={})",
+            entity.name, bucket
+        ))));
+    }
+    Ok(format!("{prefix}/"))
+}
+
+fn adls_list_prefix(
+    entity: &config::EntityConfig,
+    container: &str,
+    account: &str,
+    base_path: &str,
+) -> FloeResult<String> {
+    let prefix = base_path.trim_matches('/');
+    if prefix.is_empty() {
+        return Err(Box::new(ConfigError(format!(
+            "entity.name={} sink.accepted.path must not be container root for adls parquet outputs (container={}, account={})",
+            entity.name, container, account
+        ))));
+    }
+    Ok(format!("{prefix}/"))
+}

--- a/crates/floe-core/tests/unit/run/entity/accepted_output.rs
+++ b/crates/floe-core/tests/unit/run/entity/accepted_output.rs
@@ -365,3 +365,74 @@ entities:
     }
     assert_eq!(total_rows, 7);
 }
+
+#[test]
+fn accepted_output_append_rejects_duplicates_across_runs() {
+    let root = temp_dir("floe-entity-accepted-append-unique");
+    let input_dir = root.join("in");
+    let accepted_dir = root.join("out/accepted");
+    let rejected_dir = root.join("out/rejected");
+    let report_dir = root.join("report");
+    fs::create_dir_all(&input_dir).expect("create input dir");
+    write_csv(&input_dir, "a.csv", "id;name\n1;alice\n2;bob\n");
+
+    let yaml = format!(
+        r#"version: "0.1"
+report:
+  path: "{report_dir}"
+entities:
+  - name: "customer"
+    source:
+      format: "csv"
+      path: "{input_dir}"
+    sink:
+      write_mode: "append"
+      accepted:
+        format: "parquet"
+        path: "{accepted_dir}"
+      rejected:
+        format: "csv"
+        path: "{rejected_dir}"
+    policy:
+      severity: "reject"
+    schema:
+      columns:
+        - name: "id"
+          type: "string"
+          unique: true
+        - name: "name"
+          type: "string"
+"#,
+        report_dir = report_dir.display(),
+        input_dir = input_dir.display(),
+        accepted_dir = accepted_dir.display(),
+        rejected_dir = rejected_dir.display(),
+    );
+    let config_path = write_config(&root, &yaml);
+
+    let first = run_config(&config_path);
+    assert_eq!(first.entity_outcomes[0].report.results.accepted_total, 2);
+    assert_eq!(first.entity_outcomes[0].report.results.rejected_total, 0);
+    assert_eq!(
+        first.entity_outcomes[0].report.accepted_output.part_files,
+        vec!["part-00000.parquet".to_string()]
+    );
+
+    write_csv(&input_dir, "a.csv", "id;name\n2;bob\n3;carol\n");
+
+    let second = run_config(&config_path);
+    assert_eq!(second.entity_outcomes[0].report.results.accepted_total, 1);
+    assert_eq!(second.entity_outcomes[0].report.results.rejected_total, 1);
+    assert_eq!(
+        second.entity_outcomes[0].report.accepted_output.part_files,
+        vec!["part-00001.parquet".to_string()]
+    );
+    let rejected_path = second.entity_outcomes[0]
+        .report
+        .files
+        .first()
+        .and_then(|file| file.output.rejected_path.as_ref())
+        .expect("missing rejected output path");
+    let rejected_path = rejected_path.trim_start_matches("local://");
+    assert!(Path::new(rejected_path).exists());
+}


### PR DESCRIPTION
## Summary
This change extends append-mode uniqueness checks to consider existing accepted data. When `sink.write_mode=append` is enabled and unique columns are configured, the run now seeds the unique tracker from the current accepted target (parquet parts or delta table files) before processing new input rows.

## Issue
In append mode, uniqueness checks only de-duplicated within the current run. Duplicates that already existed in the accepted target were not detected, so re-ingesting a previously accepted value could slip through.

## User Impact (Cause and Effect)
Incremental runs could silently accept duplicates across runs, violating unique column constraints. For reject policies, expected duplicates were not sent to rejected output.

## Root Cause
The unique tracker was initialized empty for each run and only populated with values from the current input files; it was never seeded with values from existing accepted outputs in append mode.

## Fix
- Added a uniqueness seeding hook that runs only for append mode and only when unique columns are present.
- For parquet accepted targets, existing part files are read (local or remote) and unique values are seeded before row-level validation.
- For delta accepted targets, the delta table is loaded and existing parquet files are read to seed unique values.
- Allowed append mode through the rejected output path so reject policies can write duplicate rows when append is enabled.

## Behavior Changes (Before/After)
Before: append runs only detected duplicates within the current run, allowing duplicates across runs.
After: append runs detect duplicates against existing accepted data and apply the same policy behavior (warn or reject) as in-run duplicates.

## Tests
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all`
