### PR TITLE
prepare v0.2.7 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to Floe are documented in this file.
 
+## v0.2.7
+
+- Added Iceberg S3 accepted sink support (filesystem catalog, no data catalog / Glue yet).
+- Improved `floe add-entity` bootstrap UX:
+  - create a new config when target `-c` file does not exist
+  - infer default entity name from input filename stem when `--name` is omitted
+  - infer default format from input file extension when `--format` is omitted.
+- Hardened archive mode safety:
+  - archive only resolved/processed inputs
+  - collision-safe archive behavior (no silent overwrite on repeated filenames).
+
 ## v0.2.6
 
 - Added local Iceberg accepted sink MVP (`sink.accepted.format: iceberg`) with filesystem table layout and append/overwrite snapshot behavior.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3353,7 +3353,7 @@ dependencies = [
 
 [[package]]
 name = "floe-cli"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "assert_cmd",
  "clap",
@@ -3366,7 +3366,7 @@ dependencies = [
 
 [[package]]
 name = "floe-core"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "apache-avro 0.16.0",
  "arrow",

--- a/crates/floe-cli/Cargo.toml
+++ b/crates/floe-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "floe-cli"
-version = "0.2.6"
+version = "0.2.7"
 edition = "2021"
 description = "CLI for Floe, a YAML-driven technical ingestion tool."
 license = "MIT"
@@ -17,7 +17,7 @@ path = "src/main.rs"
 
 [dependencies]
 clap = { version = "4", features = ["derive"] }
-floe-core = { path = "../floe-core", version = "0.2.6" }
+floe-core = { path = "../floe-core", version = "0.2.7" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 

--- a/crates/floe-core/Cargo.toml
+++ b/crates/floe-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "floe-core"
-version = "0.2.6"
+version = "0.2.7"
 edition = "2021"
 description = "Core library for Floe, a YAML-driven technical ingestion tool."
 license = "MIT"


### PR DESCRIPTION
## Summary
- bump Floe crates to v0.2.7
- refresh `Cargo.lock` for local package versions
- add changelog entry for v0.2.7

## Included in v0.2.7
- Iceberg S3 accepted sink (filesystem catalog, no Glue) (#165 / #71)
- `floe add-entity` bootstrap + default name/format inference improvements (#166 / #164)
- archive mode safety hardening (resolved inputs only + collision-safe behavior) (#167 / #153)

## Validation
- `cargo check -p floe-cli` (used to refresh and validate `Cargo.lock` / workspace package metadata)
