### PR TITLE
[codex] #177 delta remote commit-log metrics via object_store

### DIFF
--- a/crates/floe-core/src/io/write/delta.rs
+++ b/crates/floe-core/src/io/write/delta.rs
@@ -1,5 +1,3 @@
-use std::fs::File;
-use std::io::{BufRead, BufReader};
 use std::path::Path;
 use std::sync::Arc;
 
@@ -10,6 +8,7 @@ use deltalake::arrow::array::{
 };
 use deltalake::arrow::datatypes::{Field, Schema};
 use deltalake::arrow::record_batch::RecordBatch;
+use deltalake::logstore::read_commit_entry;
 use deltalake::protocol::SaveMode;
 use deltalake::table::builder::DeltaTableBuilder;
 use polars::prelude::{DataFrame, DataType, TimeUnit};
@@ -139,8 +138,14 @@ fn write_delta_table_with_metrics(
         })
         .map_err(|err| Box::new(RunError(format!("delta write failed: {err}"))))?;
 
-    let (files_written, part_files, metrics) =
-        delta_commit_metrics_for_target(target, version, small_file_threshold_bytes)?;
+    let (files_written, part_files, metrics) = delta_commit_metrics_for_target(
+        &runtime,
+        target,
+        resolver,
+        entity,
+        version,
+        small_file_threshold_bytes,
+    )?;
 
     Ok(DeltaWriteResult {
         version,
@@ -181,41 +186,39 @@ impl AcceptedSinkAdapter for DeltaAcceptedAdapter {
 }
 
 fn delta_commit_metrics_for_target(
+    runtime: &tokio::runtime::Runtime,
     target: &Target,
+    resolver: &config::StorageResolver,
+    entity: &config::EntityConfig,
     version: i64,
     small_file_threshold_bytes: u64,
 ) -> FloeResult<(u64, Vec<String>, AcceptedWriteMetrics)> {
     match target {
         Target::Local { base_path, .. } => {
             let stats = delta_commit_add_stats(Path::new(base_path), version)?;
-            let metrics = if stats.file_sizes.len() == stats.files_written as usize {
-                metrics::summarize_written_file_sizes(&stats.file_sizes, small_file_threshold_bytes)
-            } else {
-                AcceptedWriteMetrics {
-                    total_bytes_written: None,
-                    avg_file_size_mb: None,
-                    small_files_count: None,
-                }
-            };
-            Ok((stats.files_written, stats.part_files, metrics))
+            Ok(delta_commit_stats_to_output(
+                stats,
+                small_file_threshold_bytes,
+            ))
         }
-        // Remote Delta writes may produce multiple data files (partitioning, writer chunking).
-        // Until commit-log parsing is implemented via object_store, keep the count unknown
-        // instead of reporting an incorrect hardcoded value.
-        Target::S3 { .. } | Target::Gcs { .. } | Target::Adls { .. } => Ok((
-            0,
-            Vec::new(),
-            AcceptedWriteMetrics {
-                total_bytes_written: None,
-                avg_file_size_mb: None,
-                small_files_count: None,
-            },
-        )),
+        // Best-effort metrics for remote targets: never fail a successful write because the
+        // commit log could not be read or parsed after commit.
+        Target::S3 { .. } | Target::Gcs { .. } | Target::Adls { .. } => {
+            match delta_commit_add_stats_via_object_store(
+                runtime, target, resolver, entity, version,
+            ) {
+                Ok(stats) => Ok(delta_commit_stats_to_output(
+                    stats,
+                    small_file_threshold_bytes,
+                )),
+                Err(_) => Ok(delta_commit_metrics_fallback_unknown()),
+            }
+        }
     }
 }
 
-#[derive(Debug, Default)]
-struct DeltaCommitAddStats {
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct DeltaCommitAddStats {
     files_written: u64,
     part_files: Vec<String>,
     file_sizes: Vec<u64>,
@@ -225,20 +228,64 @@ fn delta_commit_add_stats(table_root: &Path, version: i64) -> FloeResult<DeltaCo
     let log_path = table_root
         .join("_delta_log")
         .join(format!("{version:020}.json"));
-    let file = File::open(&log_path).map_err(|err| {
+    let bytes = std::fs::read(&log_path).map_err(|err| {
         Box::new(RunError(format!(
             "delta metrics failed to open commit log {}: {err}",
             log_path.display()
         )))
     })?;
-    let reader = BufReader::new(file);
-    let mut stats = DeltaCommitAddStats::default();
-    for line in reader.lines() {
-        let line = line?;
-        let record: Value = serde_json::from_str(&line).map_err(|err| {
+    parse_delta_commit_add_stats_bytes_with_context(&bytes, &log_path.display().to_string())
+}
+
+fn delta_commit_add_stats_via_object_store(
+    runtime: &tokio::runtime::Runtime,
+    target: &Target,
+    resolver: &config::StorageResolver,
+    entity: &config::EntityConfig,
+    version: i64,
+) -> FloeResult<DeltaCommitAddStats> {
+    let store = object_store::delta_store_config(target, resolver, entity)?;
+    let builder = DeltaTableBuilder::from_url(store.table_url.clone())
+        .map_err(|err| Box::new(RunError(format!("delta metrics builder failed: {err}"))))?
+        .with_storage_options(store.storage_options);
+    let log_store = builder.build_storage().map_err(|err| {
+        Box::new(RunError(format!(
+            "delta metrics log store init failed: {err}"
+        )))
+    })?;
+    let bytes = runtime
+        .block_on(async { read_commit_entry(log_store.object_store(None).as_ref(), version).await })
+        .map_err(|err| Box::new(RunError(format!("delta metrics commit read failed: {err}"))))?
+        .ok_or_else(|| {
             Box::new(RunError(format!(
-                "delta metrics failed to parse commit log {}: {err}",
-                log_path.display()
+                "delta metrics commit log missing for version {version}"
+            ))) as Box<dyn std::error::Error + Send + Sync>
+        })?;
+    parse_delta_commit_add_stats_bytes_with_context(
+        bytes.as_ref(),
+        &format!("remote delta commit version {version}"),
+    )
+}
+
+#[doc(hidden)]
+pub fn parse_delta_commit_add_stats_bytes(bytes: &[u8]) -> FloeResult<DeltaCommitAddStats> {
+    parse_delta_commit_add_stats_bytes_with_context(bytes, "delta commit log bytes")
+}
+
+fn parse_delta_commit_add_stats_bytes_with_context(
+    bytes: &[u8],
+    context: &str,
+) -> FloeResult<DeltaCommitAddStats> {
+    let content = std::str::from_utf8(bytes).map_err(|err| {
+        Box::new(RunError(format!(
+            "delta metrics failed to decode {context} as utf-8: {err}"
+        )))
+    })?;
+    let mut stats = DeltaCommitAddStats::default();
+    for line in content.lines() {
+        let record: Value = serde_json::from_str(line).map_err(|err| {
+            Box::new(RunError(format!(
+                "delta metrics failed to parse {context}: {err}"
             )))
         })?;
         let Some(add) = record.get("add") else {
@@ -260,6 +307,53 @@ fn delta_commit_add_stats(table_root: &Path, version: i64) -> FloeResult<DeltaCo
         }
     }
     Ok(stats)
+}
+
+#[doc(hidden)]
+pub fn delta_commit_metrics_from_log_bytes(
+    bytes: &[u8],
+    small_file_threshold_bytes: u64,
+) -> FloeResult<(u64, Vec<String>, AcceptedWriteMetrics)> {
+    let stats = parse_delta_commit_add_stats_bytes(bytes)?;
+    Ok(delta_commit_stats_to_output(
+        stats,
+        small_file_threshold_bytes,
+    ))
+}
+
+#[doc(hidden)]
+pub fn delta_commit_metrics_from_log_bytes_best_effort(
+    bytes: &[u8],
+    small_file_threshold_bytes: u64,
+) -> (u64, Vec<String>, AcceptedWriteMetrics) {
+    match delta_commit_metrics_from_log_bytes(bytes, small_file_threshold_bytes) {
+        Ok(output) => output,
+        Err(_) => delta_commit_metrics_fallback_unknown(),
+    }
+}
+
+fn delta_commit_stats_to_output(
+    stats: DeltaCommitAddStats,
+    small_file_threshold_bytes: u64,
+) -> (u64, Vec<String>, AcceptedWriteMetrics) {
+    let metrics = if stats.file_sizes.len() == stats.files_written as usize {
+        metrics::summarize_written_file_sizes(&stats.file_sizes, small_file_threshold_bytes)
+    } else {
+        null_accepted_write_metrics()
+    };
+    (stats.files_written, stats.part_files, metrics)
+}
+
+fn delta_commit_metrics_fallback_unknown() -> (u64, Vec<String>, AcceptedWriteMetrics) {
+    (0, Vec::new(), null_accepted_write_metrics())
+}
+
+fn null_accepted_write_metrics() -> AcceptedWriteMetrics {
+    AcceptedWriteMetrics {
+        total_bytes_written: None,
+        avg_file_size_mb: None,
+        small_files_count: None,
+    }
 }
 
 fn dataframe_to_record_batch(

--- a/crates/floe-core/tests/unit/io/write/delta_write.rs
+++ b/crates/floe-core/tests/unit/io/write/delta_write.rs
@@ -1,5 +1,8 @@
 use floe_core::io::storage::Target;
-use floe_core::io::write::delta::{delta_write_runtime_options, write_delta_table};
+use floe_core::io::write::delta::{
+    delta_commit_metrics_from_log_bytes, delta_commit_metrics_from_log_bytes_best_effort,
+    delta_write_runtime_options, write_delta_table,
+};
 use floe_core::{config, FloeResult};
 use polars::prelude::{df, ParquetReader, SerReader};
 use std::path::Path;
@@ -316,6 +319,65 @@ fn write_delta_table_respects_partition_by_columns() -> FloeResult<()> {
     assert!(entries.iter().any(|name| name == "country=ca"));
 
     Ok(())
+}
+
+#[test]
+fn delta_commit_metrics_from_log_bytes_counts_add_actions_and_caps_part_files() -> FloeResult<()> {
+    let mut content = String::new();
+    for i in 0..55_u64 {
+        content.push_str(
+            format!(
+                "{{\"add\":{{\"path\":\"country=us/part-{i:05}.parquet\",\"size\":{}}}}}\n",
+                i + 10
+            )
+            .as_str(),
+        );
+    }
+    content.push_str("{\"commitInfo\":{\"operation\":\"WRITE\"}}\n");
+
+    let (files_written, part_files, metrics) =
+        delta_commit_metrics_from_log_bytes(content.as_bytes(), 32)?;
+
+    assert_eq!(files_written, 55);
+    assert_eq!(part_files.len(), 50);
+    assert_eq!(part_files[0], "part-00000.parquet");
+    assert_eq!(part_files[49], "part-00049.parquet");
+    assert_eq!(metrics.total_bytes_written, Some((10..65).sum()));
+    assert_eq!(metrics.small_files_count, Some(22));
+    assert!(metrics.avg_file_size_mb.is_some());
+    Ok(())
+}
+
+#[test]
+fn delta_commit_metrics_from_log_bytes_missing_size_keeps_file_count_but_nulls_metrics(
+) -> FloeResult<()> {
+    let content = r#"{"add":{"path":"part-00000.parquet","size":10}}
+{"add":{"path":"part-00001.parquet"}}
+"#;
+
+    let (files_written, part_files, metrics) =
+        delta_commit_metrics_from_log_bytes(content.as_bytes(), 16)?;
+
+    assert_eq!(files_written, 2);
+    assert_eq!(part_files, vec!["part-00000.parquet", "part-00001.parquet"]);
+    assert_eq!(metrics.total_bytes_written, None);
+    assert_eq!(metrics.avg_file_size_mb, None);
+    assert_eq!(metrics.small_files_count, None);
+    Ok(())
+}
+
+#[test]
+fn delta_commit_metrics_from_log_bytes_best_effort_falls_back_on_malformed_json() {
+    let malformed = b"{\"add\":{\"path\":\"part-00000.parquet\",\"size\":10}}\n{\"add\":\n";
+
+    let (files_written, part_files, metrics) =
+        delta_commit_metrics_from_log_bytes_best_effort(malformed, 16);
+
+    assert_eq!(files_written, 0);
+    assert!(part_files.is_empty());
+    assert_eq!(metrics.total_bytes_written, None);
+    assert_eq!(metrics.avg_file_size_mb, None);
+    assert_eq!(metrics.small_files_count, None);
 }
 
 fn empty_root_config() -> config::RootConfig {


### PR DESCRIPTION
## Summary
Implements **#177**: Delta remote write metrics now read the committed Delta log entry through `object_store` and compute exact accepted-output metrics for remote Delta targets.

Parent context:
- `#159` introduced accepted output metrics fields in reports.
- `#172` (Phase B) populated Parquet + local Delta metrics and intentionally left remote Delta metrics partial/null.

This PR closes the remote Delta gap without changing Delta write behavior.

Refs #177

## What changed
### Remote Delta commit-log metrics via object_store
After a successful Delta write, Floe now reads exactly one commit log file:
- `_delta_log/<version>.json`

For remote Delta targets (`s3://`, `gs://`, `abfs://`), the commit entry is fetched through Delta's `object_store` / log-store stack and parsed line-by-line (JSON actions).

### Exact metric semantics (locked behavior)
Metrics are derived from **`add` actions only** in the committed version file:
- `files_written` = number of `add` actions in `_delta_log/<version>.json`
- `part_files` = basenames from `add.path` (capped at 50)
- `total_bytes_written` = sum of `add.size`
- `avg_file_size_mb` = average of `add.size` values (MiB)
- `small_files_count` = count of `add.size` values below Floe's small-file threshold

### Best-effort fallback (no write regression)
If metrics collection fails **after a successful Delta write** (for example object_store read error or malformed commit log parsing):
- ingestion still succeeds (write semantics preserved)
- `part_files` is empty
- size metrics remain nullable (`null`)
- no fake size metrics are emitted

(`files_written` falls back to `0` as the existing non-optional unknown sentinel when commit metrics cannot be read.)

## Scope / non-goals
- No Delta write behavior changes
- No Delta partitioning changes (already handled in `#172`)
- No Iceberg metrics work (tracked separately, e.g. `#176`)
- No report schema changes (fields already existed)

## Implementation notes
- Reuses the existing `io/write/metrics.rs` helper for size metric aggregation.
- Refactors Delta commit parsing into shared byte-based helpers so local and remote commit parsing follow the same `add`-action semantics.
- Remote metrics read uses Delta's log-store `object_store` path and fetches only the committed version file (no table listing).

## Supported remote targets
- S3 (`s3://`)
- GCS (`gs://`)
- ADLS (`abfs://`)

## Tests
### Unit (`crates/floe-core/tests/unit/...`)
Added Delta commit-log parser/metrics tests covering:
- `add` action counting semantics
- `part_files` basename extraction and 50-item cap
- partial commit actions (missing `size`) => exact file count but nullable size metrics
- malformed JSON => best-effort fallback (empty `part_files`, nullable metrics)

### Integration (`crates/floe-core/tests/integration/...`)
Existing Delta integration scenarios continue to pass, validating local behavior remains unchanged.
(No credentialed remote integration test was added in this PR; remote object_store paths remain exercised via unit parser coverage and existing Delta write paths.)

## Validation
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all`
