### PR TITLE
Release v0.2.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to Floe are documented in this file.
 
+## v0.2.3
+
+- Added append/overwrite write modes for accepted parquet and delta outputs.
+- Rejected outputs now use dataset-style part files with write modes.
+- Append mode now seeds unique checks from existing accepted data (parquet + delta).
+- Part naming improvements:
+  - UUID parts for append
+  - sequential parts for overwrite
+  - unified part listing/cleanup helpers.
+- Delta append fixes:
+  - enforce schema nullability correctly
+  - respect `normalize_columns` schema names.
+- Dagster Docker runner now writes outputs correctly.
+
 ## v0.2.2
 
 - Added Dagster orchestrator connector (`orchestrators/dagster-floe`) with:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3013,7 +3013,7 @@ dependencies = [
 
 [[package]]
 name = "floe-cli"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "assert_cmd",
  "clap",
@@ -3026,7 +3026,7 @@ dependencies = [
 
 [[package]]
 name = "floe-core"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "aws-config",
  "aws-sdk-s3",

--- a/crates/floe-cli/Cargo.toml
+++ b/crates/floe-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "floe-cli"
-version = "0.2.2"
+version = "0.2.3"
 edition = "2021"
 description = "CLI for Floe, a YAML-driven technical ingestion tool."
 license = "MIT"
@@ -17,7 +17,7 @@ path = "src/main.rs"
 
 [dependencies]
 clap = { version = "4", features = ["derive"] }
-floe-core = { path = "../floe-core", version = "0.2.2" }
+floe-core = { path = "../floe-core", version = "0.2.3" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 

--- a/crates/floe-core/Cargo.toml
+++ b/crates/floe-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "floe-core"
-version = "0.2.2"
+version = "0.2.3"
 edition = "2021"
 description = "Core library for Floe, a YAML-driven technical ingestion tool."
 license = "MIT"


### PR DESCRIPTION
## Summary
- bump crates to v0.2.3
- update CHANGELOG for v0.2.3
- refresh Cargo.lock

## Testing
- cargo check --all