### PR TITLE
[codex] Bump connector package versions before release tags

### DIFF
--- a/orchestrators/airflow-floe/pyproject.toml
+++ b/orchestrators/airflow-floe/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "airflow-floe"
-version = "0.1.0"
+version = "0.1.2"
 description = "Airflow connector for Floe CLI (manifest-first orchestration)"
 requires-python = ">=3.10"
 readme = "README.md"

--- a/orchestrators/dagster-floe/pyproject.toml
+++ b/orchestrators/dagster-floe/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "dagster-floe"
-version = "0.1.0"
+version = "0.1.1"
 description = "Dagster connector for Floe CLI (config-driven ingestion)"
 requires-python = ">=3.10"
 readme = "README.md"


### PR DESCRIPTION
## Summary
This PR bumps connector package versions so tag-triggered PyPI releases can publish successfully.

## Changes
- `orchestrators/airflow-floe/pyproject.toml`
  - `version = "0.1.2"`
- `orchestrators/dagster-floe/pyproject.toml`
  - `version = "0.1.1"`

## Why
Release workflows are tag-driven (`airflow-floe-v*`, `dagster-floe-v*`), but PyPI rejects duplicate package versions.
Current published versions are already `0.1.0` for both packages, so this bump is required before tagging.

## Follow-up after merge
- tag `airflow-floe-v0.1.2`
- tag `dagster-floe-v0.1.1`
