### PR TITLE
prepare v0.3.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to Floe are documented in this file.
 
+## v0.3.0
+
+- Core performance and observability:
+  - added internal phase timing instrumentation (gated by `FLOE_PERF_PHASE_TIMINGS`) for run- and entity-level phases
+  - reduced CSV read overhead by reusing prechecked input columns in the read path
+  - optimized JSON `read_parse` path by reducing intermediate row allocations during selector extraction.
+- Core refactoring (no intended behavior change):
+  - split `run/entity` validation + split/reject flow into dedicated modules
+  - split accepted write phase/report-state plumbing out of `run/entity/mod.rs`
+  - further modularized writer internals (Delta/Iceberg) and report plumbing for maintainability.
+- Documentation:
+  - refreshed v0.3 release communication draft and docs updates for the new core organization/perf instrumentation.
+
 ## v0.2.8
 
 - Iceberg accepted sink:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3376,7 +3376,7 @@ dependencies = [
 
 [[package]]
 name = "floe-cli"
-version = "0.2.8"
+version = "0.3.0"
 dependencies = [
  "assert_cmd",
  "clap",
@@ -3389,7 +3389,7 @@ dependencies = [
 
 [[package]]
 name = "floe-core"
-version = "0.2.8"
+version = "0.3.0"
 dependencies = [
  "apache-avro 0.16.0",
  "arrow",

--- a/crates/floe-cli/Cargo.toml
+++ b/crates/floe-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "floe-cli"
-version = "0.2.8"
+version = "0.3.0"
 edition = "2021"
 description = "CLI for Floe, a YAML-driven technical ingestion tool."
 license = "MIT"
@@ -17,7 +17,7 @@ path = "src/main.rs"
 
 [dependencies]
 clap = { version = "4", features = ["derive"] }
-floe-core = { path = "../floe-core", version = "0.2.8" }
+floe-core = { path = "../floe-core", version = "0.3.0" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 

--- a/crates/floe-core/Cargo.toml
+++ b/crates/floe-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "floe-core"
-version = "0.2.8"
+version = "0.3.0"
 edition = "2021"
 description = "Core library for Floe, a YAML-driven technical ingestion tool."
 license = "MIT"


### PR DESCRIPTION
## Summary
- bump floe-core and floe-cli to v0.3.0
- refresh Cargo.lock\n- add v0.3.0 changelog entry

## Notes\
- Floe-only release prep (connector package versions unchanged in this PR)