### PR TITLE
Iceberg sink: execute partition_spec at runtime (#175)

### DIFF
--- a/crates/floe-core/src/io/write/iceberg.rs
+++ b/crates/floe-core/src/io/write/iceberg.rs
@@ -14,9 +14,11 @@ use aws_sdk_glue::types::{
     StorageDescriptor as GlueStorageDescriptor, TableInput as GlueTableInput,
 };
 use aws_sdk_glue::Client as GlueClient;
-use iceberg::arrow::schema_to_arrow_schema;
+use iceberg::arrow::{schema_to_arrow_schema, RecordBatchPartitionSplitter};
 use iceberg::memory::{MemoryCatalogBuilder, MEMORY_CATALOG_WAREHOUSE};
-use iceberg::spec::{DataFileFormat, NestedField, PrimitiveType, Schema, Type};
+use iceberg::spec::{
+    DataFileFormat, NestedField, PrimitiveType, Schema, Transform, Type, UnboundPartitionSpec,
+};
 use iceberg::transaction::{ApplyTransactionAction, Transaction};
 use iceberg::writer::base_writer::data_file_writer::DataFileWriterBuilder;
 use iceberg::writer::file_writer::location_generator::{
@@ -24,6 +26,8 @@ use iceberg::writer::file_writer::location_generator::{
 };
 use iceberg::writer::file_writer::rolling_writer::RollingFileWriterBuilder;
 use iceberg::writer::file_writer::ParquetWriterBuilder;
+use iceberg::writer::partitioning::fanout_writer::FanoutWriter;
+use iceberg::writer::partitioning::PartitioningWriter;
 use iceberg::writer::{IcebergWriter, IcebergWriterBuilder};
 use iceberg::{Catalog, CatalogBuilder, NamespaceIdent, TableCreation, TableIdent};
 use polars::prelude::{DataFrame, DataType, Series, TimeUnit};
@@ -48,6 +52,7 @@ pub(crate) fn iceberg_accepted_adapter() -> &'static dyn AcceptedSinkAdapter {
 #[derive(Debug)]
 struct PreparedIcebergWrite {
     iceberg_schema: Schema,
+    partition_spec: Option<UnboundPartitionSpec>,
     batch: RecordBatch,
 }
 
@@ -215,6 +220,12 @@ async fn write_iceberg_table_async(
             &prepared.iceberg_schema,
             entity,
         )?;
+        ensure_partition_spec_matches(
+            existing.metadata().default_partition_spec(),
+            prepared.partition_spec.as_ref(),
+            &prepared.iceberg_schema,
+            entity,
+        )?;
     }
 
     let table = match mode {
@@ -227,6 +238,7 @@ async fn write_iceberg_table_async(
                     &table_ident,
                     table_root_uri.clone(),
                     &prepared.iceberg_schema,
+                    prepared.partition_spec.clone(),
                 )
                 .await?
             }
@@ -244,6 +256,7 @@ async fn write_iceberg_table_async(
                 &table_ident,
                 table_root_uri.clone(),
                 &prepared.iceberg_schema,
+                prepared.partition_spec.clone(),
             )
             .await?
         }
@@ -489,12 +502,16 @@ async fn create_table(
     table_ident: &TableIdent,
     table_root: String,
     schema: &Schema,
+    partition_spec: Option<UnboundPartitionSpec>,
 ) -> FloeResult<iceberg::table::Table> {
-    let creation = TableCreation::builder()
+    let creation_builder = TableCreation::builder()
         .name(table_ident.name().to_string())
         .location(table_root)
-        .schema(schema.clone())
-        .build();
+        .schema(schema.clone());
+    let creation = match partition_spec {
+        Some(partition_spec) => creation_builder.partition_spec(partition_spec).build(),
+        None => creation_builder.build(),
+    };
     catalog
         .create_table(namespace, creation)
         .await
@@ -523,18 +540,42 @@ async fn write_data_files(
         file_name_generator,
     );
 
-    let mut writer = DataFileWriterBuilder::new(rolling_writer_builder)
-        .build(None)
-        .await
-        .map_err(map_iceberg_err("iceberg data writer build failed"))?;
-    writer
-        .write(batch)
-        .await
-        .map_err(map_iceberg_err("iceberg data write failed"))?;
-    writer
-        .close()
-        .await
-        .map_err(map_iceberg_err("iceberg data writer close failed"))
+    let data_file_writer_builder = DataFileWriterBuilder::new(rolling_writer_builder);
+    let partition_spec = table.metadata().default_partition_spec().clone();
+    if partition_spec.is_unpartitioned() {
+        let mut writer = data_file_writer_builder
+            .build(None)
+            .await
+            .map_err(map_iceberg_err("iceberg data writer build failed"))?;
+        writer
+            .write(batch)
+            .await
+            .map_err(map_iceberg_err("iceberg data write failed"))?;
+        return writer
+            .close()
+            .await
+            .map_err(map_iceberg_err("iceberg data writer close failed"));
+    }
+
+    let splitter = RecordBatchPartitionSplitter::try_new_with_computed_values(
+        table.metadata().current_schema().clone(),
+        partition_spec,
+    )
+    .map_err(map_iceberg_err("iceberg partition splitter init failed"))?;
+    let partitioned_batches = splitter
+        .split(&batch)
+        .map_err(map_iceberg_err("iceberg partition split failed"))?;
+
+    let mut writer = FanoutWriter::new(data_file_writer_builder);
+    for (partition_key, partition_batch) in partitioned_batches {
+        writer
+            .write(partition_key, partition_batch)
+            .await
+            .map_err(map_iceberg_err("iceberg partitioned data write failed"))?;
+    }
+    writer.close().await.map_err(map_iceberg_err(
+        "iceberg partitioned data writer close failed",
+    ))
 }
 
 fn prepare_iceberg_write(
@@ -577,6 +618,7 @@ fn prepare_iceberg_write(
         .with_fields(iceberg_fields)
         .build()
         .map_err(map_iceberg_err("iceberg schema build failed"))?;
+    let partition_spec = build_unbound_partition_spec(&iceberg_schema, entity)?;
     let arrow_schema = Arc::new(
         schema_to_arrow_schema(&iceberg_schema)
             .map_err(map_iceberg_err("iceberg arrow schema conversion failed"))?,
@@ -589,8 +631,66 @@ fn prepare_iceberg_write(
 
     Ok(PreparedIcebergWrite {
         iceberg_schema,
+        partition_spec,
         batch,
     })
+}
+
+fn build_unbound_partition_spec(
+    iceberg_schema: &Schema,
+    entity: &config::EntityConfig,
+) -> FloeResult<Option<UnboundPartitionSpec>> {
+    let Some(fields) = entity.sink.accepted.partition_spec.as_ref() else {
+        return Ok(None);
+    };
+
+    let mut builder = UnboundPartitionSpec::builder();
+    for field in fields {
+        let column = field.column.trim();
+        let schema_field = iceberg_schema.field_by_name(column).ok_or_else(|| {
+            Box::new(RunError(format!(
+                "entity.name={} iceberg partition_spec column {} was not found in runtime schema",
+                entity.name, column
+            ))) as Box<dyn std::error::Error + Send + Sync>
+        })?;
+        let normalized_transform = field.transform.trim().to_ascii_lowercase();
+        let transform = iceberg_partition_transform(&normalized_transform, &entity.name, column)?;
+        let partition_field_name = iceberg_partition_field_name(column, &normalized_transform);
+        builder = builder
+            .add_partition_field(schema_field.id, partition_field_name, transform)
+            .map_err(map_iceberg_err("iceberg partition spec build failed"))?;
+    }
+
+    Ok(Some(builder.build()))
+}
+
+fn iceberg_partition_transform(
+    transform: &str,
+    entity_name: &str,
+    column: &str,
+) -> FloeResult<Transform> {
+    let iceberg_transform = match transform {
+        "identity" => Transform::Identity,
+        "year" => Transform::Year,
+        "month" => Transform::Month,
+        "day" => Transform::Day,
+        "hour" => Transform::Hour,
+        _ => {
+            return Err(Box::new(RunError(format!(
+            "entity.name={} iceberg partition_spec column {} has unsupported runtime transform {}",
+            entity_name, column, transform
+        ))))
+        }
+    };
+    Ok(iceberg_transform)
+}
+
+fn iceberg_partition_field_name(column: &str, transform: &str) -> String {
+    if transform == "identity" {
+        column.to_string()
+    } else {
+        format!("{column}_{transform}")
+    }
 }
 
 fn resolve_output_columns<'a>(
@@ -740,6 +840,33 @@ fn ensure_schema_matches(
     Ok(())
 }
 
+fn ensure_partition_spec_matches(
+    existing: &iceberg::spec::PartitionSpec,
+    expected: Option<&UnboundPartitionSpec>,
+    expected_schema: &Schema,
+    entity: &config::EntityConfig,
+) -> FloeResult<()> {
+    let Some(expected_unbound) = expected else {
+        return Ok(());
+    };
+
+    let expected_bound = expected_unbound
+        .clone()
+        .bind(Arc::new(expected_schema.clone()))
+        .map_err(map_iceberg_err("iceberg partition spec bind failed"))?;
+
+    if !existing.is_compatible_with(&expected_bound) {
+        return Err(Box::new(RunError(format!(
+            "entity.name={} iceberg partition spec evolution is not supported (existing={} incoming={})",
+            entity.name,
+            describe_partition_spec(existing),
+            describe_partition_spec(&expected_bound)
+        ))));
+    }
+
+    Ok(())
+}
+
 fn describe_field(field: &Arc<iceberg::spec::NestedField>) -> String {
     let required = if field.required {
         "required"
@@ -747,6 +874,18 @@ fn describe_field(field: &Arc<iceberg::spec::NestedField>) -> String {
         "optional"
     };
     format!("{}:{}:{required}", field.name, field.field_type)
+}
+
+fn describe_partition_spec(spec: &iceberg::spec::PartitionSpec) -> String {
+    if spec.fields().is_empty() {
+        return "unpartitioned".to_string();
+    }
+
+    spec.fields()
+        .iter()
+        .map(|field| format!("{}:{}:{:?}", field.source_id, field.name, field.transform))
+        .collect::<Vec<_>>()
+        .join(",")
 }
 
 fn latest_local_metadata_location(table_root: &Path) -> FloeResult<Option<String>> {

--- a/crates/floe-core/tests/integration/iceberg_run.rs
+++ b/crates/floe-core/tests/integration/iceberg_run.rs
@@ -1,7 +1,11 @@
+use std::collections::HashMap;
 use std::fs;
 use std::path::{Path, PathBuf};
 
 use floe_core::{run, RunOptions};
+use iceberg::memory::{MemoryCatalogBuilder, MEMORY_CATALOG_WAREHOUSE};
+use iceberg::spec::Transform;
+use iceberg::{Catalog, CatalogBuilder, NamespaceIdent, TableIdent};
 
 fn write_csv(dir: &Path, name: &str, contents: &str) -> PathBuf {
     let path = dir.join(name);
@@ -79,4 +83,151 @@ entities:
     assert_eq!(report.accepted_output.files_written, 1);
     assert_eq!(report.accepted_output.parts_written, 1);
     assert!(report.accepted_output.snapshot_id.is_some());
+}
+
+#[test]
+fn local_run_applies_iceberg_partition_spec_runtime() {
+    let temp_dir = tempfile::TempDir::new().expect("temp dir");
+    let root = temp_dir.path();
+    let input_dir = root.join("in");
+    let accepted_dir = root.join("out/accepted/customer_iceberg");
+    let report_dir = root.join("report");
+
+    fs::create_dir_all(&input_dir).expect("create input dir");
+    write_csv(&input_dir, "data.csv", "id,name\n1,alice\n2,bob\n");
+
+    let yaml = format!(
+        r#"version: "0.1"
+report:
+  path: "{report_dir}"
+entities:
+  - name: "customer"
+    source:
+      format: "csv"
+      path: "{input_dir}"
+    sink:
+      write_mode: "overwrite"
+      accepted:
+        format: "iceberg"
+        path: "{accepted_dir}"
+        partition_spec:
+          - column: "id"
+            transform: "identity"
+    policy:
+      severity: "warn"
+    schema:
+      columns:
+        - name: "id"
+          type: "int"
+        - name: "name"
+          type: "string"
+"#,
+        report_dir = report_dir.display(),
+        input_dir = input_dir.display(),
+        accepted_dir = accepted_dir.display(),
+    );
+    let config_path = write_config(root, &yaml);
+
+    run(
+        &config_path,
+        RunOptions {
+            run_id: Some("it-iceberg-partition-spec".to_string()),
+            entities: Vec::new(),
+            dry_run: false,
+        },
+    )
+    .expect("run config");
+
+    let data_entries = fs::read_dir(accepted_dir.join("data"))
+        .expect("data dir")
+        .map(|entry| {
+            entry
+                .expect("dir entry")
+                .file_name()
+                .to_string_lossy()
+                .to_string()
+        })
+        .collect::<Vec<_>>();
+    assert!(data_entries.iter().any(|name| name.starts_with("id=")));
+
+    let table = load_local_iceberg_table(&accepted_dir, "customer").expect("load iceberg table");
+    let fields = table.metadata().default_partition_spec().fields();
+    assert_eq!(fields.len(), 1);
+    assert_eq!(fields[0].name, "id");
+    assert_eq!(fields[0].transform, Transform::Identity);
+}
+
+fn load_local_iceberg_table(
+    table_path: &Path,
+    table_name: &str,
+) -> floe_core::FloeResult<iceberg::table::Table> {
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("runtime");
+    runtime.block_on(async {
+        let metadata_location = latest_metadata_location(table_path).ok_or_else(|| {
+            Box::new(floe_core::errors::RunError(
+                "missing iceberg metadata file".to_string(),
+            )) as Box<dyn std::error::Error + Send + Sync>
+        })?;
+        let catalog = MemoryCatalogBuilder::default()
+            .load(
+                "floe_test",
+                HashMap::from([(
+                    MEMORY_CATALOG_WAREHOUSE.to_string(),
+                    table_path.display().to_string(),
+                )]),
+            )
+            .await
+            .map_err(|err| {
+                Box::new(floe_core::errors::RunError(format!(
+                    "iceberg test catalog init failed: {err}"
+                ))) as Box<dyn std::error::Error + Send + Sync>
+            })?;
+        let namespace = NamespaceIdent::new("floe".to_string());
+        if !catalog.namespace_exists(&namespace).await.map_err(|err| {
+            Box::new(floe_core::errors::RunError(format!(
+                "iceberg test namespace exists failed: {err}"
+            ))) as Box<dyn std::error::Error + Send + Sync>
+        })? {
+            catalog
+                .create_namespace(&namespace, HashMap::new())
+                .await
+                .map_err(|err| {
+                    Box::new(floe_core::errors::RunError(format!(
+                        "iceberg test namespace create failed: {err}"
+                    ))) as Box<dyn std::error::Error + Send + Sync>
+                })?;
+        }
+        let ident = TableIdent::new(namespace, table_name.to_string());
+        catalog
+            .register_table(&ident, metadata_location)
+            .await
+            .map_err(|err| {
+                Box::new(floe_core::errors::RunError(format!(
+                    "iceberg test register table failed: {err}"
+                ))) as Box<dyn std::error::Error + Send + Sync>
+            })
+    })
+}
+
+fn latest_metadata_location(table_path: &Path) -> Option<String> {
+    let metadata_dir = table_path.join("metadata");
+    if !metadata_dir.exists() {
+        return None;
+    }
+    let mut files = fs::read_dir(metadata_dir)
+        .ok()?
+        .filter_map(Result::ok)
+        .map(|entry| entry.path())
+        .filter(|path| {
+            path.file_name()
+                .and_then(|name| name.to_str())
+                .map(|name| name.ends_with(".metadata.json"))
+                .unwrap_or(false)
+        })
+        .collect::<Vec<_>>();
+    files.sort();
+    files.last().map(|path| path.display().to_string())
 }

--- a/crates/floe-core/tests/unit/io/write/iceberg_write.rs
+++ b/crates/floe-core/tests/unit/io/write/iceberg_write.rs
@@ -8,8 +8,9 @@ use floe_core::io::write::iceberg::write_iceberg_table;
 use floe_core::{config, FloeResult};
 use futures::TryStreamExt;
 use iceberg::memory::{MemoryCatalogBuilder, MEMORY_CATALOG_WAREHOUSE};
+use iceberg::spec::Transform;
 use iceberg::{Catalog, CatalogBuilder, NamespaceIdent, TableIdent};
-use polars::prelude::{df, DataFrame, NamedFrom, Series};
+use polars::prelude::{df, DataFrame, DataType, NamedFrom, Series, TimeUnit};
 
 #[test]
 fn write_iceberg_table_append_creates_new_snapshot_and_metadata_version() -> FloeResult<()> {
@@ -214,6 +215,158 @@ fn write_iceberg_table_append_without_schema_keeps_nullability_stable() -> FloeR
     Ok(())
 }
 
+#[test]
+fn write_iceberg_table_applies_partition_spec_transforms_to_table_metadata_and_layout(
+) -> FloeResult<()> {
+    let temp_dir = tempfile::TempDir::new()?;
+    let table_path = temp_dir.path().join("iceberg_table");
+    let config = empty_root_config();
+    let resolver = config::StorageResolver::from_path(&config, temp_dir.path())?;
+    let target = resolve_local_target(&resolver, &table_path)?;
+    let mut entity = build_entity(
+        &table_path,
+        config::WriteMode::Overwrite,
+        vec![
+            column("id", "int"),
+            column("ts_year", "timestamp"),
+            column("ts_month", "timestamp"),
+            column("ts_day", "timestamp"),
+            column("ts_hour", "timestamp"),
+            column("name", "string"),
+        ],
+        None,
+    );
+    entity.sink.accepted.partition_spec = Some(vec![
+        config::IcebergPartitionFieldConfig {
+            column: "id".to_string(),
+            transform: "identity".to_string(),
+        },
+        config::IcebergPartitionFieldConfig {
+            column: "ts_year".to_string(),
+            transform: "year".to_string(),
+        },
+        config::IcebergPartitionFieldConfig {
+            column: "ts_month".to_string(),
+            transform: "month".to_string(),
+        },
+        config::IcebergPartitionFieldConfig {
+            column: "ts_day".to_string(),
+            transform: "day".to_string(),
+        },
+        config::IcebergPartitionFieldConfig {
+            column: "ts_hour".to_string(),
+            transform: "hour".to_string(),
+        },
+    ]);
+
+    let ts_raw = Series::new(
+        "ts".into(),
+        &[1_706_847_000_000_000_i64, 1_706_850_600_000_000_i64],
+    );
+    let ts = ts_raw.cast(&DataType::Datetime(TimeUnit::Microseconds, None))?;
+    let mut ts_year = ts.clone();
+    ts_year.rename("ts_year".into());
+    let mut ts_month = ts.clone();
+    ts_month.rename("ts_month".into());
+    let mut ts_day = ts.clone();
+    ts_day.rename("ts_day".into());
+    let mut ts_hour = ts.clone();
+    ts_hour.rename("ts_hour".into());
+    let mut df = DataFrame::new(vec![
+        Series::new("id".into(), &[1_i64, 2_i64]).into(),
+        ts_year.into(),
+        ts_month.into(),
+        ts_day.into(),
+        ts_hour.into(),
+        Series::new("name".into(), &["alice", "bob"]).into(),
+    ])?;
+
+    let out = write_iceberg_table(&mut df, &target, &entity, config::WriteMode::Overwrite)?;
+    assert_eq!(out.parts_written, 2);
+    assert!(out.snapshot_id.is_some());
+
+    let runtime = test_runtime()?;
+    runtime.block_on(async {
+        let table = load_table(&table_path).await?;
+        let spec = table.metadata().default_partition_spec();
+        let fields = spec.fields();
+        assert_eq!(fields.len(), 5);
+        assert_eq!(fields[0].name, "id");
+        assert_eq!(fields[0].transform, Transform::Identity);
+        assert_eq!(fields[1].name, "ts_year_year");
+        assert_eq!(fields[1].transform, Transform::Year);
+        assert_eq!(fields[2].name, "ts_month_month");
+        assert_eq!(fields[2].transform, Transform::Month);
+        assert_eq!(fields[3].name, "ts_day_day");
+        assert_eq!(fields[3].transform, Transform::Day);
+        assert_eq!(fields[4].name, "ts_hour_hour");
+        assert_eq!(fields[4].transform, Transform::Hour);
+        Ok::<(), Box<dyn std::error::Error + Send + Sync>>(())
+    })?;
+
+    let data_dirs = fs::read_dir(table_path.join("data"))?
+        .filter_map(Result::ok)
+        .map(|entry| entry.file_name().to_string_lossy().to_string())
+        .collect::<Vec<_>>();
+    assert!(data_dirs.iter().any(|name| name.starts_with("id=")));
+
+    Ok(())
+}
+
+#[test]
+fn write_iceberg_table_rejects_unsupported_partition_transform_at_runtime() -> FloeResult<()> {
+    let temp_dir = tempfile::TempDir::new()?;
+    let table_path = temp_dir.path().join("iceberg_table");
+    let config = empty_root_config();
+    let resolver = config::StorageResolver::from_path(&config, temp_dir.path())?;
+    let target = resolve_local_target(&resolver, &table_path)?;
+    let mut entity = build_entity(
+        &table_path,
+        config::WriteMode::Overwrite,
+        vec![column("id", "int")],
+        None,
+    );
+    entity.sink.accepted.partition_spec = Some(vec![config::IcebergPartitionFieldConfig {
+        column: "id".to_string(),
+        transform: "bucket[16]".to_string(),
+    }]);
+
+    let mut df = df!("id" => &[1_i64, 2_i64])?;
+    let err = write_iceberg_table(&mut df, &target, &entity, config::WriteMode::Overwrite)
+        .expect_err("unsupported runtime transform should error");
+    let msg = err.to_string();
+    assert!(msg.contains("unsupported runtime transform"));
+    assert!(msg.contains("bucket[16]"));
+    Ok(())
+}
+
+#[test]
+fn write_iceberg_table_rejects_missing_partition_column_at_runtime() -> FloeResult<()> {
+    let temp_dir = tempfile::TempDir::new()?;
+    let table_path = temp_dir.path().join("iceberg_table");
+    let config = empty_root_config();
+    let resolver = config::StorageResolver::from_path(&config, temp_dir.path())?;
+    let target = resolve_local_target(&resolver, &table_path)?;
+    let mut entity = build_entity(
+        &table_path,
+        config::WriteMode::Overwrite,
+        vec![column("id", "int")],
+        None,
+    );
+    entity.sink.accepted.partition_spec = Some(vec![config::IcebergPartitionFieldConfig {
+        column: "missing".to_string(),
+        transform: "identity".to_string(),
+    }]);
+
+    let mut df = df!("id" => &[1_i64, 2_i64])?;
+    let err = write_iceberg_table(&mut df, &target, &entity, config::WriteMode::Overwrite)
+        .expect_err("missing runtime partition column should error");
+    let msg = err.to_string();
+    assert!(msg.contains("partition_spec column missing"));
+    assert!(msg.contains("runtime schema"));
+    Ok(())
+}
+
 fn empty_root_config() -> config::RootConfig {
     config::RootConfig {
         version: "0.1".to_string(),
@@ -280,6 +433,18 @@ fn build_entity(
             mismatch: None,
             columns,
         },
+    }
+}
+
+fn column(name: &str, column_type: &str) -> config::ColumnConfig {
+    config::ColumnConfig {
+        name: name.to_string(),
+        source: None,
+        column_type: column_type.to_string(),
+        nullable: Some(true),
+        unique: None,
+        width: None,
+        trim: None,
     }
 }
 

--- a/docs/sinks/iceberg.md
+++ b/docs/sinks/iceberg.md
@@ -80,10 +80,10 @@ entities:
           type: "string"
 ```
 
-## Partition spec config (Phase A scaffolding)
+## Partition spec config
 
-Iceberg accepted sinks can now declare a validated partition spec in config
-(execution wiring is pending):
+Iceberg accepted sinks can declare a partition spec in config, and Floe executes
+it at write time for Iceberg table creation/data file layout:
 
 ```yaml
 sink:
@@ -97,10 +97,10 @@ sink:
         transform: "identity"
 ```
 
-Current validation scope:
+Current scope:
 - partition columns must exist in `schema.columns`
-- supported transforms (parse/validation phase): `identity`, `year`, `month`, `day`, `hour`
-- execution wiring for Iceberg partitioned writes remains a follow-up PR
+- supported transforms: `identity`, `year`, `month`, `day`, `hour`
+- partition spec is applied to Iceberg table metadata and partitioned file writes
 - compaction/optimization remains external to Floe
 
 ## Supported scope (current)


### PR DESCRIPTION
## Summary
- Implements runtime execution of `sink.accepted.partition_spec` for Iceberg accepted sinks (follow-up to #159)
- Applies the configured Iceberg partition spec during table creation and partitioned data-file writes
- Keeps existing append/overwrite semantics and the shared local/S3/GCS/Glue Iceberg writer flow intact

Closes #175

## What Is Implemented
- Runtime mapping from Floe Iceberg partition config to Iceberg partition transforms:
  - `identity`
  - `year`
  - `month`
  - `day`
  - `hour`
- Iceberg table creation now includes the configured partition spec (`UnboundPartitionSpec`)
- Partitioned Iceberg writes now use Iceberg Arrow partition splitting + partition-aware writers, so the `data/` object layout matches the table partition spec
- Append path defensively rejects partition-spec evolution when a configured spec does not match the existing table default partition spec
- Defensive runtime errors for unexpected invalid transform / missing partition column (if config validation is bypassed)

## Tested Sinks / Paths
- Local filesystem Iceberg: end-to-end covered (required)
- Cloud compatibility note: S3/GCS filesystem and Glue-over-S3 continue to use the same shared Iceberg write path; this PR changes the common partitioned write execution path, not storage-specific resolution

## Test Coverage Added
- Unit (`crates/floe-core/tests/unit/io/write/iceberg_write.rs`)
  - partition spec transform mapping/runtime metadata + layout behavior
  - defensive runtime error cases
- Integration (`crates/floe-core/tests/integration/iceberg_run.rs`)
  - local `floe run` with `partition_spec`
  - verifies Iceberg metadata default partition spec + partitioned `data/` layout

Validation run:
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all`

## Explicit Non-Goals (unchanged)
- Iceberg write metrics (#176)
- schema evolution / partition evolution
- merge/upsert
- cleanup / GC
