### PR TITLE
feat(dagster): expose Floe outcomes as asset checks

### DIFF
--- a/orchestrators/dagster-floe/README.md
+++ b/orchestrators/dagster-floe/README.md
@@ -21,6 +21,7 @@ Current model:
 - Multi-manifest loading (`*.manifest.json`) with collision checks.
 - Local runner (`local_process`) support.
 - `execution.defaults.env` and `execution.defaults.workdir` support.
+- Floe quality outcomes exposed as Dagster native Asset Checks (`cast_error`, `not_null`, `unique`, `schema_mismatch`, `file_status`) from Floe reports.
 
 ## Install
 
@@ -75,7 +76,6 @@ The repository example includes two manifests by domain:
 - Kubernetes/ECS runner adapters.
 - Cloud summary loading (`s3://`, `gs://`, `abfs://`).
 - Single-process multi-entity fan-out execution mode.
-- Floe checks mapped to Dagster `AssetCheckResult`.
 
 ## Releasing
 

--- a/orchestrators/dagster-floe/src/floe_dagster/asset_checks.py
+++ b/orchestrators/dagster-floe/src/floe_dagster/asset_checks.py
@@ -1,0 +1,466 @@
+from __future__ import annotations
+
+from collections import Counter
+from dataclasses import dataclass
+from typing import Any, Iterable, Mapping, Sequence
+
+from dagster import AssetCheckResult, AssetCheckSeverity, AssetCheckSpec
+
+from .events import FloeRunFinished
+
+FLOE_CHECK_NAMES: tuple[str, ...] = (
+    "floe_cast_error",
+    "floe_not_null",
+    "floe_unique",
+    "floe_schema_mismatch",
+    "floe_file_status",
+)
+
+_RULE_TO_CHECK_NAME: dict[str, str] = {
+    "cast_error": "floe_cast_error",
+    "not_null": "floe_not_null",
+    "unique": "floe_unique",
+}
+
+_TERMINAL_RUN_STATUSES = {"failed", "aborted"}
+_FAIL_FILE_STATUSES = {"rejected", "failed", "aborted", "error"}
+_WARN_FILE_STATUSES = {"warning", "warn"}
+
+
+@dataclass(frozen=True)
+class FloeCheckContext:
+    asset_key: Sequence[str]
+    entity_name: str
+    run_id: str
+    run_status: str
+    summary_uri: str | None
+    entity_report_uri: str | None
+    entity_status: str | None
+    entity_stats: Mapping[str, Any]
+
+
+def build_asset_check_specs(asset_key: Sequence[str]) -> list[AssetCheckSpec]:
+    return [AssetCheckSpec(name=name, asset=list(asset_key)) for name in FLOE_CHECK_NAMES]
+
+
+def build_asset_check_results(
+    *,
+    asset_key: Sequence[str],
+    entity_name: str,
+    finished: FloeRunFinished,
+    entity_report: Mapping[str, Any] | None,
+    entity_stats: Mapping[str, Any] | None = None,
+    summary_uri: str | None = None,
+    entity_report_uri: str | None = None,
+) -> list[AssetCheckResult]:
+    stats = entity_stats or {}
+    ctx = FloeCheckContext(
+        asset_key=list(asset_key),
+        entity_name=entity_name,
+        run_id=finished.run_id,
+        run_status=finished.status,
+        summary_uri=summary_uri,
+        entity_report_uri=entity_report_uri,
+        entity_status=_as_str(stats.get("entity_status")),
+        entity_stats=stats,
+    )
+    report_files = _as_list(entity_report.get("files")) if isinstance(entity_report, Mapping) else []
+    if not report_files:
+        return _build_summary_fallback_results(ctx)
+
+    rule_summary = _summarize_rules(report_files)
+    schema_summary = _summarize_schema_mismatches(report_files)
+    file_status_summary = _summarize_file_statuses(report_files)
+
+    results: list[AssetCheckResult] = []
+    for rule_name, check_name in _RULE_TO_CHECK_NAME.items():
+        rule_info = rule_summary.get(rule_name) or {}
+        results.append(
+            _make_rule_check_result(
+                check_name=check_name,
+                rule_name=rule_name,
+                ctx=ctx,
+                rule_info=rule_info,
+            )
+        )
+    results.append(_make_schema_check_result(ctx=ctx, schema_summary=schema_summary))
+    results.append(_make_file_status_check_result(ctx=ctx, file_status_summary=file_status_summary))
+    return results
+
+
+def _build_summary_fallback_results(ctx: FloeCheckContext) -> list[AssetCheckResult]:
+    common = _base_metadata(ctx)
+    common["fallback"] = "summary_only"
+    results: list[AssetCheckResult] = []
+
+    run_failed = ctx.run_status in _TERMINAL_RUN_STATUSES
+    file_status_failed = run_failed or (ctx.entity_status in _FAIL_FILE_STATUSES)
+    file_status_warn = (ctx.entity_status in _WARN_FILE_STATUSES) and not file_status_failed
+
+    for check_name in FLOE_CHECK_NAMES:
+        passed = True
+        severity = AssetCheckSeverity.ERROR
+        description = "Floe entity report unavailable; check derived from summary only."
+        metadata = dict(common)
+
+        if check_name == "floe_file_status":
+            if file_status_failed:
+                passed = False
+            elif file_status_warn:
+                passed = False
+                severity = AssetCheckSeverity.WARN
+            description = (
+                "Floe file status check derived from summary only "
+                "(entity report unavailable)."
+            )
+        elif run_failed:
+            passed = False
+            description = (
+                "Floe run status indicates failure/abort; detailed entity report unavailable."
+            )
+
+        results.append(
+            AssetCheckResult(
+                asset_key=list(ctx.asset_key),
+                check_name=check_name,
+                passed=passed,
+                severity=severity,
+                metadata=metadata,
+                description=description,
+            )
+        )
+    return results
+
+
+def _make_rule_check_result(
+    *,
+    check_name: str,
+    rule_name: str,
+    ctx: FloeCheckContext,
+    rule_info: Mapping[str, Any],
+) -> AssetCheckResult:
+    reject_violations = _as_int(rule_info.get("reject_violations")) or 0
+    warn_violations = _as_int(rule_info.get("warn_violations")) or 0
+    total_violations = _as_int(rule_info.get("violations_total")) or 0
+    files_impacted = _as_int(rule_info.get("files_impacted")) or 0
+
+    passed = True
+    severity = AssetCheckSeverity.ERROR
+    if ctx.run_status in _TERMINAL_RUN_STATUSES:
+        passed = False
+    elif reject_violations > 0:
+        passed = False
+    elif warn_violations > 0:
+        passed = False
+        severity = AssetCheckSeverity.WARN
+
+    metadata = _base_metadata(ctx)
+    metadata.update(
+        {
+            "rule": rule_name,
+            "violations_total": total_violations,
+            "reject_violations": reject_violations,
+            "warn_violations": warn_violations,
+            "files_impacted": files_impacted,
+        }
+    )
+    top_columns = rule_info.get("top_columns")
+    if isinstance(top_columns, list) and top_columns:
+        metadata["top_columns"] = top_columns
+
+    description = (
+        f"Floe {rule_name} violations={total_violations} "
+        f"(reject={reject_violations}, warn={warn_violations})."
+    )
+    if ctx.run_status in _TERMINAL_RUN_STATUSES:
+        description = f"Floe run status is {ctx.run_status}; treating {rule_name} check as failed."
+
+    return AssetCheckResult(
+        asset_key=list(ctx.asset_key),
+        check_name=check_name,
+        passed=passed,
+        severity=severity,
+        metadata=metadata,
+        description=description,
+    )
+
+
+def _make_schema_check_result(
+    *,
+    ctx: FloeCheckContext,
+    schema_summary: Mapping[str, Any],
+) -> AssetCheckResult:
+    files_impacted = _as_int(schema_summary.get("files_impacted")) or 0
+    rejected_files = _as_int(schema_summary.get("rejected_files")) or 0
+
+    passed = True
+    severity = AssetCheckSeverity.ERROR
+    if ctx.run_status in _TERMINAL_RUN_STATUSES:
+        passed = False
+    elif rejected_files > 0:
+        passed = False
+    elif files_impacted > 0:
+        passed = False
+        severity = AssetCheckSeverity.WARN
+
+    metadata = _base_metadata(ctx)
+    metadata.update(
+        {
+            "files_impacted": files_impacted,
+            "rejected_files": rejected_files,
+            "mismatch_actions": schema_summary.get("mismatch_actions", {}),
+        }
+    )
+    if schema_summary.get("missing_columns"):
+        metadata["missing_columns"] = schema_summary["missing_columns"]
+    if schema_summary.get("extra_columns"):
+        metadata["extra_columns"] = schema_summary["extra_columns"]
+    if schema_summary.get("sample_messages"):
+        metadata["sample_messages"] = schema_summary["sample_messages"]
+
+    description = "Floe schema mismatch summary from entity report."
+    if ctx.run_status in _TERMINAL_RUN_STATUSES:
+        description = f"Floe run status is {ctx.run_status}; treating schema mismatch check as failed."
+
+    return AssetCheckResult(
+        asset_key=list(ctx.asset_key),
+        check_name="floe_schema_mismatch",
+        passed=passed,
+        severity=severity,
+        metadata=metadata,
+        description=description,
+    )
+
+
+def _make_file_status_check_result(
+    *,
+    ctx: FloeCheckContext,
+    file_status_summary: Mapping[str, Any],
+) -> AssetCheckResult:
+    counts = file_status_summary.get("status_counts")
+    if not isinstance(counts, Mapping):
+        counts = {}
+
+    failed_file_count = sum(
+        count for status, count in counts.items() if _as_str(status) in _FAIL_FILE_STATUSES
+    )
+    warn_file_count = sum(
+        count for status, count in counts.items() if _as_str(status) in _WARN_FILE_STATUSES
+    )
+
+    passed = True
+    severity = AssetCheckSeverity.ERROR
+    if ctx.run_status in _TERMINAL_RUN_STATUSES:
+        passed = False
+    elif failed_file_count > 0:
+        passed = False
+    elif warn_file_count > 0:
+        passed = False
+        severity = AssetCheckSeverity.WARN
+
+    metadata = _base_metadata(ctx)
+    metadata["file_status_counts"] = dict(counts)
+    metadata["failed_files"] = failed_file_count
+    metadata["warn_files"] = warn_file_count
+
+    description = "Floe file-level statuses from entity report."
+    if ctx.run_status in _TERMINAL_RUN_STATUSES:
+        description = f"Floe run status is {ctx.run_status}; treating file status check as failed."
+
+    return AssetCheckResult(
+        asset_key=list(ctx.asset_key),
+        check_name="floe_file_status",
+        passed=passed,
+        severity=severity,
+        metadata=metadata,
+        description=description,
+    )
+
+
+def _summarize_rules(files: Iterable[Mapping[str, Any]]) -> dict[str, dict[str, Any]]:
+    summary: dict[str, dict[str, Any]] = {
+        "cast_error": {
+            "violations_total": 0,
+            "reject_violations": 0,
+            "warn_violations": 0,
+            "files_impacted": 0,
+            "column_counts": Counter(),
+        },
+        "not_null": {
+            "violations_total": 0,
+            "reject_violations": 0,
+            "warn_violations": 0,
+            "files_impacted": 0,
+            "column_counts": Counter(),
+        },
+        "unique": {
+            "violations_total": 0,
+            "reject_violations": 0,
+            "warn_violations": 0,
+            "files_impacted": 0,
+            "column_counts": Counter(),
+        },
+    }
+
+    for file_item in files:
+        file_had_rule: set[str] = set()
+        validation = _as_dict(file_item.get("validation"))
+        rules = _as_list(validation.get("rules"))
+        for rule_item in rules:
+            rule_name = _as_str(rule_item.get("rule"))
+            if rule_name not in summary:
+                continue
+            bucket = summary[rule_name]
+            violations = _as_int(rule_item.get("violations")) or 0
+            severity = _as_str(rule_item.get("severity"))
+            bucket["violations_total"] = (bucket.get("violations_total") or 0) + violations
+            if severity == "reject":
+                bucket["reject_violations"] = (bucket.get("reject_violations") or 0) + violations
+            elif severity in {"warn", "warning"}:
+                bucket["warn_violations"] = (bucket.get("warn_violations") or 0) + violations
+            if violations > 0:
+                file_had_rule.add(rule_name)
+
+            column_counts = bucket["column_counts"]
+            if isinstance(column_counts, Counter):
+                for column_item in _as_list(rule_item.get("columns")):
+                    column_name = _as_str(column_item.get("column"))
+                    if not column_name:
+                        continue
+                    column_violations = _as_int(column_item.get("violations")) or 0
+                    column_counts[column_name] += max(column_violations, 0)
+
+        for rule_name in file_had_rule:
+            bucket = summary[rule_name]
+            bucket["files_impacted"] = (bucket.get("files_impacted") or 0) + 1
+
+    for bucket in summary.values():
+        column_counts = bucket.pop("column_counts", Counter())
+        if isinstance(column_counts, Counter):
+            bucket["top_columns"] = [
+                {"column": name, "violations": count}
+                for name, count in column_counts.most_common(3)
+            ]
+        else:
+            bucket["top_columns"] = []
+
+    return summary
+
+
+def _summarize_schema_mismatches(files: Iterable[Mapping[str, Any]]) -> dict[str, Any]:
+    mismatch_actions: Counter[str] = Counter()
+    missing_columns: Counter[str] = Counter()
+    extra_columns: Counter[str] = Counter()
+    sample_messages: list[str] = []
+    files_impacted = 0
+    rejected_files = 0
+
+    for file_item in files:
+        mismatch = _as_dict(file_item.get("mismatch"))
+        action = _as_str(mismatch.get("mismatch_action"))
+        missing = [_as_str(v) for v in _as_list(mismatch.get("missing_columns"))]
+        extra = [_as_str(v) for v in _as_list(mismatch.get("extra_columns"))]
+        error = _as_dict(mismatch.get("error"))
+        error_rule = _as_str(error.get("rule"))
+        message = _as_str(error.get("message"))
+
+        has_schema_mismatch = bool(
+            (error_rule == "schema_mismatch")
+            or (action and action != "none" and (any(missing) or any(extra)))
+        )
+        if not has_schema_mismatch:
+            continue
+
+        files_impacted += 1
+        if _as_str(file_item.get("status")) in _FAIL_FILE_STATUSES or action == "rejected_file":
+            rejected_files += 1
+        if action:
+            mismatch_actions[action] += 1
+        for col in missing:
+            if col:
+                missing_columns[col] += 1
+        for col in extra:
+            if col:
+                extra_columns[col] += 1
+        if message and len(sample_messages) < 3:
+            sample_messages.append(message)
+
+    return {
+        "files_impacted": files_impacted,
+        "rejected_files": rejected_files,
+        "mismatch_actions": dict(mismatch_actions),
+        "missing_columns": [name for name, _ in missing_columns.most_common(5)],
+        "extra_columns": [name for name, _ in extra_columns.most_common(5)],
+        "sample_messages": sample_messages,
+    }
+
+
+def _summarize_file_statuses(files: Iterable[Mapping[str, Any]]) -> dict[str, Any]:
+    counts: Counter[str] = Counter()
+    for file_item in files:
+        status = _as_str(file_item.get("status"))
+        if status:
+            counts[status] += 1
+    return {"status_counts": dict(counts)}
+
+
+def _base_metadata(ctx: FloeCheckContext) -> dict[str, Any]:
+    metadata: dict[str, Any] = {
+        "entity": ctx.entity_name,
+        "run_id": ctx.run_id,
+        "floe_run_status": ctx.run_status,
+    }
+    if ctx.summary_uri:
+        metadata["summary_uri"] = ctx.summary_uri
+    if ctx.entity_report_uri:
+        metadata["entity_report_uri"] = ctx.entity_report_uri
+
+    for source_key, target_key in (
+        ("files", "files"),
+        ("rows", "rows"),
+        ("accepted", "accepted"),
+        ("rejected", "rejected"),
+        ("warnings", "warnings"),
+        ("errors", "errors"),
+    ):
+        value = ctx.entity_stats.get(source_key)
+        if value is not None:
+            metadata[target_key] = value
+    if ctx.entity_status:
+        metadata["entity_status"] = ctx.entity_status
+    return metadata
+
+
+def _as_dict(value: Any) -> dict[str, Any]:
+    if isinstance(value, dict):
+        return value
+    return {}
+
+
+def _as_list(value: Any) -> list[Any]:
+    if isinstance(value, list):
+        return value
+    return []
+
+
+def _as_int(value: Any) -> int | None:
+    if isinstance(value, bool):
+        return int(value)
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float):
+        return int(value)
+    if isinstance(value, str):
+        try:
+            return int(value)
+        except ValueError:
+            return None
+    return None
+
+
+def _as_str(value: Any) -> str | None:
+    if value is None:
+        return None
+    if isinstance(value, str):
+        return value
+    return str(value)

--- a/orchestrators/dagster-floe/src/floe_dagster/assets.py
+++ b/orchestrators/dagster-floe/src/floe_dagster/assets.py
@@ -7,6 +7,7 @@ from urllib.parse import unquote, urlparse
 
 from dagster import Definitions, Failure, MaterializeResult, asset
 
+from .asset_checks import build_asset_check_results, build_asset_check_specs
 from .events import last_run_finished, parse_ndjson_events, parse_run_finished
 from .manifest import (
     DagsterManifest,
@@ -86,9 +87,19 @@ def _make_entity_asset(
     execution: ManifestExecution,
     runner_definition: ManifestRunnerDefinition,
 ):
-    @asset(name=asset_name, key_prefix=key_prefix, group_name=group_name)
-    def _asset(context) -> MaterializeResult:
-        run_id = getattr(context, "run_id", None)
+    asset_key = [*key_prefix, asset_name]
+
+    @asset(
+        name=asset_name,
+        key_prefix=key_prefix,
+        group_name=group_name,
+        check_specs=build_asset_check_specs(asset_key),
+    )
+    def _asset(context):
+        run = getattr(context, "run", None)
+        run_id = getattr(run, "run_id", None) if run is not None else None
+        if run_id is None:
+            run_id = getattr(context, "run_id", None)
         result = runner.run_floe_entity(
             config_uri=config_uri,
             run_id=run_id,
@@ -111,13 +122,18 @@ def _make_entity_asset(
 
         summary_uri = finished.summary_uri
         entity_stats: dict[str, Any] = {}
+        entity_report_json: dict[str, Any] | None = None
+        entity_report_uri: str | None = None
 
         if summary_uri:
             try:
                 summary_json = _load_summary_json(summary_uri, config_uri)
                 entity_stats = _extract_entity_stats(summary_json, entity_name)
+                entity_report_uri = _as_optional_str(entity_stats.get("entity_report_file"))
+                if entity_report_uri:
+                    entity_report_json = _load_entity_report_json(entity_report_uri, config_uri)
             except Exception as exc:  # noqa: BLE001
-                context.log.warning(f"failed to load run summary: {exc}")
+                context.log.warning(f"failed to load run summary/entity report: {exc}")
 
         metadata: dict[str, Any] = {
             "run_id": finished.run_id,
@@ -128,6 +144,20 @@ def _make_entity_asset(
             metadata["summary_uri"] = summary_uri
 
         metadata.update(entity_stats)
+        if entity_report_uri:
+            metadata["entity_report_uri"] = entity_report_uri
+
+        check_results = build_asset_check_results(
+            asset_key=asset_key,
+            entity_name=entity_name,
+            finished=finished,
+            entity_report=entity_report_json,
+            entity_stats=entity_stats,
+            summary_uri=summary_uri,
+            entity_report_uri=entity_report_uri,
+        )
+        for check_result in check_results:
+            yield check_result
 
         if result.exit_code != 0 or finished.exit_code != 0:
             raise Failure(
@@ -135,30 +165,42 @@ def _make_entity_asset(
                 metadata=metadata,
             )
 
-        return MaterializeResult(metadata=metadata)
+        yield MaterializeResult(metadata=metadata)
 
     return _asset
 
 
 def _load_summary_json(summary_uri: str, config_uri: str) -> dict[str, Any]:
-    if summary_uri.startswith("local://"):
-        raw_path = unquote(summary_uri[len("local://") :])
+    return _load_local_json_document(summary_uri, config_uri, label="summary")
+
+
+def _load_entity_report_json(entity_report_uri: str, config_uri: str) -> dict[str, Any]:
+    return _load_local_json_document(entity_report_uri, config_uri, label="entity report")
+
+
+def _load_local_json_document(ref: str, config_uri: str, *, label: str) -> dict[str, Any]:
+    path = _resolve_local_json_path(ref, config_uri)
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise ValueError(f"{label} JSON must be an object")
+    return data
+
+
+def _resolve_local_json_path(ref: str, config_uri: str) -> Path:
+    if ref.startswith("local://"):
+        raw_path = unquote(ref[len("local://") :])
         path = Path(raw_path)
-    elif summary_uri.startswith("file://"):
-        parsed = urlparse(summary_uri)
+    elif ref.startswith("file://"):
+        parsed = urlparse(ref)
         path = Path(unquote(parsed.path))
-    elif "://" in summary_uri:
-        raise ValueError(f"unsupported non-local summary URI: {summary_uri}")
+    elif "://" in ref:
+        raise ValueError(f"unsupported non-local JSON URI: {ref}")
     else:
-        path = Path(summary_uri)
+        path = Path(ref)
 
     if not path.is_absolute() and "://" not in config_uri:
         path = (Path(config_uri).resolve().parent / path).resolve()
-
-    data = json.loads(path.read_text(encoding="utf-8"))
-    if not isinstance(data, dict):
-        raise ValueError("run.summary.json must be an object")
-    return data
+    return path
 
 
 def _extract_entity_stats(summary_json: dict[str, Any], entity_name: str) -> dict[str, Any]:
@@ -184,3 +226,11 @@ def _extract_entity_stats(summary_json: dict[str, Any], entity_name: str) -> dic
             "entity_report_file": item.get("report_file"),
         }
     return {}
+
+
+def _as_optional_str(value: Any) -> str | None:
+    if value is None:
+        return None
+    if isinstance(value, str):
+        return value
+    return str(value)

--- a/orchestrators/dagster-floe/tests/test_asset_checks.py
+++ b/orchestrators/dagster-floe/tests/test_asset_checks.py
@@ -1,0 +1,278 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from dagster import AssetCheckSeverity, materialize
+
+from floe_dagster.asset_checks import FLOE_CHECK_NAMES, build_asset_check_results
+from floe_dagster.assets import build_floe_asset_defs
+from floe_dagster.events import FloeRunFinished
+from floe_dagster.runner import RunResult, Runner
+
+
+class _StaticRunner(Runner):
+    def __init__(self, stdout: str, *, exit_code: int = 0, stderr: str = "") -> None:
+        self._result = RunResult(stdout=stdout, stderr=stderr, exit_code=exit_code)
+
+    def run_floe_entity(
+        self,
+        config_uri: str,
+        run_id: str | None,
+        entity: str,
+        log_format: str = "json",
+        execution=None,
+        runner_definition=None,
+    ) -> RunResult:
+        del config_uri, run_id, entity, log_format, execution, runner_definition
+        return self._result
+
+
+def test_build_asset_check_results_maps_rule_schema_and_file_statuses() -> None:
+    finished = FloeRunFinished(
+        run_id="run-123",
+        status="rejected",
+        exit_code=0,
+        summary_uri="local:///tmp/run.summary.json",
+    )
+    entity_report = {
+        "files": [
+            {
+                "status": "rejected",
+                "mismatch": {
+                    "mismatch_action": "rejected_file",
+                    "missing_columns": ["created_at"],
+                    "extra_columns": [],
+                    "error": {"rule": "schema_mismatch", "message": "missing created_at"},
+                },
+                "validation": {"rules": []},
+            },
+            {
+                "status": "rejected",
+                "mismatch": {"mismatch_action": "none", "missing_columns": [], "extra_columns": []},
+                "validation": {
+                    "rules": [
+                        {
+                            "rule": "cast_error",
+                            "severity": "reject",
+                            "violations": 4,
+                            "columns": [{"column": "created_at", "violations": 4}],
+                        },
+                        {
+                            "rule": "not_null",
+                            "severity": "reject",
+                            "violations": 1,
+                            "columns": [{"column": "customer_id", "violations": 1}],
+                        },
+                    ]
+                },
+            },
+        ]
+    }
+
+    checks = build_asset_check_results(
+        asset_key=["sales", "customers"],
+        entity_name="customers",
+        finished=finished,
+        entity_report=entity_report,
+        entity_stats={
+            "entity_status": "rejected",
+            "files": 2,
+            "rejected": 2,
+            "accepted": 0,
+            "warnings": 0,
+            "errors": 5,
+        },
+        summary_uri=finished.summary_uri,
+        entity_report_uri="/tmp/customer/run.json",
+    )
+
+    by_name = {check.check_name: check for check in checks}
+    assert set(by_name) == set(FLOE_CHECK_NAMES)
+    assert by_name["floe_cast_error"].passed is False
+    assert by_name["floe_not_null"].passed is False
+    assert by_name["floe_unique"].passed is True
+    assert by_name["floe_schema_mismatch"].passed is False
+    assert by_name["floe_file_status"].passed is False
+
+    cast_meta = by_name["floe_cast_error"].metadata or {}
+    assert _meta_value(cast_meta["entity"]) == "customers"
+    assert _meta_value(cast_meta["run_id"]) == "run-123"
+    assert _meta_value(cast_meta["violations_total"]) == 4
+    assert "top_columns" in cast_meta
+
+
+def test_build_asset_check_results_uses_warn_severity_for_warn_only_outcomes() -> None:
+    checks = build_asset_check_results(
+        asset_key=["hr", "employees"],
+        entity_name="employees",
+        finished=FloeRunFinished(run_id="run-1", status="success", exit_code=0, summary_uri=None),
+        entity_report={
+            "files": [
+                {
+                    "status": "warning",
+                    "mismatch": {"mismatch_action": "none", "missing_columns": [], "extra_columns": []},
+                    "validation": {
+                        "rules": [
+                            {
+                                "rule": "unique",
+                                "severity": "warn",
+                                "violations": 2,
+                                "columns": [{"column": "email", "violations": 2}],
+                            }
+                        ]
+                    },
+                }
+            ]
+        },
+    )
+    by_name = {check.check_name: check for check in checks}
+    unique_check = by_name["floe_unique"]
+    file_status_check = by_name["floe_file_status"]
+    assert unique_check.passed is False
+    assert unique_check.severity == AssetCheckSeverity.WARN
+    assert file_status_check.passed is False
+    assert file_status_check.severity == AssetCheckSeverity.WARN
+
+
+def test_build_asset_check_results_fallbacks_when_entity_report_fields_missing() -> None:
+    checks = build_asset_check_results(
+        asset_key=["sales", "orders"],
+        entity_name="orders",
+        finished=FloeRunFinished(run_id="run-2", status="rejected", exit_code=0, summary_uri=None),
+        entity_report={"spec_version": "0.1"},
+        entity_stats={"entity_status": "rejected", "rejected": 1, "errors": 1},
+    )
+    by_name = {check.check_name: check for check in checks}
+    assert by_name["floe_file_status"].passed is False
+    assert by_name["floe_schema_mismatch"].passed is True
+    assert by_name["floe_cast_error"].passed is True
+    fallback_meta = by_name["floe_file_status"].metadata or {}
+    assert _meta_value(fallback_meta["fallback"]) == "summary_only"
+
+
+def test_build_asset_check_results_marks_all_checks_failed_for_aborted_runs() -> None:
+    checks = build_asset_check_results(
+        asset_key=["sales", "orders"],
+        entity_name="orders",
+        finished=FloeRunFinished(run_id="run-3", status="aborted", exit_code=1, summary_uri=None),
+        entity_report={"files": []},
+    )
+    assert all(check.passed is False for check in checks)
+
+
+def test_asset_emits_native_dagster_asset_checks_from_floe_reports(tmp_path: Path) -> None:
+    report_dir = tmp_path / "report" / "run_123" / "employees"
+    report_dir.mkdir(parents=True)
+    summary_path = tmp_path / "report" / "run_123" / "run.summary.json"
+    entity_report_path = report_dir / "run.json"
+
+    entity_report = {
+        "entity": {"name": "employees"},
+        "results": {
+            "files_total": 2,
+            "rows_total": 10,
+            "accepted_total": 8,
+            "rejected_total": 2,
+            "warnings_total": 1,
+            "errors_total": 3,
+        },
+        "files": [
+            {
+                "input_file": str(tmp_path / "in" / "employees_bad.csv"),
+                "status": "rejected",
+                "mismatch": {"mismatch_action": "none", "missing_columns": [], "extra_columns": []},
+                "validation": {
+                    "rules": [
+                        {
+                            "rule": "cast_error",
+                            "severity": "reject",
+                            "violations": 3,
+                            "columns": [{"column": "hire_date", "violations": 3}],
+                        }
+                    ]
+                },
+            },
+            {
+                "input_file": str(tmp_path / "in" / "employees_ok.csv"),
+                "status": "success",
+                "mismatch": {"mismatch_action": "none", "missing_columns": [], "extra_columns": []},
+                "validation": {"rules": []},
+            },
+        ],
+    }
+    summary_json = {
+        "run": {"run_id": "run-123", "status": "rejected", "exit_code": 0},
+        "entities": [
+            {
+                "name": "employees",
+                "status": "rejected",
+                "results": {
+                    "files_total": 2,
+                    "rows_total": 10,
+                    "accepted_total": 8,
+                    "rejected_total": 2,
+                    "warnings_total": 1,
+                    "errors_total": 3,
+                },
+                "report_file": str(entity_report_path),
+            }
+        ],
+    }
+    entity_report_path.write_text(json.dumps(entity_report), encoding="utf-8")
+    summary_path.parent.mkdir(parents=True, exist_ok=True)
+    summary_path.write_text(json.dumps(summary_json), encoding="utf-8")
+
+    stdout = "\n".join(
+        [
+            json.dumps(
+                {
+                    "event": "run_started",
+                    "run_id": "run-123",
+                    "status": "running",
+                    "exit_code": 0,
+                }
+            ),
+            json.dumps(
+                {
+                    "event": "run_finished",
+                    "run_id": "run-123",
+                    "status": "rejected",
+                    "exit_code": 0,
+                    "summary_uri": f"local://{summary_path}",
+                }
+            ),
+        ]
+    )
+
+    manifest_path = Path(__file__).parent / "fixtures" / "manifest.json"
+    assets_defs, _ = build_floe_asset_defs(
+        manifest_path=str(manifest_path),
+        runner=_StaticRunner(stdout),
+        entities=["employees"],
+    )
+    result = materialize(assets_defs)
+    assert result.success is True
+
+    evaluations = result.get_asset_check_evaluations()
+    assert {ev.asset_check_key.name for ev in evaluations} == set(FLOE_CHECK_NAMES)
+
+    by_name = {ev.asset_check_key.name: ev for ev in evaluations}
+    assert by_name["floe_cast_error"].passed is False
+    assert by_name["floe_schema_mismatch"].passed is True
+    assert by_name["floe_file_status"].passed is False
+
+    cast_meta = by_name["floe_cast_error"].metadata
+    assert _meta_value(cast_meta["run_id"]) == "run-123"
+    assert _meta_value(cast_meta["entity"]) == "employees"
+    assert "entity_report_uri" in cast_meta
+
+
+def _meta_value(value: Any) -> Any:
+    for attr in ("value", "text", "path"):
+        if hasattr(value, attr):
+            return getattr(value, attr)
+    if hasattr(value, "data"):
+        return getattr(value, "data")
+    return value


### PR DESCRIPTION
Closes #154

## Summary

Expose Floe quality outcomes as native Dagster Asset Checks in `dagster-floe`, using existing Floe run reports (`run.summary.json` + entity `run.json`) without changing the manifest contract or Floe core.

## What this PR changes

- Adds connector-side Floe -> Dagster Asset Check mapping in `orchestrators/dagster-floe/src/floe_dagster/asset_checks.py`
- Declares and emits native Dagster checks for each Floe-backed asset materialization:
  - `floe_cast_error`
  - `floe_not_null`
  - `floe_unique`
  - `floe_schema_mismatch`
  - `floe_file_status`
- Loads entity `run.json` (preferred) from the `report_file` path in `run.summary.json`
- Falls back gracefully to summary-only behavior when entity reports are missing/unreadable/older-version shape
- Keeps existing manifest integration and materialization metadata behavior intact (adds `entity_report_uri` when available)
- Keeps Floe run failure behavior intact (Dagster asset still raises `Failure`), while emitting asset checks first when possible

## Severity / status mapping (first version)

- Floe run status `failed` / `aborted` => all Floe checks emitted as failed (`ERROR` severity)
- Rule outcomes (`cast_error`, `not_null`, `unique`):
  - reject violations => failed (`ERROR`)
  - warn-only violations => failed (`WARN`)
  - no violations => passed
- Schema mismatch:
  - rejected-file schema mismatch => failed (`ERROR`)
  - non-reject mismatch (if encountered) => failed (`WARN`)
  - none => passed
- File status:
  - rejected/failed/aborted/error file statuses => failed (`ERROR`)
  - warn-only file statuses => failed (`WARN`)
  - all success => passed

## Metadata included on checks (best-effort)

Each check includes Floe context where available:

- `entity`
- `run_id`
- `summary_uri`
- `entity_report_uri`
- entity counts (`files`, `rows`, `accepted`, `rejected`, `warnings`, `errors`)
- category-specific details such as:
  - `violations_total`, `reject_violations`, `warn_violations`
  - `top_columns`
  - schema mismatch actions / sample messages / top missing/extra columns
  - file status counts

## Fallback behavior (older/missing report fields)

- If entity `run.json` is missing/unreadable or does not contain usable `files[]`, checks still emit.
- `floe_file_status` degrades to summary-derived status (`entity_status` / run status).
- Rule/schema checks emit with summary-only fallback metadata (no false category attribution from incomplete data).

## Before / After

Before:
- Floe materialization metadata in Dagster showed counts/status, but no native Dagster Asset Checks.

After:
- Each Floe-backed asset materialization emits native Dagster Asset Checks (`floe_*`) visible in the Dagster UI.
- Checks carry Floe run identifiers and report references for drill-down.

## Tests

Added connector tests under `orchestrators/dagster-floe/tests/` covering:

- Floe entity report -> check status mapping (rules/schema/file status)
- warn-only severity mapping (`WARN`)
- summary-only fallback when fields are missing
- aborted/failed mapping behavior
- Dagster materialization emits native `AssetCheckEvaluation` events with Floe metadata

## Validation

Connector:
- `PYTHONPATH=orchestrators/dagster-floe/src uv run --python 3.12 --with pytest --with 'dagster>=1.7,<2' --with jsonschema pytest orchestrators/dagster-floe/tests`

Rust workspace (no core logic changes, regression check):
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all`

## Non-goals

- No Floe core quality logic changes
- No manifest schema/contract changes
- No Airflow parity work
- No cross-run history/trend backend
