### PR TITLE
prepare v0.2.8 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to Floe are documented in this file.
 
+## v0.2.8
+
+- Iceberg accepted sink:
+  - runtime execution of `sink.accepted.partition_spec` for supported transforms (`identity`, `year`, `month`, `day`, `hour`)
+  - write-time file sizing metrics in entity reports (`files_written`, `total_bytes_written`, `avg_file_size_mb`, `small_files_count`)
+- Delta accepted sink:
+  - exact remote commit-log write metrics (S3/GCS/ADLS) collected via object store commit entry parsing (best-effort fallback keeps metrics nullable)
+- `dagster-floe` connector package version bumped to `0.1.2` in the same release prep.
+
 ## v0.2.7
 
 - Added Iceberg S3 accepted sink support (filesystem catalog, no data catalog / Glue yet).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3376,7 +3376,7 @@ dependencies = [
 
 [[package]]
 name = "floe-cli"
-version = "0.2.7"
+version = "0.2.8"
 dependencies = [
  "assert_cmd",
  "clap",
@@ -3389,7 +3389,7 @@ dependencies = [
 
 [[package]]
 name = "floe-core"
-version = "0.2.7"
+version = "0.2.8"
 dependencies = [
  "apache-avro 0.16.0",
  "arrow",

--- a/crates/floe-cli/Cargo.toml
+++ b/crates/floe-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "floe-cli"
-version = "0.2.7"
+version = "0.2.8"
 edition = "2021"
 description = "CLI for Floe, a YAML-driven technical ingestion tool."
 license = "MIT"
@@ -17,7 +17,7 @@ path = "src/main.rs"
 
 [dependencies]
 clap = { version = "4", features = ["derive"] }
-floe-core = { path = "../floe-core", version = "0.2.7" }
+floe-core = { path = "../floe-core", version = "0.2.8" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 

--- a/crates/floe-core/Cargo.toml
+++ b/crates/floe-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "floe-core"
-version = "0.2.7"
+version = "0.2.8"
 edition = "2021"
 description = "Core library for Floe, a YAML-driven technical ingestion tool."
 license = "MIT"

--- a/orchestrators/dagster-floe/pyproject.toml
+++ b/orchestrators/dagster-floe/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "dagster-floe"
-version = "0.1.1"
+version = "0.1.2"
 description = "Dagster connector for Floe CLI (config-driven ingestion)"
 requires-python = ">=3.10"
 readme = "README.md"


### PR DESCRIPTION
## Summary
This PR prepares the `v0.2.8` release for Floe and bumps the `dagster-floe` connector package version in the same release prep.

## What is included
This release prep updates versioning and release metadata only:

- Floe crate version bumps to `0.2.8`
  - `crates/floe-core/Cargo.toml`
  - `crates/floe-cli/Cargo.toml`
  - `crates/floe-cli` dependency on `floe-core`
- `Cargo.lock` refreshed to reflect the new local crate versions
- `CHANGELOG.md` updated with the `v0.2.8` entry
- `orchestrators/dagster-floe/pyproject.toml` bumped from `0.1.1` to `0.1.2`

## User-facing changes captured in v0.2.8 changelog
- Iceberg accepted sink:
  - runtime execution of `sink.accepted.partition_spec`
  - write-time file sizing metrics in entity reports
- Delta accepted sink:
  - exact remote commit-log write metrics via object store parsing (best-effort fallback remains nullable)
- Dagster connector package version bump (`dagster-floe 0.1.2`)

## Validation
- `cargo check -p floe-cli`

## Notes
- This PR is release preparation only (no feature implementation changes).
- After merge, tag `v0.2.8` on `main` to trigger release workflows.
