### PR TITLE
[codex] write: uuid part names for append

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3047,6 +3047,7 @@ dependencies = [
  "time",
  "tokio",
  "url",
+ "uuid",
  "yaml-rust2",
 ]
 

--- a/crates/floe-core/Cargo.toml
+++ b/crates/floe-core/Cargo.toml
@@ -32,6 +32,7 @@ azure_identity = "0.20"
 azure_storage = "0.20"
 azure_storage_blobs = "0.20"
 futures = "0.3"
+uuid = { version = "1", features = ["v4"] }
 
 # Optional: used only to unify transitive TLS feature selection for linux release builds.
 # Enabling `vendored-openssl` forces `reqwest` to build OpenSSL from source and link it

--- a/crates/floe-core/src/io/write/csv.rs
+++ b/crates/floe-core/src/io/write/csv.rs
@@ -39,46 +39,7 @@ impl RejectedSinkAdapter for CsvRejectedAdapter {
             entity,
             mode,
         } = request;
-        let mut part_allocator = match target {
-            io::storage::Target::Local { base_path, .. } => {
-                let base_path = Path::new(base_path);
-                if mode == config::WriteMode::Overwrite {
-                    parts::clear_local_part_files(base_path, "csv")?;
-                }
-                parts::PartNameAllocator::from_local_path(base_path, "csv")?
-            }
-            io::storage::Target::S3 {
-                storage, base_key, ..
-            } => {
-                let next_index = prepare_remote_part_index(
-                    cloud, resolver, entity, storage, base_key, mode, "s3", "bucket",
-                )?;
-                parts::PartNameAllocator::from_next_index(next_index, "csv")
-            }
-            io::storage::Target::Gcs {
-                storage, base_key, ..
-            } => {
-                let next_index = prepare_remote_part_index(
-                    cloud, resolver, entity, storage, base_key, mode, "gcs", "bucket",
-                )?;
-                parts::PartNameAllocator::from_next_index(next_index, "csv")
-            }
-            io::storage::Target::Adls {
-                storage, base_path, ..
-            } => {
-                let next_index = prepare_remote_part_index(
-                    cloud,
-                    resolver,
-                    entity,
-                    storage,
-                    base_path,
-                    mode,
-                    "adls",
-                    "container",
-                )?;
-                parts::PartNameAllocator::from_next_index(next_index, "csv")
-            }
-        };
+        let mut part_allocator = prepare_part_allocator(target, mode, cloud, resolver, entity)?;
         let part_filename = part_allocator.allocate_next();
         io::storage::output::write_output(
             target,
@@ -96,16 +57,69 @@ impl RejectedSinkAdapter for CsvRejectedAdapter {
     }
 }
 
-fn prepare_remote_part_index(
+fn prepare_part_allocator(
+    target: &io::storage::Target,
+    mode: config::WriteMode,
+    cloud: &mut io::storage::CloudClient,
+    resolver: &config::StorageResolver,
+    entity: &config::EntityConfig,
+) -> FloeResult<parts::PartNameAllocator> {
+    match mode {
+        config::WriteMode::Overwrite => {
+            clear_output_parts(target, cloud, resolver, entity)?;
+            Ok(parts::PartNameAllocator::from_next_index(0, "csv"))
+        }
+        config::WriteMode::Append => Ok(parts::PartNameAllocator::unique("csv")),
+    }
+}
+
+fn clear_output_parts(
+    target: &io::storage::Target,
+    cloud: &mut io::storage::CloudClient,
+    resolver: &config::StorageResolver,
+    entity: &config::EntityConfig,
+) -> FloeResult<()> {
+    match target {
+        io::storage::Target::Local { base_path, .. } => {
+            let base_path = Path::new(base_path);
+            let _ = parts::clear_local_part_files(base_path, "csv")?;
+        }
+        io::storage::Target::S3 {
+            storage, base_key, ..
+        } => {
+            clear_remote_part_files(cloud, resolver, entity, storage, base_key, "s3", "bucket")?;
+        }
+        io::storage::Target::Gcs {
+            storage, base_key, ..
+        } => {
+            clear_remote_part_files(cloud, resolver, entity, storage, base_key, "gcs", "bucket")?;
+        }
+        io::storage::Target::Adls {
+            storage, base_path, ..
+        } => {
+            clear_remote_part_files(
+                cloud,
+                resolver,
+                entity,
+                storage,
+                base_path,
+                "adls",
+                "container",
+            )?;
+        }
+    }
+    Ok(())
+}
+
+fn clear_remote_part_files(
     cloud: &mut io::storage::CloudClient,
     resolver: &config::StorageResolver,
     entity: &config::EntityConfig,
     storage: &str,
     base_key: &str,
-    mode: config::WriteMode,
     target_type: &str,
     root_label: &str,
-) -> FloeResult<usize> {
+) -> FloeResult<()> {
     let prefix = base_key.trim_matches('/');
     if prefix.is_empty() {
         return Err(Box::new(ConfigError(format!(
@@ -116,41 +130,16 @@ fn prepare_remote_part_index(
     let list_prefix = format!("{prefix}/");
     let client = cloud.client_for(resolver, storage, entity)?;
     let objects = client.list(&list_prefix)?;
-    let mut next_index = 0usize;
-    let mut part_uris = Vec::new();
     for object in objects {
         if !object.key.starts_with(&list_prefix) || object.key.is_empty() {
             continue;
         }
-        let Some(index) = parse_part_index_from_key(&object.key, "csv") else {
+        if !parts::is_part_key(&object.key, "csv") {
             continue;
-        };
-        next_index = next_index.max(index.saturating_add(1));
-        if mode == config::WriteMode::Overwrite {
-            part_uris.push(object.uri);
         }
+        client.delete_object(&object.uri)?;
     }
-    if mode == config::WriteMode::Overwrite {
-        for uri in part_uris {
-            client.delete_object(&uri)?;
-        }
-        Ok(0)
-    } else {
-        Ok(next_index)
-    }
-}
-
-fn parse_part_index_from_key(key: &str, extension: &str) -> Option<usize> {
-    let path = Path::new(key);
-    if path.extension()?.to_str()? != extension {
-        return None;
-    }
-    let stem = path.file_stem()?.to_str()?;
-    let digits = stem.strip_prefix("part-")?;
-    if digits.len() < 5 || !digits.bytes().all(|value| value.is_ascii_digit()) {
-        return None;
-    }
-    digits.parse::<usize>().ok()
+    Ok(())
 }
 
 // Filename construction is shared via io::storage::paths helpers.

--- a/crates/floe-core/src/io/write/parquet.rs
+++ b/crates/floe-core/src/io/write/parquet.rs
@@ -132,17 +132,7 @@ fn prepare_part_allocator(
             clear_output_parts(target, cloud, resolver, entity)?;
             Ok(parts::PartNameAllocator::from_next_index(0, "parquet"))
         }
-        config::WriteMode::Append => match target {
-            Target::Local { base_path, .. } => {
-                parts::PartNameAllocator::from_local_path(Path::new(base_path), "parquet")
-            }
-            Target::S3 { .. } | Target::Gcs { .. } | Target::Adls { .. } => {
-                let next_index = next_cloud_part_index(target, cloud, resolver, entity)?;
-                Ok(parts::PartNameAllocator::from_next_index(
-                    next_index, "parquet",
-                ))
-            }
-        },
+        config::WriteMode::Append => Ok(parts::PartNameAllocator::unique("parquet")),
     }
 }
 
@@ -185,66 +175,6 @@ fn clear_output_parts(
     Ok(())
 }
 
-fn next_cloud_part_index(
-    target: &Target,
-    cloud: &mut io::storage::CloudClient,
-    resolver: &config::StorageResolver,
-    entity: &config::EntityConfig,
-) -> FloeResult<usize> {
-    match target {
-        Target::Local { .. } => Ok(0),
-        Target::S3 {
-            storage, base_key, ..
-        } => {
-            let list_prefix = s3_list_prefix(entity, base_key)?;
-            let client = cloud.client_for(resolver, storage, entity)?;
-            let keys = client.list(&list_prefix)?;
-            next_part_index_from_objects(keys.into_iter().filter_map(|obj| {
-                if obj.key.starts_with(&list_prefix) {
-                    parse_part_index_from_key(&obj.key)
-                } else {
-                    None
-                }
-            }))
-        }
-        Target::Gcs {
-            storage,
-            bucket,
-            base_key,
-            ..
-        } => {
-            let list_prefix = gcs_list_prefix(entity, bucket, base_key)?;
-            let client = cloud.client_for(resolver, storage, entity)?;
-            let keys = client.list(&list_prefix)?;
-            next_part_index_from_objects(keys.into_iter().filter_map(|obj| {
-                if obj.key.starts_with(&list_prefix) {
-                    parse_part_index_from_key(&obj.key)
-                } else {
-                    None
-                }
-            }))
-        }
-        Target::Adls {
-            storage,
-            container,
-            account,
-            base_path,
-            ..
-        } => {
-            let list_prefix = adls_list_prefix(entity, container, account, base_path)?;
-            let client = cloud.client_for(resolver, storage, entity)?;
-            let keys = client.list(&list_prefix)?;
-            next_part_index_from_objects(keys.into_iter().filter_map(|obj| {
-                if obj.key.starts_with(&list_prefix) {
-                    parse_part_index_from_key(&obj.key)
-                } else {
-                    None
-                }
-            }))
-        }
-    }
-}
-
 fn clear_s3_output_prefix(
     cloud: &mut io::storage::CloudClient,
     resolver: &config::StorageResolver,
@@ -258,7 +188,7 @@ fn clear_s3_output_prefix(
     for object in keys
         .into_iter()
         .filter(|obj| obj.key.starts_with(&list_prefix))
-        .filter(|obj| parse_part_index_from_key(&obj.key).is_some())
+        .filter(|obj| parts::is_part_key(&obj.key, "parquet"))
     {
         client.delete_object(&object.uri)?;
     }
@@ -279,7 +209,7 @@ fn clear_gcs_output_prefix(
     for object in keys
         .into_iter()
         .filter(|obj| obj.key.starts_with(&list_prefix))
-        .filter(|obj| parse_part_index_from_key(&obj.key).is_some())
+        .filter(|obj| parts::is_part_key(&obj.key, "parquet"))
     {
         client.delete_object(&object.uri)?;
     }
@@ -301,32 +231,11 @@ fn clear_adls_output_prefix(
     for object in keys
         .into_iter()
         .filter(|obj| obj.key.starts_with(&list_prefix))
-        .filter(|obj| parse_part_index_from_key(&obj.key).is_some())
+        .filter(|obj| parts::is_part_key(&obj.key, "parquet"))
     {
         client.delete_object(&object.uri)?;
     }
     Ok(())
-}
-
-fn parse_part_index_from_key(key: &str) -> Option<usize> {
-    let file_name = Path::new(key).file_name()?.to_str()?;
-    let stem = file_name.strip_suffix(".parquet")?;
-    let index = stem.strip_prefix("part-")?;
-    if index.is_empty() || !index.chars().all(|ch| ch.is_ascii_digit()) {
-        return None;
-    }
-    index.parse::<usize>().ok()
-}
-
-fn next_part_index_from_objects(indexes: impl IntoIterator<Item = usize>) -> FloeResult<usize> {
-    match indexes.into_iter().max() {
-        Some(index) => index.checked_add(1).ok_or_else(|| {
-            Box::new(ConfigError(
-                "parquet part index overflow while preparing append write".to_string(),
-            )) as Box<dyn std::error::Error + Send + Sync>
-        }),
-        None => Ok(0),
-    }
 }
 
 fn s3_list_prefix(entity: &config::EntityConfig, base_key: &str) -> FloeResult<String> {

--- a/crates/floe-core/src/io/write/parts.rs
+++ b/crates/floe-core/src/io/write/parts.rs
@@ -1,6 +1,7 @@
 use std::path::{Path, PathBuf};
 
 use crate::{io, FloeResult};
+use uuid::Uuid;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PartFile {
@@ -11,29 +12,41 @@ pub struct PartFile {
 
 #[derive(Debug, Clone)]
 pub struct PartNameAllocator {
-    next_index: usize,
+    next_index: Option<usize>,
     extension: String,
 }
 
 impl PartNameAllocator {
     pub fn from_local_path(base_path: &Path, extension: &str) -> FloeResult<Self> {
         Ok(Self {
-            next_index: next_local_part_index(base_path, extension)?,
+            next_index: Some(next_local_part_index(base_path, extension)?),
             extension: normalize_extension(extension),
         })
     }
 
     pub fn from_next_index(next_index: usize, extension: &str) -> Self {
         Self {
-            next_index,
+            next_index: Some(next_index),
+            extension: normalize_extension(extension),
+        }
+    }
+
+    pub fn unique(extension: &str) -> Self {
+        Self {
+            next_index: None,
             extension: normalize_extension(extension),
         }
     }
 
     pub fn allocate_next(&mut self) -> String {
-        let file_name = part_filename(self.next_index, &self.extension);
-        self.next_index += 1;
-        file_name
+        match self.next_index {
+            Some(index) => {
+                let file_name = part_filename(index, &self.extension);
+                self.next_index = Some(index.saturating_add(1));
+                file_name
+            }
+            None => append_part_filename(&self.extension),
+        }
     }
 }
 
@@ -41,6 +54,36 @@ pub fn part_filename(index: usize, extension: &str) -> String {
     let extension = normalize_extension(extension);
     let stem = io::storage::paths::build_part_stem(index);
     io::storage::paths::build_output_filename(&stem, "", &extension)
+}
+
+pub fn append_part_filename(extension: &str) -> String {
+    let extension = normalize_extension(extension);
+    let id = Uuid::new_v4();
+    format!("part-{id}.{extension}")
+}
+
+pub fn is_part_filename(file_name: &str, extension: &str) -> bool {
+    let extension = normalize_extension(extension);
+    let path = Path::new(file_name);
+    if path.extension().and_then(|ext| ext.to_str()) != Some(extension.as_str()) {
+        return false;
+    }
+    let stem = match path.file_stem().and_then(|stem| stem.to_str()) {
+        Some(stem) => stem,
+        None => return false,
+    };
+    match stem.strip_prefix("part-") {
+        Some(rest) => !rest.is_empty(),
+        None => false,
+    }
+}
+
+pub fn is_part_key(key: &str, extension: &str) -> bool {
+    let file_name = match Path::new(key).file_name().and_then(|name| name.to_str()) {
+        Some(name) => name,
+        None => return false,
+    };
+    is_part_filename(file_name, extension)
 }
 
 pub fn list_local_part_files(base_path: &Path, extension: &str) -> FloeResult<Vec<PartFile>> {
@@ -96,11 +139,22 @@ pub fn clear_local_part_files(base_path: &Path, extension: &str) -> FloeResult<u
         return Ok(0);
     }
 
-    let part_files = list_local_part_files(base_path, extension)?;
-    for part_file in &part_files {
-        std::fs::remove_file(&part_file.path)?;
+    let mut removed = 0usize;
+    for entry in std::fs::read_dir(base_path)? {
+        let entry = entry?;
+        if !entry.file_type()?.is_file() {
+            continue;
+        }
+        let file_name = entry.file_name();
+        let Some(file_name) = file_name.to_str() else {
+            continue;
+        };
+        if is_part_filename(file_name, extension) {
+            std::fs::remove_file(entry.path())?;
+            removed += 1;
+        }
     }
-    Ok(part_files.len())
+    Ok(removed)
 }
 
 fn parse_part_index(file_name: &str, extension: &str) -> Option<usize> {

--- a/crates/floe-core/tests/unit/io/write/parts.rs
+++ b/crates/floe-core/tests/unit/io/write/parts.rs
@@ -1,10 +1,12 @@
 use floe_core::io::write::parts::{
-    clear_local_part_files, list_local_part_files, next_local_part_filename, PartNameAllocator,
+    append_part_filename, clear_local_part_files, is_part_filename, list_local_part_files,
+    next_local_part_filename, PartNameAllocator,
 };
 use floe_core::FloeResult;
+use uuid::Uuid;
 
 #[test]
-fn append_allocation_uses_next_available_part_index() -> FloeResult<()> {
+fn sequential_allocation_uses_next_available_part_index() -> FloeResult<()> {
     let temp_dir = tempfile::TempDir::new()?;
     let output_dir = temp_dir.path().join("accepted");
     std::fs::create_dir_all(&output_dir)?;
@@ -33,15 +35,39 @@ fn append_allocation_uses_next_available_part_index() -> FloeResult<()> {
 }
 
 #[test]
+fn append_allocation_generates_unique_part_names() -> FloeResult<()> {
+    let mut allocator = PartNameAllocator::unique("parquet");
+    let first = allocator.allocate_next();
+    let second = allocator.allocate_next();
+    assert_ne!(first, second);
+    assert!(is_part_filename(&first, "parquet"));
+    assert!(is_part_filename(&second, "parquet"));
+
+    let first_id = first
+        .strip_prefix("part-")
+        .and_then(|name| name.strip_suffix(".parquet"))
+        .expect("uuid suffix");
+    let second_id = second
+        .strip_prefix("part-")
+        .and_then(|name| name.strip_suffix(".parquet"))
+        .expect("uuid suffix");
+    assert!(Uuid::parse_str(first_id).is_ok());
+    assert!(Uuid::parse_str(second_id).is_ok());
+
+    Ok(())
+}
+
+#[test]
 fn overwrite_cleanup_deletes_existing_part_files() -> FloeResult<()> {
     let temp_dir = tempfile::TempDir::new()?;
     let output_dir = temp_dir.path().join("accepted");
     std::fs::create_dir_all(&output_dir)?;
     std::fs::write(output_dir.join("part-00000.parquet"), b"p0")?;
     std::fs::write(output_dir.join("part-00001.parquet"), b"p1")?;
+    std::fs::write(output_dir.join(append_part_filename("parquet")), b"uuid")?;
 
     let removed = clear_local_part_files(&output_dir, "parquet")?;
-    assert_eq!(removed, 2);
+    assert_eq!(removed, 3);
     assert!(!output_dir.join("part-00000.parquet").exists());
     assert!(!output_dir.join("part-00001.parquet").exists());
     assert!(list_local_part_files(&output_dir, "parquet")?.is_empty());
@@ -57,18 +83,25 @@ fn overwrite_cleanup_preserves_non_part_files() -> FloeResult<()> {
 
     std::fs::write(output_dir.join("part-00000.parquet"), b"p0")?;
     std::fs::write(output_dir.join("part-00001.parquet"), b"p1")?;
+    std::fs::write(
+        output_dir.join("part-123e4567-e89b-12d3-a456-426614174000.parquet"),
+        b"uuid",
+    )?;
     std::fs::write(output_dir.join("part-00001.csv"), b"csv")?;
-    std::fs::write(output_dir.join("part-abcde.parquet"), b"invalid-part-name")?;
+    std::fs::write(output_dir.join("part-.parquet"), b"invalid-part-name")?;
     std::fs::write(output_dir.join("manifest.parquet"), b"manifest")?;
     std::fs::write(output_dir.join("_delta_log/00000.json"), b"log")?;
 
     let removed = clear_local_part_files(&output_dir, "parquet")?;
-    assert_eq!(removed, 2);
+    assert_eq!(removed, 3);
 
     assert!(!output_dir.join("part-00000.parquet").exists());
     assert!(!output_dir.join("part-00001.parquet").exists());
+    assert!(!output_dir
+        .join("part-123e4567-e89b-12d3-a456-426614174000.parquet")
+        .exists());
     assert!(output_dir.join("part-00001.csv").exists());
-    assert!(output_dir.join("part-abcde.parquet").exists());
+    assert!(output_dir.join("part-.parquet").exists());
     assert!(output_dir.join("manifest.parquet").exists());
     assert!(output_dir.join("_delta_log/00000.json").exists());
 

--- a/crates/floe-core/tests/unit/io/write/rejected_csv.rs
+++ b/crates/floe-core/tests/unit/io/write/rejected_csv.rs
@@ -2,6 +2,7 @@ use std::fs;
 use std::path::Path;
 
 use floe_core::io::format::RejectedWriteRequest;
+use floe_core::io::write::parts::is_part_filename;
 use floe_core::{config, io, FloeResult};
 use polars::prelude::{DataFrame, NamedFrom, Series};
 
@@ -123,15 +124,24 @@ fn rejected_csv_append_writes_additional_dataset_parts() -> FloeResult<()> {
         "beta",
     )?;
 
-    assert!(first_path.ends_with("part-00000.csv"));
-    assert!(second_path.ends_with("part-00001.csv"));
-    assert!(rejected_dir.join("part-00000.csv").exists());
-    assert!(rejected_dir.join("part-00001.csv").exists());
+    let first_file = Path::new(&first_path)
+        .file_name()
+        .and_then(|name| name.to_str())
+        .expect("first part filename");
+    let second_file = Path::new(&second_path)
+        .file_name()
+        .and_then(|name| name.to_str())
+        .expect("second part filename");
+    assert!(is_part_filename(first_file, "csv"));
+    assert!(is_part_filename(second_file, "csv"));
+    assert_ne!(first_file, second_file);
+    assert!(rejected_dir.join(first_file).exists());
+    assert!(rejected_dir.join(second_file).exists());
     assert!(!rejected_dir.join("first_rejected.csv").exists());
     assert!(!rejected_dir.join("second_rejected.csv").exists());
 
-    let first_contents = fs::read_to_string(rejected_dir.join("part-00000.csv"))?;
-    let second_contents = fs::read_to_string(rejected_dir.join("part-00001.csv"))?;
+    let first_contents = fs::read_to_string(rejected_dir.join(first_file))?;
+    let second_contents = fs::read_to_string(rejected_dir.join(second_file))?;
     assert!(first_contents.contains("alpha"));
     assert!(second_contents.contains("beta"));
     Ok(())

--- a/crates/floe-core/tests/unit/run/check_order.rs
+++ b/crates/floe-core/tests/unit/run/check_order.rs
@@ -2,6 +2,7 @@ use std::fs;
 use std::path::{Path, PathBuf};
 use std::time::{SystemTime, UNIX_EPOCH};
 
+use floe_core::io::write::parts::is_part_filename;
 use floe_core::report::{FileStatus, MismatchAction, RuleName};
 use floe_core::{run, RunOptions};
 use polars::prelude::{ParquetReader, SerReader};
@@ -232,8 +233,9 @@ entities:
         .map(|entry| entry.file_name().to_string_lossy().to_string())
         .collect::<Vec<_>>();
     rejected_files.sort();
-    assert_eq!(
-        rejected_files,
-        vec!["part-00000.csv".to_string(), "part-00001.csv".to_string()]
-    );
+    assert_eq!(rejected_files.len(), 2);
+    assert!(rejected_files
+        .iter()
+        .all(|name| is_part_filename(name, "csv")));
+    assert_ne!(rejected_files[0], rejected_files[1]);
 }

--- a/crates/floe-core/tests/unit/run/entity/accepted_output.rs
+++ b/crates/floe-core/tests/unit/run/entity/accepted_output.rs
@@ -2,6 +2,7 @@ use std::fs;
 use std::path::{Path, PathBuf};
 use std::time::{SystemTime, UNIX_EPOCH};
 
+use floe_core::io::write::parts::is_part_filename;
 use floe_core::{run, RunOptions};
 use polars::prelude::{ParquetReader, SerReader};
 
@@ -315,6 +316,18 @@ entities:
             .parts_written,
         6
     );
+    let mut first_part_files = Vec::new();
+    for entry in fs::read_dir(&accepted_dir).expect("read accepted dir") {
+        let entry = entry.expect("read accepted entry");
+        if entry.path().extension().and_then(|ext| ext.to_str()) == Some("parquet") {
+            first_part_files.push(entry.file_name().to_string_lossy().to_string());
+        }
+    }
+    first_part_files.sort();
+    assert_eq!(first_part_files.len(), 6);
+    assert!(first_part_files
+        .iter()
+        .all(|name| is_part_filename(name, "parquet")));
 
     write_csv(&input_dir, "a.csv", "id;name\n7;zoe\n");
     fs::remove_file(input_dir.join("b.csv")).expect("remove second input");
@@ -328,10 +341,9 @@ entities:
             .parts_written,
         1
     );
-    assert_eq!(
-        second.entity_outcomes[0].report.accepted_output.part_files,
-        vec!["part-00006.parquet".to_string()]
-    );
+    let appended_parts = &second.entity_outcomes[0].report.accepted_output.part_files;
+    assert_eq!(appended_parts.len(), 1);
+    assert!(is_part_filename(&appended_parts[0], "parquet"));
 
     let mut part_files = Vec::new();
     for entry in fs::read_dir(&accepted_dir).expect("read accepted dir") {
@@ -341,18 +353,17 @@ entities:
         }
     }
     part_files.sort();
-    assert_eq!(
-        part_files,
-        vec![
-            "part-00000.parquet".to_string(),
-            "part-00001.parquet".to_string(),
-            "part-00002.parquet".to_string(),
-            "part-00003.parquet".to_string(),
-            "part-00004.parquet".to_string(),
-            "part-00005.parquet".to_string(),
-            "part-00006.parquet".to_string(),
-        ]
-    );
+    assert_eq!(part_files.len(), 7);
+    assert!(part_files
+        .iter()
+        .all(|name| is_part_filename(name, "parquet")));
+    let extra_parts = part_files
+        .iter()
+        .filter(|name| !first_part_files.contains(name))
+        .cloned()
+        .collect::<Vec<_>>();
+    assert_eq!(extra_parts.len(), 1);
+    assert_eq!(extra_parts[0], appended_parts[0]);
 
     let mut total_rows = 0usize;
     for file_name in part_files {


### PR DESCRIPTION
## Issue
Append mode for parquet and rejected CSV currently lists cloud prefixes to find the next part index. On large prefixes this list-before-write is costly and slows down appends.

## Root Cause
Append part naming depended on sequential indices, which required a pre-flight list of existing part files to avoid collisions. That same approach was used for local and cloud targets.

## Fix
Append part files now use UUID-based names generated in the shared parts policy, so append can write without listing existing parts. Overwrite continues to clear existing part files and then writes sequential `part-00000` style names. Part cleanup now treats any `part-<id>.<ext>` as a part file so UUID-named parts are also removed on overwrite. Tests were updated to assert patterns and uniqueness instead of fixed append filenames.

## User Impact
Append writes for parquet and rejected CSV no longer need prefix listing, which avoids extra calls on large cloud datasets. Overwrite behavior stays the same, and local append still works with unique part names.

## Validation
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all`
