### PR TITLE
[feature] add manifest generate CLI for airflow/dagster

### DIFF
--- a/crates/floe-cli/src/main.rs
+++ b/crates/floe-cli/src/main.rs
@@ -6,6 +6,7 @@ use floe_core::{
 use std::io::Write;
 
 use crate::logging::LogFormat;
+use crate::manifest_output::ManifestTarget;
 use crate::validate_output::ValidateOutputFormat;
 
 const VERSION: &str = env!("FLOE_VERSION");
@@ -62,7 +63,16 @@ const VALIDATE_LONG_ABOUT: &str = concat!(
     "  floe validate -c example/config.yml\n",
 );
 
+const MANIFEST_LONG_ABOUT: &str = concat!(
+    "Generate orchestrator manifest JSON from a validated Floe config.\n",
+    "\n",
+    "Examples:\n",
+    "  floe manifest generate -c example/config.yml --target airflow --output manifest.airflow.json\n",
+    "  floe manifest generate -c example/config.yml --target dagster --output -\n",
+);
+
 mod logging;
+mod manifest_output;
 mod output;
 mod validate_output;
 
@@ -128,6 +138,33 @@ enum Command {
         log_format: LogFormat,
         #[arg(long, help = "Resolve and print inputs/outputs without executing")]
         dry_run: bool,
+    },
+    #[command(
+        about = "Generate orchestrator manifest JSON",
+        long_about = MANIFEST_LONG_ABOUT
+    )]
+    Manifest {
+        #[command(subcommand)]
+        command: ManifestCommand,
+    },
+}
+
+#[derive(Subcommand, Debug)]
+enum ManifestCommand {
+    #[command(about = "Generate a manifest JSON file")]
+    Generate {
+        #[arg(short, long, help = "Path or URI to the Floe config file")]
+        config: String,
+        #[arg(long, value_enum, help = "Manifest target (airflow|dagster)")]
+        target: ManifestTarget,
+        #[arg(short, long, help = "Output path for manifest JSON, or '-' for stdout")]
+        output: String,
+        #[arg(
+            long,
+            value_delimiter = ',',
+            help = "Optional comma-separated list of entity names"
+        )]
+        entities: Vec<String>,
     },
 }
 
@@ -310,5 +347,50 @@ fn main() -> FloeResult<()> {
 
             std::process::exit(outcome.summary.run.exit_code);
         }
+        Command::Manifest { command } => match command {
+            ManifestCommand::Generate {
+                config,
+                target,
+                output,
+                entities,
+            } => {
+                let config_location = match resolve_config_location(&config) {
+                    Ok(location) => location,
+                    Err(err) => {
+                        let mut err_out = std::io::stderr().lock();
+                        let _ = writeln!(err_out, "Error: {err}");
+                        let _ = err_out.flush();
+                        std::process::exit(1);
+                    }
+                };
+
+                let options = ValidateOptions {
+                    entities: entities.clone(),
+                };
+                if let Err(err) =
+                    validate_with_base(&config_location.path, config_location.base.clone(), options)
+                {
+                    let mut err_out = std::io::stderr().lock();
+                    let _ = writeln!(err_out, "Error: {err}");
+                    let _ = err_out.flush();
+                    std::process::exit(1);
+                }
+
+                let config = load_config(&config_location.path)?;
+                let manifest_json = manifest_output::build_manifest_json(
+                    &config_location,
+                    &config,
+                    target,
+                    &entities,
+                )?;
+                manifest_output::write_manifest(&output, &manifest_json)?;
+                if output != "-" {
+                    let mut out = std::io::stdout().lock();
+                    let _ = writeln!(out, "Manifest written: {output}");
+                    let _ = out.flush();
+                }
+                Ok(())
+            }
+        },
     }
 }

--- a/crates/floe-cli/src/manifest_output.rs
+++ b/crates/floe-cli/src/manifest_output.rs
@@ -1,0 +1,184 @@
+use clap::ValueEnum;
+use floe_core::config::{RootConfig, StorageResolver};
+use floe_core::{ConfigLocation, FloeResult};
+use serde::Serialize;
+use std::fs;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+#[derive(ValueEnum, Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ManifestTarget {
+    Airflow,
+    Dagster,
+}
+
+impl ManifestTarget {
+    fn schema(self) -> &'static str {
+        match self {
+            ManifestTarget::Airflow => "floe.airflow.manifest.v1",
+            ManifestTarget::Dagster => "floe.dagster.manifest.v1",
+        }
+    }
+}
+
+#[derive(Serialize)]
+struct ManifestOutput {
+    schema: &'static str,
+    generated_at_ts_ms: u64,
+    floe_version: &'static str,
+    config_uri: String,
+    config_checksum: Option<String>,
+    entities: Vec<ManifestEntity>,
+}
+
+#[derive(Serialize)]
+struct ManifestEntity {
+    name: String,
+    domain: Option<String>,
+    group_name: String,
+    asset_key: Vec<String>,
+    source_format: String,
+    accepted_sink_uri: String,
+    rejected_sink_uri: Option<String>,
+}
+
+struct ResolvedOrRaw {
+    uri: String,
+}
+
+pub fn build_manifest_json(
+    config_location: &ConfigLocation,
+    config: &RootConfig,
+    target: ManifestTarget,
+    selected_entities: &[String],
+) -> FloeResult<String> {
+    let resolver = StorageResolver::new(config, config_location.base.clone())?;
+
+    let mut entities: Vec<_> = if selected_entities.is_empty() {
+        config.entities.iter().collect()
+    } else {
+        config
+            .entities
+            .iter()
+            .filter(|entity| selected_entities.iter().any(|name| name == &entity.name))
+            .collect()
+    };
+    entities.sort_by(|left, right| left.name.cmp(&right.name));
+
+    let mut manifest_entities = Vec::with_capacity(entities.len());
+    for entity in entities {
+        let accepted = resolve_or_raw(
+            &resolver,
+            &entity.name,
+            "sink.accepted.path",
+            entity.sink.accepted.storage.as_deref(),
+            &entity.sink.accepted.path,
+        );
+
+        let rejected = entity.sink.rejected.as_ref().map(|target| {
+            resolve_or_raw(
+                &resolver,
+                &entity.name,
+                "sink.rejected.path",
+                target.storage.as_deref(),
+                &target.path,
+            )
+        });
+
+        let (asset_key, group_name) = if let Some(domain) = &entity.domain {
+            (vec![domain.clone(), entity.name.clone()], domain.clone())
+        } else {
+            (vec![entity.name.clone()], "floe".to_string())
+        };
+
+        manifest_entities.push(ManifestEntity {
+            name: entity.name.clone(),
+            domain: entity.domain.clone(),
+            group_name,
+            asset_key,
+            source_format: entity.source.format.clone(),
+            accepted_sink_uri: accepted.uri,
+            rejected_sink_uri: rejected.map(|value| value.uri),
+        });
+    }
+
+    let output = ManifestOutput {
+        schema: target.schema(),
+        generated_at_ts_ms: now_ts_ms(),
+        floe_version: env!("FLOE_VERSION"),
+        config_uri: config_location.display.clone(),
+        config_checksum: None,
+        entities: manifest_entities,
+    };
+
+    Ok(serde_json::to_string_pretty(&output)?)
+}
+
+pub fn write_manifest(output_path: &str, payload: &str) -> FloeResult<()> {
+    if output_path == "-" {
+        let mut out = std::io::stdout().lock();
+        writeln!(out, "{payload}")?;
+        out.flush()?;
+        return Ok(());
+    }
+
+    write_atomic(Path::new(output_path), payload.as_bytes())
+}
+
+fn write_atomic(path: &Path, bytes: &[u8]) -> FloeResult<()> {
+    if let Some(parent) = path.parent() {
+        if !parent.as_os_str().is_empty() {
+            fs::create_dir_all(parent)?;
+        }
+    }
+
+    let tmp_path = temp_path(path);
+    fs::write(&tmp_path, bytes)?;
+
+    if let Err(rename_err) = fs::rename(&tmp_path, path) {
+        if path.exists() {
+            fs::remove_file(path)?;
+            fs::rename(&tmp_path, path)?;
+        } else {
+            let _ = fs::remove_file(&tmp_path);
+            return Err(Box::new(rename_err));
+        }
+    }
+
+    Ok(())
+}
+
+fn temp_path(path: &Path) -> PathBuf {
+    let stamp = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|value| value.as_nanos())
+        .unwrap_or(0);
+    let filename = path
+        .file_name()
+        .map(|value| value.to_string_lossy().to_string())
+        .unwrap_or_else(|| "manifest.json".to_string());
+    path.with_file_name(format!(".{filename}.{stamp}.tmp"))
+}
+
+fn resolve_or_raw(
+    resolver: &StorageResolver,
+    entity_name: &str,
+    field: &str,
+    storage_name: Option<&str>,
+    raw_path: &str,
+) -> ResolvedOrRaw {
+    match resolver.resolve_path(entity_name, field, storage_name, raw_path) {
+        Ok(resolved) => ResolvedOrRaw { uri: resolved.uri },
+        Err(_) => ResolvedOrRaw {
+            uri: raw_path.to_string(),
+        },
+    }
+}
+
+fn now_ts_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_millis() as u64)
+        .unwrap_or(0)
+}

--- a/crates/floe-cli/tests/manifest_output.rs
+++ b/crates/floe-cli/tests/manifest_output.rs
@@ -1,0 +1,103 @@
+use assert_cmd::Command;
+use predicates::prelude::*;
+use serde_json::Value;
+use std::fs;
+use std::path::PathBuf;
+use tempfile::tempdir;
+
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../..")
+}
+
+#[test]
+fn manifest_generate_airflow_to_file() {
+    let config_path = repo_root().join("example/config.yml");
+    let expected_config_uri = std::fs::canonicalize(&config_path)
+        .expect("canonicalize config path")
+        .display()
+        .to_string();
+    let tmp = tempdir().expect("create temp dir");
+    let output_path = tmp.path().join("manifest.airflow.json");
+
+    let mut cmd = Command::new(assert_cmd::cargo::cargo_bin!("floe"));
+    cmd.args(["manifest", "generate", "-c"])
+        .arg(&config_path)
+        .args(["--target", "airflow", "--output"])
+        .arg(&output_path)
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Manifest written:"));
+
+    let payload = fs::read_to_string(&output_path).expect("manifest file exists");
+    let value: Value = serde_json::from_str(&payload).expect("manifest should be valid json");
+
+    assert_eq!(value["schema"], "floe.airflow.manifest.v1");
+    assert_eq!(value["config_uri"], expected_config_uri);
+
+    let entities = value["entities"].as_array().expect("entities array");
+    let names: Vec<_> = entities
+        .iter()
+        .map(|entity| entity["name"].as_str().unwrap().to_string())
+        .collect();
+    assert_eq!(names, vec!["customer", "orders"]);
+
+    let first_asset_key = entities[0]["asset_key"].as_array().unwrap();
+    assert!(!first_asset_key.is_empty());
+}
+
+#[test]
+fn manifest_generate_dagster_to_stdout() {
+    let config_path = repo_root().join("example/config.yml");
+
+    let mut cmd = Command::new(assert_cmd::cargo::cargo_bin!("floe"));
+    let assert = cmd
+        .args(["manifest", "generate", "-c"])
+        .arg(&config_path)
+        .args(["--target", "dagster", "--output", "-"])
+        .assert()
+        .success();
+
+    let stdout = String::from_utf8_lossy(&assert.get_output().stdout);
+    let value: Value = serde_json::from_str(stdout.trim()).expect("stdout should be json");
+    assert_eq!(value["schema"], "floe.dagster.manifest.v1");
+}
+
+#[test]
+fn manifest_generate_with_entity_filter() {
+    let config_path = repo_root().join("example/config.yml");
+
+    let mut cmd = Command::new(assert_cmd::cargo::cargo_bin!("floe"));
+    let assert = cmd
+        .args(["manifest", "generate", "-c"])
+        .arg(&config_path)
+        .args([
+            "--target",
+            "airflow",
+            "--entities",
+            "orders",
+            "--output",
+            "-",
+        ])
+        .assert()
+        .success();
+
+    let stdout = String::from_utf8_lossy(&assert.get_output().stdout);
+    let value: Value = serde_json::from_str(stdout.trim()).expect("stdout should be json");
+    let entities = value["entities"].as_array().expect("entities array");
+    assert_eq!(entities.len(), 1);
+    assert_eq!(entities[0]["name"], "orders");
+}
+
+#[test]
+fn manifest_generate_invalid_config_fails() {
+    let fixture_path =
+        PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/invalid_config.yml");
+
+    let mut cmd = Command::new(assert_cmd::cargo::cargo_bin!("floe"));
+    cmd.args(["manifest", "generate", "-c"])
+        .arg(&fixture_path)
+        .args(["--target", "airflow", "--output", "-"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("Error:"));
+}

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -15,6 +15,12 @@
   - `--quiet` reduces console output to run totals.
   - `--verbose` expands run output details.
 
+- `floe manifest generate -c <config> --target airflow|dagster --output <path|-> [--entities <name[,name...]>]`
+  - Validate config and generate orchestrator manifest JSON.
+  - `--target airflow` outputs `schema=floe.airflow.manifest.v1`.
+  - `--target dagster` outputs `schema=floe.dagster.manifest.v1`.
+  - `--output -` writes manifest JSON to stdout.
+
 ### Dry-run behavior
 
 - Dry-run resolves input files/objects using the same planning path as real runs.
@@ -34,6 +40,10 @@
   - `floe run -c example/config.yml --entities customer --log-format json`
 - Dry-run preview:
   - `floe run -c example/config.yml --entities customer --dry-run`
+- Generate Airflow manifest:
+  - `floe manifest generate -c example/config.yml --target airflow --output orchestrators/airflow-floe/example/manifest.airflow.json`
+- Generate Dagster manifest:
+  - `floe manifest generate -c example/config.yml --target dagster --output -`
 - Report output:
     - `example/report/run_<run_id>/run.summary.json`
     - `example/report/run_<run_id>/customer/run.json`

--- a/orchestrators/dagster-floe/schemas/floe.dagster.manifest.v1.json
+++ b/orchestrators/dagster-floe/schemas/floe.dagster.manifest.v1.json
@@ -1,0 +1,95 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/malon64/floe/orchestrators/dagster-floe/schemas/floe.dagster.manifest.v1.json",
+  "title": "Floe Dagster Manifest v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema",
+    "generated_at_ts_ms",
+    "config_uri",
+    "entities"
+  ],
+  "properties": {
+    "schema": {
+      "const": "floe.dagster.manifest.v1"
+    },
+    "generated_at_ts_ms": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "floe_version": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "config_uri": {
+      "type": "string",
+      "minLength": 1
+    },
+    "config_checksum": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "entities": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/entity"
+      }
+    }
+  },
+  "$defs": {
+    "entity": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "name",
+        "group_name",
+        "source_format",
+        "accepted_sink_uri",
+        "asset_key"
+      ],
+      "properties": {
+        "name": {
+          "type": "string",
+          "minLength": 1
+        },
+        "domain": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "group_name": {
+          "type": "string",
+          "minLength": 1
+        },
+        "source_format": {
+          "type": "string",
+          "minLength": 1
+        },
+        "accepted_sink_uri": {
+          "type": "string",
+          "minLength": 1
+        },
+        "rejected_sink_uri": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "asset_key": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
This PR adds a new manifest generation command in the Floe CLI so orchestrator integrations can consume a stable, versioned artifact without re-parsing runtime logs.

New command:
- `floe manifest generate -c <config> --target airflow|dagster --output <path|-> [--entities ...]`

It validates the config first, then emits a strict JSON manifest for the selected target.

## Problem / User impact
Before this change, we had no dedicated CLI command to materialize a target manifest from Floe config. That forced orchestrator-side adapters to either:
- depend on `floe validate --output json` internals, or
- duplicate planning logic.

Both options increase coupling and make parse-time orchestration less stable.

## Root cause
Manifest generation was discussed in the integration spec, but not yet implemented in `floe-cli` as a first-class command with target-specific schema id.

## What changed
### CLI
- Added top-level subcommand:
  - `manifest generate`
- Added `--target airflow|dagster` and `--output <path|->`.
- Supports `--entities` filtering (same behavior style as existing commands).

### Manifest payload generation
- New module: `crates/floe-cli/src/manifest_output.rs`
- Emits deterministic, sorted entities.
- Uses `StorageResolver` to resolve accepted/rejected sink URIs.
- Falls back to raw configured path if URI resolution fails.
- Supports stdout output (`--output -`) and atomic file write for file outputs.

### Output contract
Produced JSON fields:
- `schema` (`floe.airflow.manifest.v1` or `floe.dagster.manifest.v1`)
- `generated_at_ts_ms`
- `floe_version`
- `config_uri`
- `config_checksum` (currently `null`)
- `entities[]` with:
  - `name`, `domain`, `group_name`, `asset_key`
  - `source_format`
  - `accepted_sink_uri`
  - `rejected_sink_uri`

### Tests
- Added `crates/floe-cli/tests/manifest_output.rs` covering:
  - airflow manifest generation to file
  - dagster manifest generation to stdout
  - entity filter behavior
  - invalid config failure path

### Docs / schema
- Updated CLI docs: `docs/cli.md`
- Added Dagster manifest schema file:
  - `orchestrators/dagster-floe/schemas/floe.dagster.manifest.v1.json`

## Backward compatibility
- No behavior change for existing `validate` / `run` commands.
- New functionality is additive.

## Validation run
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all`

All passed locally.

## Related
- Related to orchestration manifest work tracked under #142.
