### PR TITLE
feat(iceberg): add write-time file sizing metrics

### DIFF
--- a/crates/floe-core/src/io/write/iceberg.rs
+++ b/crates/floe-core/src/io/write/iceberg.rs
@@ -39,6 +39,8 @@ use crate::io::format::{AcceptedSinkAdapter, AcceptedWriteMetrics, AcceptedWrite
 use crate::io::storage::{object_store::iceberg_store_config, ObjectRef, Target};
 use crate::{config, io, FloeResult};
 
+use super::metrics;
+
 struct IcebergAcceptedAdapter;
 
 static ICEBERG_ACCEPTED_ADAPTER: IcebergAcceptedAdapter = IcebergAcceptedAdapter;
@@ -62,6 +64,7 @@ struct IcebergWriteResult {
     snapshot_id: Option<i64>,
     metadata_version: Option<i64>,
     file_paths: Vec<String>,
+    metrics: AcceptedWriteMetrics,
     table_root_uri: String,
     iceberg_catalog_name: Option<String>,
     iceberg_database: Option<String>,
@@ -137,13 +140,20 @@ fn write_iceberg_table_with_remote_context(
 ) -> FloeResult<AcceptedWriteOutput> {
     let write_ctx = build_iceberg_write_context(target, entity, mode, remote.as_mut())?;
     let prepared = prepare_iceberg_write(df, entity)?;
+    let small_file_threshold_bytes = iceberg_small_file_threshold_bytes(entity);
 
     let runtime = tokio::runtime::Builder::new_current_thread()
         .enable_all()
         .build()
         .map_err(|err| Box::new(RunError(format!("iceberg runtime init failed: {err}"))))?;
 
-    let result = runtime.block_on(write_iceberg_table_async(write_ctx, prepared, entity, mode))?;
+    let result = runtime.block_on(write_iceberg_table_async(
+        write_ctx,
+        prepared,
+        entity,
+        mode,
+        small_file_threshold_bytes,
+    ))?;
     Ok(AcceptedWriteOutput {
         files_written: result.files_written,
         parts_written: result.files_written,
@@ -158,11 +168,7 @@ fn write_iceberg_table_with_remote_context(
         iceberg_database: result.iceberg_database,
         iceberg_namespace: result.iceberg_namespace,
         iceberg_table: result.iceberg_table,
-        metrics: AcceptedWriteMetrics {
-            total_bytes_written: None,
-            avg_file_size_mb: None,
-            small_files_count: None,
-        },
+        metrics: result.metrics,
     })
 }
 
@@ -171,6 +177,7 @@ async fn write_iceberg_table_async(
     prepared: PreparedIcebergWrite,
     entity: &config::EntityConfig,
     mode: config::WriteMode,
+    small_file_threshold_bytes: u64,
 ) -> FloeResult<IcebergWriteResult> {
     let IcebergWriteContext {
         table_root_uri,
@@ -263,12 +270,19 @@ async fn write_iceberg_table_async(
     };
 
     let mut file_paths = Vec::new();
+    let mut file_sizes = Vec::new();
     let mut files_written = 0_u64;
     let mut table_after_write = table;
 
     if prepared.batch.num_rows() > 0 {
         let data_files = write_data_files(&table_after_write, prepared.batch).await?;
         files_written = data_files.len() as u64;
+        // Iceberg returns DataFile entries for data files only, so these sizes exclude
+        // metadata/manifests and match the accepted-output metrics semantics.
+        file_sizes = data_files
+            .iter()
+            .map(iceberg::spec::DataFile::file_size_in_bytes)
+            .collect();
         file_paths = data_files
             .iter()
             .map(|file| {
@@ -320,18 +334,31 @@ async fn write_iceberg_table_async(
         )
         .await?;
     }
+    let metrics = metrics::summarize_written_file_sizes(&file_sizes, small_file_threshold_bytes);
 
     Ok(IcebergWriteResult {
         files_written,
         snapshot_id,
         metadata_version,
         file_paths,
+        metrics,
         table_root_uri,
         iceberg_catalog_name: glue_catalog.as_ref().map(|cfg| cfg.catalog_name.clone()),
         iceberg_database: glue_catalog.as_ref().map(|cfg| cfg.database.clone()),
         iceberg_namespace: glue_catalog.as_ref().map(|cfg| cfg.namespace.clone()),
         iceberg_table: glue_catalog.as_ref().map(|cfg| cfg.table.clone()),
     })
+}
+
+fn iceberg_small_file_threshold_bytes(entity: &config::EntityConfig) -> u64 {
+    metrics::default_small_file_threshold_bytes(
+        entity
+            .sink
+            .accepted
+            .options
+            .as_ref()
+            .and_then(|options| options.max_size_per_file),
+    )
 }
 
 fn build_iceberg_write_context(

--- a/crates/floe-core/tests/integration/iceberg_run.rs
+++ b/crates/floe-core/tests/integration/iceberg_run.rs
@@ -83,6 +83,42 @@ entities:
     assert_eq!(report.accepted_output.files_written, 1);
     assert_eq!(report.accepted_output.parts_written, 1);
     assert!(report.accepted_output.snapshot_id.is_some());
+    assert!(report.accepted_output.total_bytes_written.is_some());
+    assert!(report.accepted_output.avg_file_size_mb.is_some());
+    assert!(report.accepted_output.small_files_count.is_some());
+
+    let (data_file_count, data_total_bytes) =
+        collect_file_stats(&accepted_dir.join("data")).expect("collect iceberg data stats");
+    assert_eq!(report.accepted_output.files_written, data_file_count);
+    assert_eq!(
+        report.accepted_output.total_bytes_written,
+        Some(data_total_bytes)
+    );
+}
+
+fn collect_file_stats(dir: &Path) -> Result<(u64, u64), std::io::Error> {
+    if !dir.exists() {
+        return Ok((0, 0));
+    }
+    let mut files = 0_u64;
+    let mut total_bytes = 0_u64;
+    let mut stack = vec![dir.to_path_buf()];
+    while let Some(path) = stack.pop() {
+        for entry in fs::read_dir(path)? {
+            let entry = entry?;
+            let entry_path = entry.path();
+            let metadata = entry.metadata()?;
+            if metadata.is_dir() {
+                stack.push(entry_path);
+                continue;
+            }
+            if metadata.is_file() {
+                files += 1;
+                total_bytes += metadata.len();
+            }
+        }
+    }
+    Ok((files, total_bytes))
 }
 
 #[test]

--- a/crates/floe-core/tests/unit/io/write/iceberg_write.rs
+++ b/crates/floe-core/tests/unit/io/write/iceberg_write.rs
@@ -125,9 +125,46 @@ fn write_iceberg_table_empty_dataframe_creates_table_without_snapshot() -> FloeR
     let out = write_iceberg_table(&mut df, &target, &entity, config::WriteMode::Overwrite)?;
     assert_eq!(out.parts_written, 0);
     assert!(out.snapshot_id.is_none());
+    assert_eq!(out.metrics.total_bytes_written, None);
+    assert_eq!(out.metrics.avg_file_size_mb, None);
+    assert_eq!(out.metrics.small_files_count, None);
     assert!(table_path.join("metadata").exists());
     assert!(!table_path.join("data").exists());
     assert_eq!(metadata_json_count(&table_path)?, 1);
+
+    Ok(())
+}
+
+#[test]
+fn write_iceberg_table_local_metrics_count_data_files_not_metadata() -> FloeResult<()> {
+    let temp_dir = tempfile::TempDir::new()?;
+    let table_path = temp_dir.path().join("iceberg_table");
+    let config = empty_root_config();
+    let resolver = config::StorageResolver::from_path(&config, temp_dir.path())?;
+    let target = resolve_local_target(&resolver, &table_path)?;
+    let entity = build_entity(&table_path, config::WriteMode::Overwrite, Vec::new(), None);
+
+    let mut df = df!(
+        "id" => &[1i64, 2, 3, 4, 5],
+        "name" => &["a", "b", "c", "d", "e"]
+    )?;
+    let out = write_iceberg_table(&mut df, &target, &entity, config::WriteMode::Overwrite)?;
+
+    let (data_file_count, data_total_bytes) = collect_file_stats(&table_path.join("data"))?;
+    let (_metadata_file_count, metadata_total_bytes) =
+        collect_file_stats(&table_path.join("metadata"))?;
+
+    assert_eq!(out.files_written, data_file_count);
+    assert_eq!(out.parts_written, data_file_count);
+    assert_eq!(out.metrics.total_bytes_written, Some(data_total_bytes));
+    assert!(out.metrics.avg_file_size_mb.is_some());
+    assert!(out.metrics.small_files_count.is_some());
+    assert!(metadata_total_bytes > 0);
+    assert!(data_total_bytes < data_total_bytes + metadata_total_bytes);
+    if let Some(avg_mb) = out.metrics.avg_file_size_mb {
+        let expected_avg_mb = data_total_bytes as f64 / data_file_count as f64 / (1024.0 * 1024.0);
+        assert!((avg_mb - expected_avg_mb).abs() < 1e-12);
+    }
 
     Ok(())
 }
@@ -594,4 +631,29 @@ fn map_iceberg_err(
     context: &'static str,
 ) -> impl FnOnce(iceberg::Error) -> Box<dyn std::error::Error + Send + Sync> {
     move |err| Box::new(floe_core::errors::RunError(format!("{context}: {err}")))
+}
+
+fn collect_file_stats(dir: &Path) -> FloeResult<(u64, u64)> {
+    if !dir.exists() {
+        return Ok((0, 0));
+    }
+    let mut files = 0_u64;
+    let mut total_bytes = 0_u64;
+    let mut stack = vec![dir.to_path_buf()];
+    while let Some(path) = stack.pop() {
+        for entry in fs::read_dir(path)? {
+            let entry = entry?;
+            let entry_path = entry.path();
+            let metadata = entry.metadata()?;
+            if metadata.is_dir() {
+                stack.push(entry_path);
+                continue;
+            }
+            if metadata.is_file() {
+                files += 1;
+                total_bytes += metadata.len();
+            }
+        }
+    }
+    Ok((files, total_bytes))
 }


### PR DESCRIPTION
Closes #176

Parent tracking: #159

## Summary

Populate accepted-output write-time file sizing metrics for Iceberg writes, bringing Iceberg closer to Parquet / local Delta parity without changing partitioning behavior.

This PR fills:
- `files_written`
- `total_bytes_written`
- `avg_file_size_mb`
- `small_files_count`

for Iceberg accepted writes using Iceberg `DataFile` metadata returned by the writer.

## What counts as "written files"

For Iceberg metrics in this PR, "written files" means **Iceberg data files only** (the `DataFile` entries produced by the writer / append transaction).

It explicitly does **not** include:
- Iceberg metadata JSON files
- manifest / manifest-list files
- other table metadata artifacts

This matches the accepted-output metrics semantics used for Parquet/Delta data-file metrics.

## Local vs cloud behavior

- **Local Iceberg**: exact metrics (required by this issue)
- **Cloud Iceberg (S3/GCS)**: also exact in this implementation

Why cloud can be exact here:
- We reuse the Iceberg writer's returned `DataFile` entries and `file_size_in_bytes`, so no filesystem/container rescan or object listing is required.
- Values are derived from the committed data files generated by the write path.

No fake/placeholder values are emitted for unknown sizes/counts.

## Implementation notes

- Reuses shared metrics conventions introduced in `#172` via `io/write/metrics.rs`
- Computes small-file threshold from `sink.accepted.options.max_size_per_file` when configured, otherwise uses the shared default threshold behavior
- Keeps report schema unchanged
- Keeps partitioning / `partition_spec` runtime behavior out of scope (handled separately in `#175`)

## Tests

### Unit (`crates/floe-core/tests/unit/...`)
- Iceberg local write metrics are populated and match actual bytes of files under the Iceberg `data/` directory
- Metrics exclude metadata files (validated by comparing data-dir totals vs metadata-dir totals)
- Empty Iceberg writes keep metric fields unset (`None`)

### Integration (`crates/floe-core/tests/integration/...`)
- Local Iceberg run report now asserts non-null accepted-output metrics
- Reported `files_written` / `total_bytes_written` match the actual Iceberg `data/` files on disk

## Relation to follow-ups

- `#177` (remote Delta metrics): unchanged; this PR is Iceberg-only
- `#185` (metrics semantics): this PR follows current accepted-output metrics semantics and documents the Iceberg file-count scope explicitly (data files only)

## Validation

- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all`
