### PR TITLE
[codex] add-entity bootstrap config creation and default inference

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3353,7 +3353,7 @@ dependencies = [
 
 [[package]]
 name = "floe-cli"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "assert_cmd",
  "clap",
@@ -3366,7 +3366,7 @@ dependencies = [
 
 [[package]]
 name = "floe-core"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "apache-avro 0.16.0",
  "arrow",
@@ -7108,7 +7108,7 @@ version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
 dependencies = [
- "indexmap",
+ "indexmap 2.13.0",
  "itoa",
  "ryu",
  "serde",

--- a/crates/floe-cli/src/main.rs
+++ b/crates/floe-cli/src/main.rs
@@ -75,9 +75,12 @@ const ADD_ENTITY_LONG_ABOUT: &str = concat!(
     "v0.3 scope:\n",
     "  - Supports csv, json, parquet input inference\n",
     "  - JSON inference uses top-level keys only (nested values are inferred as string)\n",
+    "  - Creates a minimal config when -c points to a missing file\n",
+    "  - Infers --format from file extension when omitted (.csv, .json, .parquet)\n",
+    "  - Infers --name from the input filename stem when omitted\n",
     "\n",
     "Example:\n",
-    "  floe add-entity -c config.yml --input ./in/customers.csv --format csv --name customers\n",
+    "  floe add-entity -c config.yml --input ./in/customers.csv\n",
 );
 
 mod logging;
@@ -156,8 +159,12 @@ enum Command {
         config: String,
         #[arg(long, help = "Input file path or file:// URI to infer schema from")]
         input: String,
-        #[arg(long, value_enum, help = "Input format (csv|json|parquet)")]
-        format: AddEntityFormat,
+        #[arg(
+            long,
+            value_enum,
+            help = "Input format (csv|json|parquet). If omitted, infer from file extension"
+        )]
+        format: Option<AddEntityFormat>,
         #[arg(long, help = "Entity name (defaults to input file stem)")]
         name: Option<String>,
         #[arg(long, help = "Optional entity domain to set")]
@@ -394,7 +401,7 @@ fn main() -> FloeResult<()> {
                 config_path,
                 output_path,
                 input,
-                format: format.as_str().to_string(),
+                format: format.as_ref().map(|value| value.as_str().to_string()),
                 name,
                 domain,
                 dry_run,

--- a/crates/floe-cli/tests/add_entity.rs
+++ b/crates/floe-cli/tests/add_entity.rs
@@ -7,10 +7,9 @@ use tempfile::tempdir;
 fn add_entity_writes_config_that_validates() {
     let dir = tempdir().expect("tempdir");
     let config_path = dir.path().join("config.yml");
-    let input_path = dir.path().join("customers.csv");
+    let input_path = dir.path().join("orders.csv");
 
-    fs::write(&config_path, "version: \"0.2\"\nentities: []\n").expect("write config");
-    fs::write(&input_path, "id,name\n1,Alice\n2,Bob\n").expect("write csv");
+    fs::write(&input_path, "id,total\n1,10.0\n2,20.0\n").expect("write csv");
 
     let mut add_cmd = Command::new(assert_cmd::cargo::cargo_bin!("floe"));
     add_cmd
@@ -18,17 +17,41 @@ fn add_entity_writes_config_that_validates() {
         .arg(&config_path)
         .args(["--input"])
         .arg(&input_path)
-        .args(["--format", "csv", "--name", "customers"])
         .assert()
         .success()
-        .stdout(predicate::str::contains("Entity added: customers"));
+        .stdout(predicate::str::contains("Entity added: orders"))
+        .stdout(predicate::str::contains("format=csv"));
 
     let mut validate_cmd = Command::new(assert_cmd::cargo::cargo_bin!("floe"));
     validate_cmd
         .args(["validate", "-c"])
         .arg(&config_path)
-        .args(["--entities", "customers"])
+        .args(["--entities", "orders"])
         .assert()
         .success()
         .stdout(predicate::str::contains("Config valid:"));
+}
+
+#[test]
+fn add_entity_dry_run_does_not_write_config_file() {
+    let dir = tempdir().expect("tempdir");
+    let config_path = dir.path().join("new-config.yml");
+    let input_path = dir.path().join("employees.csv");
+
+    fs::write(&input_path, "id,name\n1,Alice\n").expect("write csv");
+    assert!(!config_path.exists());
+
+    let mut cmd = Command::new(assert_cmd::cargo::cargo_bin!("floe"));
+    cmd.args(["add-entity", "-c"])
+        .arg(&config_path)
+        .args(["--input"])
+        .arg(&input_path)
+        .arg("--dry-run")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("# add-entity dry run"))
+        .stdout(predicate::str::contains("name: employees"))
+        .stdout(predicate::str::contains("format: csv"));
+
+    assert!(!config_path.exists());
 }

--- a/crates/floe-core/src/add_entity.rs
+++ b/crates/floe-core/src/add_entity.rs
@@ -15,13 +15,14 @@ use crate::errors::IoError;
 use crate::{ConfigError, FloeResult, ValidateOptions};
 
 const DEFAULT_SAMPLE_ROWS: usize = 200;
+const MINIMAL_CONFIG_YAML: &str = "version: \"0.2\"\nentities: []\n";
 
 #[derive(Debug, Clone)]
 pub struct AddEntityOptions {
     pub config_path: PathBuf,
     pub output_path: Option<PathBuf>,
     pub input: String,
-    pub format: String,
+    pub format: Option<String>,
     pub name: Option<String>,
     pub domain: Option<String>,
     pub dry_run: bool,
@@ -150,7 +151,7 @@ struct JsonColumnStats {
 pub fn add_entity_to_config(options: AddEntityOptions) -> FloeResult<AddEntityOutcome> {
     let inferred = infer_entity_from_input(
         &options.input,
-        options.format.as_str(),
+        options.format.as_deref(),
         options.name.as_deref(),
         options.domain.as_deref(),
     )?;
@@ -159,12 +160,7 @@ pub fn add_entity_to_config(options: AddEntityOptions) -> FloeResult<AddEntityOu
         .output_path
         .clone()
         .unwrap_or_else(|| options.config_path.clone());
-    let config_text = fs::read_to_string(&options.config_path).map_err(|err| {
-        Box::new(IoError(format!(
-            "failed to read config at {}: {err}",
-            options.config_path.display()
-        ))) as Box<dyn std::error::Error + Send + Sync>
-    })?;
+    let config_text = load_or_initialize_config_text(&options.config_path)?;
 
     let updated_yaml = append_entity_yaml(&config_text, &inferred)?;
     if !options.dry_run {
@@ -205,7 +201,7 @@ pub fn add_entity_to_config(options: AddEntityOptions) -> FloeResult<AddEntityOu
 
 fn infer_entity_from_input(
     input: &str,
-    format: &str,
+    format_override: Option<&str>,
     name_override: Option<&str>,
     domain: Option<&str>,
 ) -> FloeResult<InferredEntity> {
@@ -220,8 +216,9 @@ fn infer_entity_from_input(
     }
 
     let local_input_path = resolve_local_input_path(input)?;
+    let format = resolve_add_entity_format(format_override, input, &local_input_path)?;
     let persisted_input_path = normalize_persisted_input_path(input, &local_input_path);
-    let (source_options, columns, notes) = match format {
+    let (source_options, columns, notes) = match format.as_str() {
         "csv" => infer_csv_columns(&local_input_path)?,
         "json" => infer_json_columns(&local_input_path)?,
         "parquet" => infer_parquet_columns(&local_input_path)?,
@@ -241,13 +238,53 @@ fn infer_entity_from_input(
 
     Ok(InferredEntity {
         name: entity_name,
-        format: format.to_string(),
+        format,
         input: persisted_input_path,
         domain: domain.map(ToString::to_string),
         source_options,
         columns,
         notes,
     })
+}
+
+fn load_or_initialize_config_text(config_path: &Path) -> FloeResult<String> {
+    match fs::read_to_string(config_path) {
+        Ok(text) => Ok(text),
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
+            Ok(MINIMAL_CONFIG_YAML.to_string())
+        }
+        Err(err) => Err(Box::new(IoError(format!(
+            "failed to read config at {}: {err}",
+            config_path.display()
+        )))),
+    }
+}
+
+fn resolve_add_entity_format(
+    format_override: Option<&str>,
+    input: &str,
+    local_input_path: &Path,
+) -> FloeResult<String> {
+    if let Some(format) = format_override {
+        return Ok(format.to_string());
+    }
+
+    infer_format_from_extension(local_input_path).ok_or_else(|| {
+        Box::new(ConfigError(format!(
+            "could not infer add-entity format from input {} (supported extensions: .csv, .json, .parquet); use --format",
+            input
+        ))) as Box<dyn std::error::Error + Send + Sync>
+    })
+}
+
+fn infer_format_from_extension(path: &Path) -> Option<String> {
+    let ext = path.extension()?.to_string_lossy().to_ascii_lowercase();
+    match ext.as_str() {
+        "csv" => Some("csv".to_string()),
+        "json" => Some("json".to_string()),
+        "parquet" => Some("parquet".to_string()),
+        _ => None,
+    }
 }
 
 fn infer_csv_columns(

--- a/crates/floe-core/tests/unit/config/add_entity.rs
+++ b/crates/floe-core/tests/unit/config/add_entity.rs
@@ -1,11 +1,26 @@
 use std::fs;
+use std::path::{Path, PathBuf};
 
 use floe_core::{add_entity_to_config, load_config, validate, AddEntityOptions, ValidateOptions};
+use polars::prelude::{DataFrame, NamedFrom, ParquetWriter, Series};
 use tempfile::tempdir;
 use url::Url;
 
 fn write_file(path: &std::path::Path, contents: &str) {
     fs::write(path, contents).expect("write test file");
+}
+
+fn write_parquet(path: &Path) -> PathBuf {
+    let mut df = DataFrame::new(vec![
+        Series::new("employee_id".into(), vec![1_i64, 2_i64]).into(),
+        Series::new("active".into(), vec![true, false]).into(),
+    ])
+    .expect("dataframe");
+    let file = fs::File::create(path).expect("create parquet");
+    ParquetWriter::new(file)
+        .finish(&mut df)
+        .expect("write parquet");
+    path.to_path_buf()
 }
 
 fn base_config_yaml() -> &'static str {
@@ -34,7 +49,7 @@ fn add_entity_infers_csv_and_appends_defaults() {
         config_path: config_path.clone(),
         output_path: None,
         input: input_path.display().to_string(),
-        format: "csv".to_string(),
+        format: Some("csv".to_string()),
         name: Some("customers".to_string()),
         domain: Some("sales".to_string()),
         dry_run: false,
@@ -105,7 +120,7 @@ fn add_entity_infers_json_top_level_keys_only() {
         config_path: config_path.clone(),
         output_path: None,
         input: input_path.display().to_string(),
-        format: "json".to_string(),
+        format: Some("json".to_string()),
         name: None,
         domain: None,
         dry_run: false,
@@ -173,7 +188,7 @@ fn add_entity_normalizes_file_uri_before_persisting_source_path() {
         config_path: config_path.clone(),
         output_path: None,
         input: input_uri,
-        format: "csv".to_string(),
+        format: Some("csv".to_string()),
         name: Some("customers".to_string()),
         domain: None,
         dry_run: false,
@@ -184,4 +199,170 @@ fn add_entity_normalizes_file_uri_before_persisting_source_path() {
     let entity = config.entities.first().expect("entity");
     assert_eq!(entity.source.path, input_path.display().to_string());
     assert!(!entity.source.path.starts_with("file://"));
+}
+
+#[test]
+fn add_entity_bootstraps_missing_config_file() {
+    let dir = tempdir().expect("tempdir");
+    let config_path = dir.path().join("new.yml");
+    let input_path = dir.path().join("orders.csv");
+
+    write_file(&input_path, "id,total\n1,10.1\n");
+    assert!(!config_path.exists());
+
+    let outcome = add_entity_to_config(AddEntityOptions {
+        config_path: config_path.clone(),
+        output_path: None,
+        input: input_path.display().to_string(),
+        format: None,
+        name: None,
+        domain: None,
+        dry_run: false,
+    })
+    .expect("bootstrap config and add entity");
+
+    assert!(config_path.exists());
+    assert_eq!(outcome.entity_name, "orders");
+    assert_eq!(outcome.format, "csv");
+    validate(&config_path, ValidateOptions::default()).expect("validate bootstrapped config");
+}
+
+#[test]
+fn add_entity_infers_name_from_file_uri_stem_by_default() {
+    let dir = tempdir().expect("tempdir");
+    let config_path = dir.path().join("config.yml");
+    let input_path = dir.path().join("order_events.json");
+    write_file(&config_path, "version: \"0.2\"\nentities: []\n");
+    write_file(&input_path, "[{\"id\":1}]");
+
+    let input_uri = Url::from_file_path(&input_path)
+        .expect("file url")
+        .to_string();
+    let outcome = add_entity_to_config(AddEntityOptions {
+        config_path: config_path.clone(),
+        output_path: None,
+        input: input_uri,
+        format: None,
+        name: None,
+        domain: None,
+        dry_run: false,
+    })
+    .expect("add entity");
+
+    assert_eq!(outcome.entity_name, "order_events");
+    let config = load_config(&config_path).expect("load config");
+    assert_eq!(config.entities[0].name, "order_events");
+}
+
+#[test]
+fn add_entity_infers_format_from_extension_csv_json_and_parquet() {
+    let dir = tempdir().expect("tempdir");
+
+    let csv_config = dir.path().join("csv.yml");
+    let csv_input = dir.path().join("orders.csv");
+    write_file(&csv_input, "id\n1\n");
+    add_entity_to_config(AddEntityOptions {
+        config_path: csv_config.clone(),
+        output_path: None,
+        input: csv_input.display().to_string(),
+        format: None,
+        name: None,
+        domain: None,
+        dry_run: false,
+    })
+    .expect("csv inferred");
+    assert_eq!(
+        load_config(&csv_config).expect("csv cfg").entities[0]
+            .source
+            .format,
+        "csv"
+    );
+
+    let json_config = dir.path().join("json.yml");
+    let json_input = dir.path().join("events.json");
+    write_file(&json_input, "[{\"id\":1}]");
+    add_entity_to_config(AddEntityOptions {
+        config_path: json_config.clone(),
+        output_path: None,
+        input: json_input.display().to_string(),
+        format: None,
+        name: None,
+        domain: None,
+        dry_run: false,
+    })
+    .expect("json inferred");
+    assert_eq!(
+        load_config(&json_config).expect("json cfg").entities[0]
+            .source
+            .format,
+        "json"
+    );
+
+    let parquet_config = dir.path().join("parquet.yml");
+    let parquet_input = write_parquet(&dir.path().join("employees.parquet"));
+    add_entity_to_config(AddEntityOptions {
+        config_path: parquet_config.clone(),
+        output_path: None,
+        input: parquet_input.display().to_string(),
+        format: None,
+        name: None,
+        domain: None,
+        dry_run: false,
+    })
+    .expect("parquet inferred");
+    assert_eq!(
+        load_config(&parquet_config).expect("parquet cfg").entities[0]
+            .source
+            .format,
+        "parquet"
+    );
+}
+
+#[test]
+fn add_entity_explicit_name_and_format_override_inferred_values() {
+    let dir = tempdir().expect("tempdir");
+    let config_path = dir.path().join("config.yml");
+    let input_path = dir.path().join("strange_name.data");
+
+    write_file(&input_path, "id,name\n1,Alice\n");
+
+    let outcome = add_entity_to_config(AddEntityOptions {
+        config_path: config_path.clone(),
+        output_path: None,
+        input: input_path.display().to_string(),
+        format: Some("csv".to_string()),
+        name: Some("customers_override".to_string()),
+        domain: None,
+        dry_run: false,
+    })
+    .expect("add entity");
+
+    assert_eq!(outcome.entity_name, "customers_override");
+    assert_eq!(outcome.format, "csv");
+    let config = load_config(&config_path).expect("load config");
+    let entity = &config.entities[0];
+    assert_eq!(entity.name, "customers_override");
+    assert_eq!(entity.source.format, "csv");
+}
+
+#[test]
+fn add_entity_unknown_extension_requires_explicit_format() {
+    let dir = tempdir().expect("tempdir");
+    let config_path = dir.path().join("config.yml");
+    let input_path = dir.path().join("payload.unknown");
+
+    write_file(&input_path, "some,data\n");
+
+    let err = add_entity_to_config(AddEntityOptions {
+        config_path,
+        output_path: None,
+        input: input_path.display().to_string(),
+        format: None,
+        name: None,
+        domain: None,
+        dry_run: false,
+    })
+    .expect_err("unknown extension should require --format");
+
+    assert!(err.to_string().contains("use --format"));
 }

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -18,8 +18,11 @@
   - Validate config and generate a common orchestrator manifest JSON (`schema=floe.manifest.v1`).
   - `--output -` writes manifest JSON to stdout.
 
-- `floe add-entity -c <config> --input <path|file://...> --format csv|json|parquet [--name <entity>] [--domain <domain>]`
+- `floe add-entity -c <config> --input <path|file://...> [--format csv|json|parquet] [--name <entity>] [--domain <domain>]`
   - Infer a schema from an input file and append a new entity to `entities[]`.
+  - If `-c` points to a missing file, Floe creates a minimal config and adds the entity.
+  - If `--format` is omitted, Floe infers it from the input file extension (`.csv`, `.json`, `.parquet`).
+  - If `--name` is omitted, Floe infers it from the input filename stem.
   - Generates defaults for `sink`, `policy`, and `schema.mismatch`.
   - JSON inference is v0.3 bootstrap-focused: top-level keys only; nested objects/arrays are inferred as `string`.
   - `--dry-run` prints the updated YAML without writing.
@@ -49,6 +52,8 @@
   - `floe manifest generate -c example/config.yml --output -`
 - Add an entity from a CSV file:
   - `floe add-entity -c example/config.yml --input ./in/customers.csv --format csv --name customers`
+- Bootstrap a new config file and infer name/format:
+  - `floe add-entity -c new-config.yml --input ./in/orders.csv`
 - Report output:
   - `example/report/run_<run_id>/run.summary.json`
   - `example/report/run_<run_id>/customer/run.json`


### PR DESCRIPTION
Closes #164

## Summary

This PR improves the UX of the existing `floe add-entity` command (introduced in #158) by adding bootstrap config creation and default name/format inference.

`#158` added the feature itself. This PR is the UX/bootstrap follow-up requested in `#164`.

## What changed

### 1) Bootstrap config creation when `-c` target does not exist

`floe add-entity` now auto-creates a minimal valid config when the target config file is missing.

Minimal config used:

```yaml
version: "0.2"
entities: []
```

The command then appends the inferred entity and validates the generated config before writing.

### 2) Default entity name inference (`--name` optional)

If `--name` is omitted, the entity name is inferred from the input filename stem:

- `orders.csv` -> `orders`
- `/tmp/hr/employees.parquet` -> `employees`
- `file:///tmp/sales/order_events.json` -> `order_events`

This reuses the existing filename-stem logic (including `file://` handling).

### 3) Default format inference (`--format` optional)

If `--format` is omitted, Floe infers the source format from the input file extension:

- `.csv` -> `csv`
- `.json` -> `json`
- `.parquet` -> `parquet`

If the extension is unknown, the command fails with a clear error telling the user to pass `--format` explicitly.

## Examples

### Create missing config + add entity (bootstrap)

```bash
floe add-entity -c new.yml --input ./orders.csv
```

Behavior:
- creates `new.yml` with a minimal config
- infers `name=orders`
- infers `format=csv`
- appends inferred entity and writes a valid config

### Infer name and format from input

```bash
floe add-entity -c config.yml --input /tmp/hr/employees.parquet
```

Behavior:
- infers `name=employees`
- infers `format=parquet`

### Unknown extension error (requires explicit `--format`)

```bash
floe add-entity -c config.yml --input ./payload.dat
```

Result:
- clear error indicating format cannot be inferred and `--format` is required

## Scope / non-goals preserved

This PR intentionally does **not** expand inference scope beyond the existing implementation:

- No remote URI schema inference
- No new formats beyond CSV / JSON / Parquet
- No redesign of the command surface
- `-c` remains required

## Tests

Added/updated tests for `#164` requirements:

### `floe-core` unit tests (`crates/floe-core/tests/unit/config/add_entity.rs`)
- bootstrap config creation path
- default entity name inference
- default format inference (csv/json/parquet)
- explicit `--name` / `--format` override inferred values
- unknown extension error
- existing regressions (including `file://` source path normalization)

### `floe-cli` tests (`crates/floe-cli/tests/add_entity.rs`)
- happy path command (writes config that validates)
- dry-run path (prints YAML and does not write config)

## Validation run

Executed successfully on latest `main` in the worktree:

- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all`
