### PR TITLE
[codex] json selector extraction

### DIFF
--- a/crates/floe-core/src/checks/mismatch.rs
+++ b/crates/floe-core/src/checks/mismatch.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use polars::prelude::{DataFrame, DataType, Series};
 
 use crate::errors::RunError;
-use crate::{config, report, FloeResult};
+use crate::{config, report, ConfigError, FloeResult};
 
 const MAX_MISMATCH_COLUMNS: usize = 50;
 
@@ -18,6 +18,39 @@ pub struct MismatchOutcome {
     pub extra: Vec<String>,
     pub fill_missing: bool,
     pub ignore_extra: bool,
+}
+
+pub fn top_level_declared_columns(
+    columns: &[config::ColumnConfig],
+    normalize_strategy: Option<&str>,
+) -> FloeResult<Vec<config::ColumnConfig>> {
+    let mut resolved = Vec::new();
+    let mut seen = std::collections::HashSet::new();
+    for column in columns {
+        let source = column.source_or_name();
+        if source.contains('.') || source.contains('[') {
+            continue;
+        }
+        let normalized = if let Some(strategy) = normalize_strategy {
+            crate::checks::normalize::normalize_name(source, strategy)
+        } else {
+            source.to_string()
+        };
+        if !seen.insert(normalized.clone()) {
+            return Err(Box::new(ConfigError(format!(
+                "duplicate top-level column selector: {}",
+                normalized
+            ))));
+        }
+        resolved.push(config::ColumnConfig {
+            name: normalized,
+            source: None,
+            column_type: column.column_type.clone(),
+            nullable: column.nullable,
+            unique: column.unique,
+        });
+    }
+    Ok(resolved)
 }
 
 pub fn plan_schema_mismatch(

--- a/crates/floe-core/src/checks/mod.rs
+++ b/crates/floe-core/src/checks/mod.rs
@@ -11,7 +11,8 @@ use crate::{ConfigError, FloeResult};
 
 pub use cast::{cast_mismatch_counts, cast_mismatch_errors, cast_mismatch_errors_sparse};
 pub use mismatch::{
-    apply_mismatch_plan, apply_schema_mismatch, plan_schema_mismatch, MismatchOutcome,
+    apply_mismatch_plan, apply_schema_mismatch, plan_schema_mismatch, top_level_declared_columns,
+    MismatchOutcome,
 };
 pub use not_null::{not_null_counts, not_null_errors, not_null_errors_sparse};
 pub use unique::{unique_counts, unique_errors, unique_errors_sparse, UniqueTracker};

--- a/crates/floe-core/src/checks/normalize.rs
+++ b/crates/floe-core/src/checks/normalize.rs
@@ -57,6 +57,36 @@ pub fn resolve_source_columns(
     }
 }
 
+pub fn resolve_source_columns_with_sources(
+    columns: &[config::ColumnConfig],
+    strategy: Option<&str>,
+) -> FloeResult<Vec<config::ColumnConfig>> {
+    let mut resolved = Vec::with_capacity(columns.len());
+    let mut seen = HashMap::new();
+    for column in columns {
+        let source_name = column.source_or_name();
+        let normalized_name = if let Some(strategy) = strategy {
+            normalize_name(source_name, strategy)
+        } else {
+            source_name.to_string()
+        };
+        if let Some(existing) = seen.insert(normalized_name.clone(), source_name.to_string()) {
+            return Err(Box::new(ConfigError(format!(
+                "column source collision: {} and {} -> {}",
+                existing, column.name, normalized_name
+            ))));
+        }
+        resolved.push(config::ColumnConfig {
+            name: normalized_name,
+            source: Some(source_name.to_string()),
+            column_type: column.column_type.clone(),
+            nullable: column.nullable,
+            unique: column.unique,
+        });
+    }
+    Ok(resolved)
+}
+
 pub fn output_column_mapping(
     columns: &[config::ColumnConfig],
     strategy: Option<&str>,

--- a/crates/floe-core/src/io/read/json.rs
+++ b/crates/floe-core/src/io/read/json.rs
@@ -6,6 +6,9 @@ use polars::prelude::{DataFrame, NamedFrom, Series};
 use serde_json::Value;
 
 use crate::io::format::{self, FileReadError, InputAdapter, InputFile, ReadInput};
+use crate::io::read::json_selector::{
+    compact_json, evaluate_selector, parse_selector, SelectorToken, SelectorValue,
+};
 use crate::{config, FloeResult};
 
 struct JsonInputAdapter;
@@ -30,14 +33,85 @@ impl std::fmt::Display for JsonReadError {
 
 impl std::error::Error for JsonReadError {}
 
-fn read_ndjson_file(input_path: &Path) -> Result<DataFrame, JsonReadError> {
+struct SelectorPlan {
+    source: String,
+    tokens: Vec<SelectorToken>,
+}
+
+fn build_selector_plan(
+    columns: &[config::ColumnConfig],
+) -> Result<Vec<SelectorPlan>, JsonReadError> {
+    let mut plans = Vec::with_capacity(columns.len());
+    let mut seen = HashSet::new();
+    for column in columns {
+        let source = column.source_or_name().to_string();
+        if !seen.insert(source.clone()) {
+            return Err(JsonReadError {
+                rule: "json_selector_invalid".to_string(),
+                message: format!("duplicate json selector source: {}", source),
+            });
+        }
+        let tokens = parse_selector(&source).map_err(|err| JsonReadError {
+            rule: "json_selector_invalid".to_string(),
+            message: format!("invalid selector {}: {}", source, err.message),
+        })?;
+        plans.push(SelectorPlan { source, tokens });
+    }
+    Ok(plans)
+}
+
+fn extract_row(
+    value: &Value,
+    plans: &[SelectorPlan],
+    cast_mode: &str,
+    location: &str,
+) -> Result<BTreeMap<String, Option<String>>, JsonReadError> {
+    let mut row = BTreeMap::new();
+    for plan in plans {
+        let selected = evaluate_selector(value, &plan.tokens).map_err(|err| JsonReadError {
+            rule: "json_selector_invalid".to_string(),
+            message: format!("invalid selector {}: {}", plan.source, err.message),
+        })?;
+        let cell = match selected {
+            SelectorValue::Null => None,
+            SelectorValue::Scalar(value) => Some(value),
+            SelectorValue::NonScalar(value) => {
+                if cast_mode == "coerce" {
+                    Some(compact_json(&value).map_err(|err| JsonReadError {
+                        rule: "json_selector_non_scalar".to_string(),
+                        message: format!(
+                            "failed to stringify selector {} at {}: {}",
+                            plan.source, location, err.message
+                        ),
+                    })?)
+                } else {
+                    return Err(JsonReadError {
+                        rule: "json_selector_non_scalar".to_string(),
+                        message: format!(
+                            "non-scalar value for selector {} at {}",
+                            plan.source, location
+                        ),
+                    });
+                }
+            }
+        };
+        row.insert(plan.source.clone(), cell);
+    }
+    Ok(row)
+}
+
+fn read_ndjson_file(
+    input_path: &Path,
+    columns: &[config::ColumnConfig],
+    cast_mode: &str,
+) -> Result<DataFrame, JsonReadError> {
     let content = std::fs::read_to_string(input_path).map_err(|err| JsonReadError {
         rule: "json_parse_error".to_string(),
         message: format!("failed to read json at {}: {err}", input_path.display()),
     })?;
 
+    let plans = build_selector_plan(columns)?;
     let mut rows: Vec<BTreeMap<String, Option<String>>> = Vec::new();
-    let mut keys = HashSet::new();
     for (idx, line) in content.lines().enumerate() {
         let line = line.trim();
         if line.is_empty() {
@@ -47,38 +121,21 @@ fn read_ndjson_file(input_path: &Path) -> Result<DataFrame, JsonReadError> {
             rule: "json_parse_error".to_string(),
             message: format!("json parse error at line {}: {err}", idx + 1),
         })?;
-        let object = value.as_object().ok_or_else(|| JsonReadError {
-            rule: "json_parse_error".to_string(),
-            message: format!("expected json object at line {}", idx + 1),
-        })?;
-
-        let mut row = BTreeMap::new();
-        for (key, value) in object {
-            if value.is_object() || value.is_array() {
-                return Err(JsonReadError {
-                    rule: "json_unsupported_value".to_string(),
-                    message: format!(
-                        "nested json values are not supported (line {}, key {})",
-                        idx + 1,
-                        key
-                    ),
-                });
-            }
-            let cell = match value {
-                Value::Null => None,
-                Value::String(value) => Some(value.clone()),
-                Value::Bool(value) => Some(value.to_string()),
-                Value::Number(value) => Some(value.to_string()),
-                _ => None,
-            };
-            row.insert(key.clone(), cell);
-            keys.insert(key.clone());
+        if !value.is_object() {
+            return Err(JsonReadError {
+                rule: "json_parse_error".to_string(),
+                message: format!("expected json object at line {}", idx + 1),
+            });
         }
+
+        let row = extract_row(&value, &plans, cast_mode, &format!("line {}", idx + 1))?;
         rows.push(row);
     }
 
-    let mut columns = keys.into_iter().collect::<Vec<String>>();
-    columns.sort();
+    let columns = plans
+        .iter()
+        .map(|plan| plan.source.clone())
+        .collect::<Vec<_>>();
 
     build_dataframe(&columns, &rows)
 }
@@ -106,20 +163,7 @@ fn read_ndjson_columns(input_path: &Path) -> Result<Vec<String>, JsonReadError> 
                     rule: "json_parse_error".to_string(),
                     message: format!("expected json object at line {}", idx + 1),
                 })?;
-                let mut keys = Vec::with_capacity(object.len());
-                for (key, value) in object {
-                    if value.is_object() || value.is_array() {
-                        return Err(JsonReadError {
-                            rule: "json_unsupported_value".to_string(),
-                            message: format!(
-                                "nested json values are not supported (line {}, key {})",
-                                idx + 1,
-                                key
-                            ),
-                        });
-                    }
-                    keys.push(key.clone());
-                }
+                let mut keys = object.keys().cloned().collect::<Vec<_>>();
                 keys.sort();
                 return Ok(keys);
             }
@@ -141,7 +185,11 @@ fn read_ndjson_columns(input_path: &Path) -> Result<Vec<String>, JsonReadError> 
     }))
 }
 
-fn read_json_array_file(input_path: &Path) -> Result<DataFrame, JsonReadError> {
+fn read_json_array_file(
+    input_path: &Path,
+    columns: &[config::ColumnConfig],
+    cast_mode: &str,
+) -> Result<DataFrame, JsonReadError> {
     let content = std::fs::read_to_string(input_path).map_err(|err| JsonReadError {
         rule: "json_parse_error".to_string(),
         message: format!("failed to read json at {}: {err}", input_path.display()),
@@ -156,64 +204,26 @@ fn read_json_array_file(input_path: &Path) -> Result<DataFrame, JsonReadError> {
         message: "expected json array at root".to_string(),
     })?;
 
+    let plans = build_selector_plan(columns)?;
     let mut rows: Vec<BTreeMap<String, Option<String>>> = Vec::with_capacity(array.len());
-    let mut columns = Vec::new();
 
     for (idx, value) in array.iter().enumerate() {
-        let object = value.as_object().ok_or_else(|| JsonReadError {
-            rule: "json_parse_error".to_string(),
-            message: format!("expected json object at index {}", idx),
-        })?;
-
-        let mut row = BTreeMap::new();
-        if columns.is_empty() {
-            for key in object.keys() {
-                columns.push(key.clone());
-            }
+        if !value.is_object() {
+            return Err(JsonReadError {
+                rule: "json_parse_error".to_string(),
+                message: format!("expected json object at index {}", idx),
+            });
         }
-
-        for (key, value) in object {
-            if value.is_object() || value.is_array() {
-                return Err(JsonReadError {
-                    rule: "json_unsupported_value".to_string(),
-                    message: format!(
-                        "nested json values are not supported (index {}, key {})",
-                        idx, key
-                    ),
-                });
-            }
-            let cell = match value {
-                Value::Null => None,
-                Value::String(value) => Some(value.clone()),
-                Value::Bool(value) => Some(value.to_string()),
-                Value::Number(value) => Some(value.to_string()),
-                _ => None,
-            };
-            row.insert(key.clone(), cell);
-        }
+        let row = extract_row(value, &plans, cast_mode, &format!("index {}", idx))?;
         rows.push(row);
     }
 
+    let columns = plans
+        .iter()
+        .map(|plan| plan.source.clone())
+        .collect::<Vec<_>>();
+
     build_dataframe(&columns, &rows)
-}
-
-fn build_dataframe(
-    columns: &[String],
-    rows: &[BTreeMap<String, Option<String>>],
-) -> Result<DataFrame, JsonReadError> {
-    let mut series = Vec::with_capacity(columns.len());
-    for name in columns {
-        let mut values = Vec::with_capacity(rows.len());
-        for row in rows {
-            values.push(row.get(name).cloned().unwrap_or(None));
-        }
-        series.push(Series::new(name.as_str().into(), values).into());
-    }
-
-    DataFrame::new(series).map_err(|err| JsonReadError {
-        rule: "json_parse_error".to_string(),
-        message: format!("failed to build dataframe: {err}"),
-    })
 }
 
 fn read_json_array_columns(input_path: &Path) -> Result<Vec<String>, JsonReadError> {
@@ -239,21 +249,28 @@ fn read_json_array_columns(input_path: &Path) -> Result<Vec<String>, JsonReadErr
         rule: "json_parse_error".to_string(),
         message: "expected json object at index 0".to_string(),
     })?;
-    let mut keys = Vec::with_capacity(object.len());
-    for (key, value) in object {
-        if value.is_object() || value.is_array() {
-            return Err(JsonReadError {
-                rule: "json_unsupported_value".to_string(),
-                message: format!(
-                    "nested json values are not supported (index 0, key {})",
-                    key
-                ),
-            });
-        }
-        keys.push(key.clone());
-    }
+    let mut keys = object.keys().cloned().collect::<Vec<_>>();
     keys.sort();
     Ok(keys)
+}
+
+fn build_dataframe(
+    columns: &[String],
+    rows: &[BTreeMap<String, Option<String>>],
+) -> Result<DataFrame, JsonReadError> {
+    let mut series = Vec::with_capacity(columns.len());
+    for name in columns {
+        let mut values = Vec::with_capacity(rows.len());
+        for row in rows {
+            values.push(row.get(name).cloned().unwrap_or(None));
+        }
+        series.push(Series::new(name.as_str().into(), values).into());
+    }
+
+    DataFrame::new(series).map_err(|err| JsonReadError {
+        rule: "json_parse_error".to_string(),
+        message: format!("failed to build dataframe: {err}"),
+    })
 }
 
 impl InputAdapter for JsonInputAdapter {
@@ -306,11 +323,12 @@ impl InputAdapter for JsonInputAdapter {
             .as_ref()
             .and_then(|options| options.json_mode.as_deref())
             .unwrap_or("array");
+        let cast_mode = entity.source.cast_mode.as_deref().unwrap_or("strict");
         for input_file in files {
             let path = &input_file.source_local_path;
             let read_result = match json_mode {
-                "ndjson" => read_ndjson_file(path),
-                "array" => read_json_array_file(path),
+                "ndjson" => read_ndjson_file(path, columns, cast_mode),
+                "array" => read_json_array_file(path, columns, cast_mode),
                 other => Err(JsonReadError {
                     rule: "json_parse_error".to_string(),
                     message: format!(

--- a/crates/floe-core/src/io/read/json_selector.rs
+++ b/crates/floe-core/src/io/read/json_selector.rs
@@ -1,0 +1,165 @@
+use serde_json::Value;
+
+use crate::ConfigError;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SelectorToken {
+    Field(String),
+    Index(usize),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SelectorValue {
+    Scalar(String),
+    Null,
+    NonScalar(Value),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SelectorError {
+    pub message: String,
+}
+
+impl std::fmt::Display for SelectorError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.message)
+    }
+}
+
+impl std::error::Error for SelectorError {}
+
+pub fn parse_selector(selector: &str) -> Result<Vec<SelectorToken>, SelectorError> {
+    let trimmed = selector.trim();
+    if trimmed.is_empty() {
+        return Err(SelectorError {
+            message: "selector is empty".to_string(),
+        });
+    }
+    let mut tokens = Vec::new();
+    let mut buf = String::new();
+    let mut chars = trimmed.chars().peekable();
+    let mut last_was_index = false;
+    while let Some(ch) = chars.next() {
+        match ch {
+            '.' => {
+                if buf.is_empty() {
+                    if last_was_index {
+                        last_was_index = false;
+                        continue;
+                    }
+                    return Err(SelectorError {
+                        message: "selector contains empty field".to_string(),
+                    });
+                }
+                tokens.push(SelectorToken::Field(buf.clone()));
+                buf.clear();
+                last_was_index = false;
+            }
+            '[' => {
+                if !buf.is_empty() {
+                    tokens.push(SelectorToken::Field(buf.clone()));
+                    buf.clear();
+                }
+                let mut index_buf = String::new();
+                for next in chars.by_ref() {
+                    if next == ']' {
+                        break;
+                    }
+                    index_buf.push(next);
+                }
+                if index_buf.is_empty() {
+                    return Err(SelectorError {
+                        message: "selector index is empty".to_string(),
+                    });
+                }
+                if !index_buf.chars().all(|c| c.is_ascii_digit()) {
+                    return Err(SelectorError {
+                        message: format!("selector index is not numeric: {}", index_buf),
+                    });
+                }
+                let index = index_buf.parse::<usize>().map_err(|_| SelectorError {
+                    message: format!("selector index is invalid: {}", index_buf),
+                })?;
+                tokens.push(SelectorToken::Index(index));
+                last_was_index = true;
+            }
+            ']' => {
+                return Err(SelectorError {
+                    message: "selector contains unexpected ']'".to_string(),
+                });
+            }
+            _ => {
+                buf.push(ch);
+                last_was_index = false;
+            }
+        }
+    }
+    if !buf.is_empty() {
+        tokens.push(SelectorToken::Field(buf));
+    }
+    Ok(tokens)
+}
+
+pub fn evaluate_selector(
+    value: &Value,
+    tokens: &[SelectorToken],
+) -> Result<SelectorValue, SelectorError> {
+    if tokens.is_empty() {
+        return Err(SelectorError {
+            message: "selector has no tokens".to_string(),
+        });
+    }
+    let mut current = value;
+    for token in tokens {
+        match token {
+            SelectorToken::Field(name) => {
+                let object = match current.as_object() {
+                    Some(object) => object,
+                    None => return Ok(SelectorValue::Null),
+                };
+                match object.get(name) {
+                    Some(next) => current = next,
+                    None => return Ok(SelectorValue::Null),
+                }
+            }
+            SelectorToken::Index(index) => {
+                let array = match current.as_array() {
+                    Some(array) => array,
+                    None => return Ok(SelectorValue::Null),
+                };
+                if let Some(next) = array.get(*index) {
+                    current = next;
+                } else {
+                    return Ok(SelectorValue::Null);
+                }
+            }
+        }
+    }
+    if current.is_null() {
+        return Ok(SelectorValue::Null);
+    }
+    if current.is_object() || current.is_array() {
+        return Ok(SelectorValue::NonScalar(current.clone()));
+    }
+    match current {
+        Value::String(value) => Ok(SelectorValue::Scalar(value.clone())),
+        Value::Bool(value) => Ok(SelectorValue::Scalar(value.to_string())),
+        Value::Number(value) => Ok(SelectorValue::Scalar(value.to_string())),
+        Value::Null => Ok(SelectorValue::Null),
+        Value::Object(_) | Value::Array(_) => Ok(SelectorValue::NonScalar(current.clone())),
+    }
+}
+
+pub fn selector_is_top_level(selector: &str) -> bool {
+    !selector.contains('.') && !selector.contains('[')
+}
+
+pub fn compact_json(value: &Value) -> Result<String, SelectorError> {
+    serde_json::to_string(value).map_err(|err| SelectorError {
+        message: format!("failed to serialize json value: {err}"),
+    })
+}
+
+pub fn selector_tokens_or_error(selector: &str) -> Result<Vec<SelectorToken>, ConfigError> {
+    parse_selector(selector).map_err(|err| ConfigError(err.message))
+}

--- a/crates/floe-core/src/io/read/mod.rs
+++ b/crates/floe-core/src/io/read/mod.rs
@@ -1,3 +1,4 @@
 pub mod csv;
 pub mod json;
+pub mod json_selector;
 pub mod parquet;

--- a/crates/floe-core/src/run/entity/mod.rs
+++ b/crates/floe-core/src/run/entity/mod.rs
@@ -11,7 +11,7 @@ use super::output::{
 use super::{EntityOutcome, RunContext, MAX_RESOLVED_INPUTS};
 use crate::checks::normalize::{
     output_column_mapping, rename_output_columns, resolve_normalize_strategy,
-    resolve_source_columns,
+    resolve_source_columns, resolve_source_columns_with_sources,
 };
 use crate::report::build::summarize_validation_sparse;
 
@@ -63,6 +63,14 @@ pub(super) fn run_entity(
     let normalize_strategy = resolve_normalize_strategy(entity)?;
     let normalized_columns =
         resolve_source_columns(&entity.schema.columns, normalize_strategy.as_deref())?;
+    let json_columns = if entity.source.format == "json" {
+        Some(resolve_source_columns_with_sources(
+            &entity.schema.columns,
+            normalize_strategy.as_deref(),
+        )?)
+    } else {
+        None
+    };
     let output_column_map =
         output_column_mapping(&entity.schema.columns, normalize_strategy.as_deref())?;
     let required_cols = required_columns(&normalized_columns);
@@ -193,10 +201,11 @@ pub(super) fn run_entity(
             mismatch,
             file_timer,
         } = prechecked;
+        let read_columns = json_columns.as_deref().unwrap_or(&normalized_columns);
         let mut inputs = input_adapter.read_inputs(
             entity,
             std::slice::from_ref(&input_file),
-            &normalized_columns,
+            read_columns,
             normalize_strategy.as_deref(),
             collect_raw,
         )?;
@@ -253,7 +262,7 @@ pub(super) fn run_entity(
                     accepted_count: 0,
                     rejected_count: 0,
                     mismatch: report::FileMismatch {
-                        declared_columns_count: normalized_columns.len() as u64,
+                        declared_columns_count: mismatch_report.declared_columns_count,
                         input_columns_count: mismatch_report.input_columns_count,
                         missing_columns: mismatch_report.missing_columns,
                         extra_columns: mismatch_report.extra_columns,

--- a/crates/floe-core/src/run/entity/precheck.rs
+++ b/crates/floe-core/src/run/entity/precheck.rs
@@ -1,5 +1,6 @@
 use std::time::Instant;
 
+use crate::checks::normalize::resolve_normalize_strategy;
 use crate::{check, config, io, report, warnings, ConfigError, FloeResult};
 
 use super::super::output::{validate_rejected_target, write_rejected_raw_output};
@@ -53,6 +54,12 @@ pub(super) fn run_precheck(
     } = context;
     let mut abort_run = false;
     let mut prechecked_inputs = Vec::with_capacity(input_files.len());
+    let normalize_strategy = resolve_normalize_strategy(entity)?;
+    let mismatch_columns = if entity.source.format == "json" {
+        check::top_level_declared_columns(&entity.schema.columns, normalize_strategy.as_deref())?
+    } else {
+        normalized_columns.to_vec()
+    };
     for input_file in input_files {
         let file_timer = Instant::now();
         observer.on_event(crate::run::events::RunEvent::FileStarted {
@@ -98,7 +105,7 @@ pub(super) fn run_precheck(
                         accepted_count: 0,
                         rejected_count: 0,
                         mismatch: report::FileMismatch {
-                            declared_columns_count: normalized_columns.len() as u64,
+                            declared_columns_count: mismatch_columns.len() as u64,
                             input_columns_count: 0,
                             missing_columns: Vec::new(),
                             extra_columns: Vec::new(),
@@ -150,7 +157,7 @@ pub(super) fn run_precheck(
                 }
             };
 
-        let mismatch = check::plan_schema_mismatch(entity, normalized_columns, &input_columns)?;
+        let mismatch = check::plan_schema_mismatch(entity, &mismatch_columns, &input_columns)?;
         if let Some(message) = mismatch.report.warning.as_deref() {
             warnings::emit(
                 &context.run_id,

--- a/crates/floe-core/tests/integration/json_selectors.rs
+++ b/crates/floe-core/tests/integration/json_selectors.rs
@@ -1,0 +1,250 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use floe_core::report::FileStatus;
+use floe_core::{run, RunOptions};
+use polars::prelude::{ParquetReader, SerReader};
+
+fn write_json(dir: &Path, name: &str, contents: &str) -> PathBuf {
+    let path = dir.join(name);
+    fs::write(&path, contents).expect("write json");
+    path
+}
+
+fn write_config(dir: &Path, contents: &str) -> PathBuf {
+    let path = dir.join("config.yml");
+    fs::write(&path, contents).expect("write config");
+    path
+}
+
+fn parquet_files(dir: &Path) -> Vec<PathBuf> {
+    let mut parquet_files = Vec::new();
+    if dir.exists() {
+        for entry in fs::read_dir(dir).expect("read accepted dir") {
+            let entry = entry.expect("read entry");
+            if entry.path().extension().and_then(|ext| ext.to_str()) == Some("parquet") {
+                parquet_files.push(entry.path());
+            }
+        }
+    }
+    parquet_files
+}
+
+#[test]
+fn json_selector_strict_rejects_non_scalar() {
+    let temp_dir = tempfile::TempDir::new().expect("temp dir");
+    let root = temp_dir.path();
+    let input_dir = root.join("in");
+    let accepted_dir = root.join("out/accepted/customer");
+    let rejected_dir = root.join("out/rejected/customer");
+    let report_dir = root.join("report");
+
+    fs::create_dir_all(&input_dir).expect("create input dir");
+    write_json(
+        &input_dir,
+        "data.json",
+        r#"[{"id":"1","user":{"name":"Ada"}}]"#,
+    );
+
+    let yaml = format!(
+        r#"version: "0.1"
+report:
+  path: "{report_dir}"
+entities:
+  - name: "customer"
+    source:
+      format: "json"
+      path: "{input_dir}"
+      cast_mode: "strict"
+    sink:
+      accepted:
+        format: "parquet"
+        path: "{accepted_dir}"
+      rejected:
+        format: "csv"
+        path: "{rejected_dir}"
+    policy:
+      severity: "reject"
+    schema:
+      columns:
+        - name: "id"
+          type: "string"
+        - name: "user_payload"
+          source: "user"
+          type: "string"
+"#,
+        report_dir = report_dir.display(),
+        input_dir = input_dir.display(),
+        accepted_dir = accepted_dir.display(),
+        rejected_dir = rejected_dir.display(),
+    );
+    let config_path = write_config(root, &yaml);
+
+    let outcome = run(
+        &config_path,
+        RunOptions {
+            run_id: Some("it-json-strict".to_string()),
+            entities: Vec::new(),
+        },
+    )
+    .expect("run config");
+
+    let file_report = &outcome.entity_outcomes[0].report.files[0];
+    assert_eq!(file_report.status, FileStatus::Rejected);
+    assert_eq!(
+        file_report
+            .mismatch
+            .error
+            .as_ref()
+            .expect("mismatch error")
+            .rule,
+        "json_selector_non_scalar"
+    );
+}
+
+#[test]
+fn json_selector_coerce_stringifies_non_scalar() {
+    let temp_dir = tempfile::TempDir::new().expect("temp dir");
+    let root = temp_dir.path();
+    let input_dir = root.join("in");
+    let accepted_dir = root.join("out/accepted/customer");
+    let rejected_dir = root.join("out/rejected/customer");
+    let report_dir = root.join("report");
+
+    fs::create_dir_all(&input_dir).expect("create input dir");
+    write_json(
+        &input_dir,
+        "data.json",
+        r#"[{"id":"1","user":{"name":"Ada"}}]"#,
+    );
+
+    let yaml = format!(
+        r#"version: "0.1"
+report:
+  path: "{report_dir}"
+entities:
+  - name: "customer"
+    source:
+      format: "json"
+      path: "{input_dir}"
+      cast_mode: "coerce"
+    sink:
+      accepted:
+        format: "parquet"
+        path: "{accepted_dir}"
+      rejected:
+        format: "csv"
+        path: "{rejected_dir}"
+    policy:
+      severity: "warn"
+    schema:
+      columns:
+        - name: "id"
+          type: "string"
+        - name: "user_payload"
+          source: "user"
+          type: "string"
+"#,
+        report_dir = report_dir.display(),
+        input_dir = input_dir.display(),
+        accepted_dir = accepted_dir.display(),
+        rejected_dir = rejected_dir.display(),
+    );
+    let config_path = write_config(root, &yaml);
+
+    let outcome = run(
+        &config_path,
+        RunOptions {
+            run_id: Some("it-json-coerce".to_string()),
+            entities: Vec::new(),
+        },
+    )
+    .expect("run config");
+
+    let file_report = &outcome.entity_outcomes[0].report.files[0];
+    assert_eq!(file_report.status, FileStatus::Success);
+
+    let files = parquet_files(&accepted_dir);
+    assert_eq!(files.len(), 1);
+    let file = fs::File::open(&files[0]).expect("open parquet");
+    let df = ParquetReader::new(file).finish().expect("read parquet");
+    let value = df
+        .column("user_payload")
+        .expect("user_payload column")
+        .as_materialized_series()
+        .str()
+        .expect("string column")
+        .get(0)
+        .expect("value");
+    assert_eq!(value, "{\"name\":\"Ada\"}");
+}
+
+#[test]
+fn json_selector_mismatch_uses_top_level_only() {
+    let temp_dir = tempfile::TempDir::new().expect("temp dir");
+    let root = temp_dir.path();
+    let input_dir = root.join("in");
+    let accepted_dir = root.join("out/accepted/customer");
+    let rejected_dir = root.join("out/rejected/customer");
+    let report_dir = root.join("report");
+
+    fs::create_dir_all(&input_dir).expect("create input dir");
+    write_json(
+        &input_dir,
+        "data.json",
+        r#"[{"id":"1","user":{"name":"Ada"},"extra":"x"}]"#,
+    );
+
+    let yaml = format!(
+        r#"version: "0.1"
+report:
+  path: "{report_dir}"
+entities:
+  - name: "customer"
+    source:
+      format: "json"
+      path: "{input_dir}"
+      cast_mode: "strict"
+    sink:
+      accepted:
+        format: "parquet"
+        path: "{accepted_dir}"
+      rejected:
+        format: "csv"
+        path: "{rejected_dir}"
+    policy:
+      severity: "reject"
+    schema:
+      mismatch:
+        extra_columns: "reject_file"
+      columns:
+        - name: "id"
+          type: "string"
+        - name: "user_name"
+          source: "user.name"
+          type: "string"
+"#,
+        report_dir = report_dir.display(),
+        input_dir = input_dir.display(),
+        accepted_dir = accepted_dir.display(),
+        rejected_dir = rejected_dir.display(),
+    );
+    let config_path = write_config(root, &yaml);
+
+    let outcome = run(
+        &config_path,
+        RunOptions {
+            run_id: Some("it-json-mismatch".to_string()),
+            entities: Vec::new(),
+        },
+    )
+    .expect("run config");
+
+    let file_report = &outcome.entity_outcomes[0].report.files[0];
+    assert_eq!(file_report.status, FileStatus::Rejected);
+    assert_eq!(file_report.mismatch.missing_columns, Vec::<String>::new());
+    assert_eq!(
+        file_report.mismatch.extra_columns,
+        vec!["extra".to_string(), "user".to_string()]
+    );
+}

--- a/crates/floe-core/tests/integration/mod.rs
+++ b/crates/floe-core/tests/integration/mod.rs
@@ -1,2 +1,3 @@
+pub mod json_selectors;
 pub mod local_run;
 pub mod run_entities_filter;

--- a/crates/floe-core/tests/unit/io/read/json_array.rs
+++ b/crates/floe-core/tests/unit/io/read/json_array.rs
@@ -245,7 +245,7 @@ entities:
 }
 
 #[test]
-fn json_array_nested_values_reject_file() {
+fn json_array_nested_values_are_ignored() {
     let root = temp_dir("floe-json-array-nested");
     let input_dir = root.join("in");
     let accepted_dir = root.join("out/accepted");
@@ -288,8 +288,6 @@ entities:
 
     let outcome = run_config(&config_path);
     let file = &outcome.entity_outcomes[0].report.files[0];
-    assert_eq!(file.status, FileStatus::Rejected);
-    let issue = file.mismatch.error.as_ref().expect("expected json error");
-    assert_eq!(issue.rule, "json_unsupported_value");
-    assert!(issue.message.contains("entity.name=customer"));
+    assert_eq!(file.status, FileStatus::Success);
+    assert!(file.mismatch.error.is_none());
 }

--- a/crates/floe-core/tests/unit/io/read/json_ndjson.rs
+++ b/crates/floe-core/tests/unit/io/read/json_ndjson.rs
@@ -202,7 +202,7 @@ entities:
 }
 
 #[test]
-fn ndjson_nested_values_reject_file() {
+fn ndjson_nested_values_are_ignored() {
     let root = temp_dir("floe-ndjson-nested");
     let input_dir = root.join("in");
     let accepted_dir = root.join("out/accepted");
@@ -249,8 +249,6 @@ entities:
 
     let outcome = run_config(&config_path);
     let file = &outcome.entity_outcomes[0].report.files[0];
-    assert_eq!(file.status, FileStatus::Rejected);
-    let issue = file.mismatch.error.as_ref().expect("expected json error");
-    assert_eq!(issue.rule, "json_unsupported_value");
-    assert!(issue.message.contains("entity.name=customer"));
+    assert_eq!(file.status, FileStatus::Success);
+    assert!(file.mismatch.error.is_none());
 }

--- a/crates/floe-core/tests/unit/io/read/json_selector.rs
+++ b/crates/floe-core/tests/unit/io/read/json_selector.rs
@@ -1,0 +1,157 @@
+use floe_core::io::read::json_selector::{
+    compact_json, evaluate_selector, parse_selector, selector_is_top_level, SelectorToken,
+    SelectorValue,
+};
+use serde_json::json;
+
+#[test]
+fn parse_selector_simple_field() {
+    let tokens = parse_selector("user").expect("parse selector");
+    assert_eq!(tokens, vec![SelectorToken::Field("user".to_string())]);
+}
+
+#[test]
+fn parse_selector_nested_fields() {
+    let tokens = parse_selector("a.b.c").expect("parse selector");
+    assert_eq!(
+        tokens,
+        vec![
+            SelectorToken::Field("a".to_string()),
+            SelectorToken::Field("b".to_string()),
+            SelectorToken::Field("c".to_string())
+        ]
+    );
+}
+
+#[test]
+fn parse_selector_with_index() {
+    let tokens = parse_selector("a[2]").expect("parse selector");
+    assert_eq!(
+        tokens,
+        vec![
+            SelectorToken::Field("a".to_string()),
+            SelectorToken::Index(2)
+        ]
+    );
+}
+
+#[test]
+fn parse_selector_nested_with_index() {
+    let tokens = parse_selector("a.b[0].c").expect("parse selector");
+    assert_eq!(
+        tokens,
+        vec![
+            SelectorToken::Field("a".to_string()),
+            SelectorToken::Field("b".to_string()),
+            SelectorToken::Index(0),
+            SelectorToken::Field("c".to_string())
+        ]
+    );
+}
+
+#[test]
+fn parse_selector_empty_string_errors() {
+    assert!(parse_selector("").is_err());
+}
+
+#[test]
+fn parse_selector_empty_field_errors() {
+    assert!(parse_selector(".a").is_err());
+}
+
+#[test]
+fn parse_selector_empty_index_errors() {
+    assert!(parse_selector("a[]").is_err());
+}
+
+#[test]
+fn parse_selector_non_numeric_index_errors() {
+    assert!(parse_selector("a[foo]").is_err());
+}
+
+#[test]
+fn parse_selector_unexpected_bracket_errors() {
+    assert!(parse_selector("a]").is_err());
+}
+
+#[test]
+fn evaluate_selector_missing_field_returns_null() {
+    let value = json!({"a": 1});
+    let tokens = parse_selector("missing").expect("parse selector");
+    assert_eq!(evaluate_selector(&value, &tokens), Ok(SelectorValue::Null));
+}
+
+#[test]
+fn evaluate_selector_missing_index_returns_null() {
+    let value = json!({"a": [1]});
+    let tokens = parse_selector("a[2]").expect("parse selector");
+    assert_eq!(evaluate_selector(&value, &tokens), Ok(SelectorValue::Null));
+}
+
+#[test]
+fn evaluate_selector_wrong_type_returns_null() {
+    let value = json!({"a": 1});
+    let tokens = parse_selector("a.b").expect("parse selector");
+    assert_eq!(evaluate_selector(&value, &tokens), Ok(SelectorValue::Null));
+}
+
+#[test]
+fn evaluate_selector_scalar_string() {
+    let value = json!({"a": {"b": "ok"}});
+    let tokens = parse_selector("a.b").expect("parse selector");
+    assert_eq!(
+        evaluate_selector(&value, &tokens),
+        Ok(SelectorValue::Scalar("ok".to_string()))
+    );
+}
+
+#[test]
+fn evaluate_selector_scalar_number() {
+    let value = json!({"a": 42});
+    let tokens = parse_selector("a").expect("parse selector");
+    assert_eq!(
+        evaluate_selector(&value, &tokens),
+        Ok(SelectorValue::Scalar("42".to_string()))
+    );
+}
+
+#[test]
+fn evaluate_selector_scalar_bool() {
+    let value = json!({"a": true});
+    let tokens = parse_selector("a").expect("parse selector");
+    assert_eq!(
+        evaluate_selector(&value, &tokens),
+        Ok(SelectorValue::Scalar("true".to_string()))
+    );
+}
+
+#[test]
+fn evaluate_selector_null() {
+    let value = json!({"a": null});
+    let tokens = parse_selector("a").expect("parse selector");
+    assert_eq!(evaluate_selector(&value, &tokens), Ok(SelectorValue::Null));
+}
+
+#[test]
+fn evaluate_selector_non_scalar() {
+    let value = json!({"a": {"b": 1}});
+    let tokens = parse_selector("a").expect("parse selector");
+    match evaluate_selector(&value, &tokens) {
+        Ok(SelectorValue::NonScalar(val)) => assert!(val.is_object()),
+        other => panic!("unexpected selector value: {:?}", other),
+    }
+}
+
+#[test]
+fn compact_json_is_minified() {
+    let value = json!({"a": 1, "b": [true, false]});
+    let compact = compact_json(&value).expect("compact json");
+    assert_eq!(compact, "{\"a\":1,\"b\":[true,false]}");
+}
+
+#[test]
+fn selector_is_top_level_only_for_simple_fields() {
+    assert!(selector_is_top_level("a"));
+    assert!(!selector_is_top_level("a.b"));
+    assert!(!selector_is_top_level("a[0]"));
+}

--- a/crates/floe-core/tests/unit/io/read/mod.rs
+++ b/crates/floe-core/tests/unit/io/read/mod.rs
@@ -1,4 +1,5 @@
 pub mod csv_nulls;
 pub mod json_array;
 pub mod json_ndjson;
+pub mod json_selector;
 pub mod parquet_input;


### PR DESCRIPTION
## Summary
This PR adds JSON selector extraction to support nested JSON inputs while keeping mismatch checks scoped to top-level keys. Selectors defined in `columns[].source` are now parsed and evaluated, with non-scalar handling that respects `cast_mode` (strict rejects the file, coerce stringifies the value).

## Problem
Nested JSON objects/arrays were previously rejected outright, which blocked ingestion of common JSON shapes and made `columns[].source` selectors unusable. Schema mismatch checks also treated all declared columns as top-level, which is incorrect once selectors can refer to nested paths.

## Root Cause
The JSON reader only accepted flat objects and rejected nested values during parsing. Mismatch planning did not account for selector semantics, so it compared all declared columns against top-level JSON keys.

## Fix
- Added a selector parser/evaluator for `a.b`, `a[0]`, and `a.b[0].c` patterns.
- JSON read pipeline now extracts values by selector into source-named columns and applies:
  - strict: reject file on non-scalar selector result
  - coerce: stringify non-scalar JSON into compact strings
- Mismatch planning for JSON now only considers top-level selectors (no `.` or `[`), while nested selectors are excluded from missing/extra checks.
- Retained existing CSV/Parquet behavior; only JSON extraction/mismatch changed.
- Added integration tests covering strict/coerce and top-level mismatch semantics, plus updated unit tests to reflect the new JSON behavior.

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all`
