### PR TITLE
release 0.2.4 prep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to Floe are documented in this file.
 
+## v0.2.4
+
+- Added new source input formats: `tsv`, `xlsx`, `fixed`, `orc`, `avro`, and `xml`.
+- Added nested JSON selector extraction from `schema.columns[].source` with top-level-only mismatch checks.
+- Added source-column mapping behavior (`source` as input selector, `name` as output column) in validation and run surfaces.
+- Added XML selector support (`.` or `/` paths and terminal `@attribute`) with required `source.options.row_tag`.
+- Dry-run now resolves inputs before execution, shows resolved file lists (with capped preview), and uses the same resolved plan as real runs.
+- Refactored runtime/storage boundaries to reduce format- and storage-specific coupling in run orchestration.
+
 ## v0.2.3
 
 - Added append/overwrite write modes for accepted parquet and delta outputs.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3114,7 +3114,7 @@ dependencies = [
 
 [[package]]
 name = "floe-cli"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "assert_cmd",
  "clap",
@@ -3127,7 +3127,7 @@ dependencies = [
 
 [[package]]
 name = "floe-core"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "apache-avro",
  "arrow",

--- a/crates/floe-cli/Cargo.toml
+++ b/crates/floe-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "floe-cli"
-version = "0.2.3"
+version = "0.2.4"
 edition = "2021"
 description = "CLI for Floe, a YAML-driven technical ingestion tool."
 license = "MIT"
@@ -17,7 +17,7 @@ path = "src/main.rs"
 
 [dependencies]
 clap = { version = "4", features = ["derive"] }
-floe-core = { path = "../floe-core", version = "0.2.3" }
+floe-core = { path = "../floe-core", version = "0.2.4" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 

--- a/crates/floe-core/Cargo.toml
+++ b/crates/floe-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "floe-core"
-version = "0.2.3"
+version = "0.2.4"
 edition = "2021"
 description = "Core library for Floe, a YAML-driven technical ingestion tool."
 license = "MIT"

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -11,6 +11,16 @@
   - Run reports are written under `<report.path>/run_<run_id>/...` as defined in the config.
   - `-c` accepts local paths or cloud URIs (`s3://`, `gs://`, `abfs://`).
   - `--log-format json` emits NDJSON events to stdout (useful for orchestrators).
+  - `--dry-run` resolves entity inputs and output targets without running ingestion.
+  - `--quiet` reduces console output to run totals.
+  - `--verbose` expands run output details.
+
+### Dry-run behavior
+
+- Dry-run resolves input files/objects using the same planning path as real runs.
+- For cloud sources, dry-run lists matching objects but does not download them.
+- Console preview prints resolved file count and a capped list (`50` entries by default).
+- Use `--verbose` to print the full resolved file list.
 
 ## Examples
 
@@ -22,6 +32,8 @@
   - `floe run -c example/config.yml --entities customer`
 - Run with JSON logs:
   - `floe run -c example/config.yml --entities customer --log-format json`
+- Dry-run preview:
+  - `floe run -c example/config.yml --entities customer --dry-run`
 - Report output:
     - `example/report/run_<run_id>/run.summary.json`
     - `example/report/run_<run_id>/customer/run.json`

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -8,6 +8,8 @@ entity. The order is deterministic and is reflected in reports.
 ### A) Entity planning (entity-level)
 
 1. Resolve input files/objects (local directory/glob or storage prefix).
+   - In normal runs, resolved cloud objects are then downloaded to temp files.
+   - In dry-run, resolution is list-only for cloud inputs (no downloads, no writes).
 2. Resolve storage targets for accepted/rejected/report outputs.
 3. Prepare output directories if needed.
 
@@ -15,10 +17,14 @@ entity. The order is deterministic and is reflected in reports.
 
 Floe inspects only the file header/schema before reading full data:
 
-- **CSV**: header row (or the first row for headerless CSV).
+- **CSV/TSV**: header row (or the first row for headerless CSV/TSV).
+- **Fixed-width**: declared schema widths and inferred columns from row slices.
 - **Parquet**: schema metadata.
+- **ORC**: schema metadata.
 - **NDJSON**: the first valid JSON object line.
 - **Avro**: writer schema fields.
+- **XLSX**: configured sheet header row.
+- **XML**: fields from the first matching `row_tag` element.
 
 Then it applies the schema mismatch policy:
 

--- a/docs/summary.md
+++ b/docs/summary.md
@@ -1,4 +1,4 @@
-# Floe Documentation Summary (v0.2)
+# Floe Documentation Summary
 
 This page is the entry point to Floe documentation. It groups the most
 important references so you can quickly find the right guide.
@@ -37,8 +37,12 @@ important references so you can quickly find the right guide.
 
 - Bench setup and results: [docs/benchmarking.md](benchmarking.md)
 
-## Notes for v0.2
+## Notes
 
+- Recent additions:
+  - New input formats: TSV, XLSX, fixed-width, ORC, Avro, and XML.
+  - `schema.columns[].source` now supports nested JSON selectors and XML selectors.
+  - Dry-run now resolves inputs ahead of execution and previews resolved files.
 - Cloud IO for CSV/JSON/Parquet uses temp download/upload (file-level IO).
 - Delta writes to cloud use transactional object_store (no temp upload).
 - Reports can be written to cloud storages via temp upload.


### PR DESCRIPTION
## Summary
This PR prepares Floe `v0.2.4` release metadata and docs:

- bumps crate versions to `0.2.4` (`floe-core`, `floe-cli`)
- updates `floe-cli -> floe-core` dependency to `0.2.4`
- refreshes `Cargo.lock` for the new package versions
- adds `v0.2.4` release notes to `CHANGELOG.md`
- updates documentation to cover missing behavior around dry-run resolution and expanded precheck/input coverage
- removes version-tag mention from docs summary (version tags remain in `CHANGELOG.md` only)

## Why
After merging the recent feature set (new input formats + source selector behavior + dry-run resolve-before-run), we needed a clean release branch that:

- reflects the new crate version
- documents user-facing behavior changes
- keeps version tags centralized in the changelog

Without this update, the published crate metadata and release notes would lag the actual behavior on `main`.

## Root Cause
The repository had already merged the features targeted for the next release, but release metadata (`Cargo.toml`/lockfile) and docs were still at `0.2.3` and did not fully describe the dry-run resolution improvements in the CLI/docs.

## Changes
### Versioning
- `crates/floe-core/Cargo.toml`: `0.2.3` -> `0.2.4`
- `crates/floe-cli/Cargo.toml`: `0.2.3` -> `0.2.4`
- `crates/floe-cli/Cargo.toml`: dependency `floe-core = 0.2.4`
- `Cargo.lock`: updated package versions to `0.2.4`

### Changelog
- Added `## v0.2.4` section in `CHANGELOG.md` covering:
  - new input formats (`tsv`, `xlsx`, `fixed`, `orc`, `avro`, `xml`)
  - nested JSON selector extraction behavior
  - source/target column mapping behavior (`source` vs `name`)
  - XML selector support
  - dry-run input resolution/preview behavior
  - runtime/storage refactor note

### Docs
- `docs/cli.md`
  - documented `--dry-run`, `--quiet`, `--verbose`
  - added dry-run behavior details (list-only cloud resolution, capped preview list, verbose full list)
  - added dry-run command example
- `docs/how-it-works.md`
  - clarified planning phase behavior for normal run vs dry-run
  - expanded precheck format coverage (`CSV/TSV`, `fixed`, `ORC`, `XLSX`, `XML`)
- `docs/summary.md`
  - removed explicit release tag mention and kept feature notes version-agnostic

## Validation
- `cargo check --workspace`
- `cargo test --workspace`
