### PR TITLE
feat(core): composite unique keys with primary_key constraints

### DIFF
--- a/config.schema.yaml
+++ b/config.schema.yaml
@@ -332,6 +332,19 @@ $defs:
         $ref: "#/$defs/normalize_columns"
       mismatch:
         $ref: "#/$defs/schema_mismatch"
+      primary_key:
+        type: array
+        minItems: 1
+        items:
+          type: string
+      unique_keys:
+        type: array
+        minItems: 1
+        items:
+          type: array
+          minItems: 1
+          items:
+            type: string
       columns:
         type: array
         items:

--- a/crates/floe-cli/tests/output.rs
+++ b/crates/floe-cli/tests/output.rs
@@ -62,6 +62,7 @@ fn sample_outcome() -> RunOutcome {
             avg_file_size_mb: None,
             small_files_count: None,
         },
+        unique_constraints: Vec::new(),
         results: report::ResultsTotals {
             files_total: 1,
             rows_total: 10,

--- a/crates/floe-core/src/checks/mod.rs
+++ b/crates/floe-core/src/checks/mod.rs
@@ -15,7 +15,10 @@ pub use mismatch::{
     top_level_declared_columns, MismatchOutcome,
 };
 pub use not_null::{not_null_counts, not_null_errors, not_null_errors_sparse};
-pub use unique::{unique_counts, unique_errors, unique_errors_sparse, UniqueTracker};
+pub use unique::{
+    resolve_schema_unique_keys, unique_counts, unique_errors, unique_errors_sparse,
+    UniqueConstraint, UniqueConstraintResult, UniqueTracker,
+};
 
 pub type ColumnIndex = HashMap<String, usize>;
 

--- a/crates/floe-core/src/checks/unique.rs
+++ b/crates/floe-core/src/checks/unique.rs
@@ -1,9 +1,11 @@
-use polars::prelude::{is_duplicated, is_first_distinct, AnyValue, DataFrame};
-use std::collections::{HashMap, HashSet};
+use polars::prelude::{AnyValue, DataFrame, Series};
+use std::collections::{BTreeMap, HashMap, HashSet};
 
 use super::{ColumnIndex, RowError, SparseRowErrors};
 use crate::errors::RunError;
 use crate::{config, FloeResult};
+
+const UNIQUE_SAMPLE_LIMIT: usize = 5;
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 enum UniqueKey {
@@ -15,195 +17,110 @@ enum UniqueKey {
     Other(String),
 }
 
-fn unique_key(value: AnyValue) -> Option<UniqueKey> {
-    match value {
-        AnyValue::Null => None,
-        AnyValue::Boolean(value) => Some(UniqueKey::Bool(value)),
-        AnyValue::Int8(value) => Some(UniqueKey::I64(value as i64)),
-        AnyValue::Int16(value) => Some(UniqueKey::I64(value as i64)),
-        AnyValue::Int32(value) => Some(UniqueKey::I64(value as i64)),
-        AnyValue::Int64(value) => Some(UniqueKey::I64(value)),
-        AnyValue::Int128(value) => Some(UniqueKey::Other(value.to_string())),
-        AnyValue::UInt8(value) => Some(UniqueKey::U64(value as u64)),
-        AnyValue::UInt16(value) => Some(UniqueKey::U64(value as u64)),
-        AnyValue::UInt32(value) => Some(UniqueKey::U64(value as u64)),
-        AnyValue::UInt64(value) => Some(UniqueKey::U64(value)),
-        AnyValue::UInt128(value) => Some(UniqueKey::Other(value.to_string())),
-        AnyValue::Float32(value) => Some(UniqueKey::F64((value as f64).to_bits())),
-        AnyValue::Float64(value) => Some(UniqueKey::F64(value.to_bits())),
-        AnyValue::String(value) => Some(UniqueKey::String(value.to_string())),
-        AnyValue::StringOwned(value) => Some(UniqueKey::String(value.to_string())),
-        other => Some(UniqueKey::Other(other.to_string())),
+impl UniqueKey {
+    fn as_string(&self) -> String {
+        match self {
+            UniqueKey::Bool(value) => value.to_string(),
+            UniqueKey::I64(value) => value.to_string(),
+            UniqueKey::U64(value) => value.to_string(),
+            UniqueKey::F64(value) => f64::from_bits(*value).to_string(),
+            UniqueKey::String(value) | UniqueKey::Other(value) => value.clone(),
+        }
     }
 }
 
-pub fn unique_errors(
-    df: &DataFrame,
-    columns: &[config::ColumnConfig],
-    indices: &ColumnIndex,
-) -> FloeResult<Vec<Vec<RowError>>> {
-    let mut errors_per_row = vec![Vec::new(); df.height()];
-    let unique_columns: Vec<&config::ColumnConfig> = columns
-        .iter()
-        .filter(|col| col.unique == Some(true))
-        .collect();
-    if unique_columns.is_empty() {
-        return Ok(errors_per_row);
-    }
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct CompositeKey(Vec<UniqueKey>);
 
-    for column in unique_columns {
-        let index = indices.get(&column.name).ok_or_else(|| {
-            Box::new(RunError(format!("unique column {} not found", column.name)))
-        })?;
-        let series = df.select_at_idx(*index).ok_or_else(|| {
-            Box::new(RunError(format!("unique column {} not found", column.name)))
-        })?;
-        let series = series.as_materialized_series();
-        let non_null = series.len().saturating_sub(series.null_count());
-        if non_null == 0 {
-            continue;
-        }
-        let mut duplicate_mask = is_duplicated(series).map_err(|err| {
-            Box::new(RunError(format!(
-                "unique column {} read failed: {err}",
-                column.name
-            )))
-        })?;
-        let not_null = series.is_not_null();
-        duplicate_mask = &duplicate_mask & &not_null;
-        let mut first_mask = is_first_distinct(series).map_err(|err| {
-            Box::new(RunError(format!(
-                "unique column {} read failed: {err}",
-                column.name
-            )))
-        })?;
-        first_mask = &first_mask & &not_null;
-        let mask = duplicate_mask & !first_mask;
-        for (row_idx, is_dup) in mask.into_iter().enumerate() {
-            if is_dup == Some(true) {
-                errors_per_row[row_idx].push(RowError::new(
-                    "unique",
-                    &column.name,
-                    "duplicate value",
-                ));
-            }
-        }
-    }
-
-    Ok(errors_per_row)
+#[derive(Debug, Clone)]
+pub struct UniqueConstraint {
+    pub runtime_columns: Vec<String>,
+    pub report_columns: Vec<String>,
 }
 
-pub fn unique_errors_sparse(
-    df: &DataFrame,
-    columns: &[config::ColumnConfig],
-    indices: &ColumnIndex,
-) -> FloeResult<SparseRowErrors> {
-    let mut errors = SparseRowErrors::new(df.height());
-    if df.height() == 0 {
-        return Ok(errors);
-    }
-    let unique_columns: Vec<&config::ColumnConfig> = columns
-        .iter()
-        .filter(|col| col.unique == Some(true))
-        .collect();
-    if unique_columns.is_empty() {
-        return Ok(errors);
-    }
+#[derive(Debug, Clone)]
+pub struct UniqueConstraintSample {
+    pub values: BTreeMap<String, String>,
+    pub count: u64,
+}
 
-    for column in unique_columns {
-        let index = indices.get(&column.name).ok_or_else(|| {
-            Box::new(RunError(format!(
-                "unique column {} not found in dataframe",
-                column.name
-            )))
-        })?;
-        let series = df
-            .select_at_idx(*index)
-            .ok_or_else(|| {
-                Box::new(RunError(format!(
-                    "unique column {} not found in dataframe",
-                    column.name
-                )))
-            })?
-            .as_materialized_series()
-            .rechunk();
-        let mut seen: HashSet<UniqueKey> = HashSet::new();
-        for (row_idx, value) in series.iter().enumerate() {
-            let key = match unique_key(value) {
-                Some(key) => key,
-                None => continue,
-            };
-            if seen.contains(&key) {
-                errors.add_error(
-                    row_idx,
-                    RowError::new("unique", &column.name, "duplicate value"),
-                );
-            } else {
-                seen.insert(key);
-            }
-        }
-    }
+#[derive(Debug, Clone)]
+pub struct UniqueConstraintResult {
+    pub columns: Vec<String>,
+    pub duplicates_count: u64,
+    pub affected_rows_count: u64,
+    pub samples: Vec<UniqueConstraintSample>,
+}
 
-    Ok(errors)
+#[derive(Debug, Clone)]
+struct ConstraintState {
+    constraint: UniqueConstraint,
+    seen: HashSet<CompositeKey>,
+    duplicates_count: u64,
+    sample_counts: HashMap<CompositeKey, u64>,
 }
 
 #[derive(Debug, Default)]
 pub struct UniqueTracker {
-    seen: HashMap<String, HashSet<UniqueKey>>,
+    states: Vec<ConstraintState>,
 }
 
 impl UniqueTracker {
     pub fn new(columns: &[config::ColumnConfig]) -> Self {
-        let mut seen = HashMap::new();
-        for column in columns.iter().filter(|col| col.unique == Some(true)) {
-            seen.insert(column.name.clone(), HashSet::new());
-        }
-        Self { seen }
+        let constraints = legacy_unique_constraints(columns)
+            .into_iter()
+            .map(|column| UniqueConstraint {
+                runtime_columns: vec![column.clone()],
+                report_columns: vec![column],
+            })
+            .collect::<Vec<_>>();
+        Self::with_constraints(constraints)
+    }
+
+    pub fn with_constraints(constraints: Vec<UniqueConstraint>) -> Self {
+        let states = constraints
+            .into_iter()
+            .map(|constraint| ConstraintState {
+                constraint,
+                seen: HashSet::new(),
+                duplicates_count: 0,
+                sample_counts: HashMap::new(),
+            })
+            .collect();
+        Self { states }
     }
 
     pub fn is_empty(&self) -> bool {
-        self.seen.is_empty()
+        self.states.is_empty()
     }
 
-    pub fn seed_from_df(
-        &mut self,
-        df: &DataFrame,
-        columns: &[config::ColumnConfig],
-    ) -> FloeResult<()> {
-        if df.height() == 0 || self.seen.is_empty() {
-            return Ok(());
+    pub fn runtime_columns(&self) -> Vec<String> {
+        let mut seen = HashSet::new();
+        let mut columns = Vec::new();
+        for state in &self.states {
+            for column in &state.constraint.runtime_columns {
+                if seen.insert(column.clone()) {
+                    columns.push(column.clone());
+                }
+            }
         }
-        let unique_columns: Vec<&config::ColumnConfig> = columns
-            .iter()
-            .filter(|col| col.unique == Some(true))
-            .collect();
-        if unique_columns.is_empty() {
-            return Ok(());
-        }
+        columns
+    }
 
-        for column in unique_columns {
-            let series = df.column(&column.name).map_err(|err| {
-                Box::new(RunError(format!(
-                    "unique column {} not found: {err}",
-                    column.name
-                )))
-            })?;
-            let series = series.as_materialized_series().rechunk();
-            let seen = self.seen.get_mut(&column.name).ok_or_else(|| {
-                Box::new(RunError(format!(
-                    "unique column {} not tracked",
-                    column.name
-                )))
-            })?;
-            for value in series.iter() {
-                let key = match unique_key(value) {
+    pub fn seed_from_df(&mut self, df: &DataFrame) -> FloeResult<()> {
+        if df.height() == 0 || self.states.is_empty() {
+            return Ok(());
+        }
+        for state in &mut self.states {
+            let columns = load_constraint_columns(df, &state.constraint.runtime_columns)?;
+            for row_idx in 0..df.height() {
+                let key = match composite_key_from_row(&columns, row_idx)? {
                     Some(key) => key,
                     None => continue,
                 };
-                seen.insert(key);
+                state.seen.insert(key);
             }
         }
-
         Ok(())
     }
 
@@ -213,100 +130,107 @@ impl UniqueTracker {
         columns: &[config::ColumnConfig],
     ) -> FloeResult<Vec<Vec<RowError>>> {
         let mut errors_per_row = vec![Vec::new(); df.height()];
-        if df.height() == 0 {
-            return Ok(errors_per_row);
-        }
-        let unique_columns: Vec<&config::ColumnConfig> = columns
-            .iter()
-            .filter(|col| col.unique == Some(true))
-            .collect();
-        if unique_columns.is_empty() {
-            return Ok(errors_per_row);
-        }
-
-        for column in unique_columns {
-            let series = df.column(&column.name).map_err(|err| {
-                Box::new(RunError(format!(
-                    "unique column {} not found: {err}",
-                    column.name
-                )))
-            })?;
-            let series = series.as_materialized_series().rechunk();
-            let seen = self.seen.get_mut(&column.name).ok_or_else(|| {
-                Box::new(RunError(format!(
-                    "unique column {} not tracked",
-                    column.name
-                )))
-            })?;
-            for (row_idx, value) in series.iter().enumerate() {
-                let key = match unique_key(value) {
-                    Some(key) => key,
-                    None => continue,
-                };
-                if seen.contains(&key) {
-                    errors_per_row[row_idx].push(RowError::new(
-                        "unique",
-                        &column.name,
-                        "duplicate value",
-                    ));
-                } else {
-                    seen.insert(key);
-                }
+        let sparse = self.apply_sparse(df, columns)?;
+        for (row_idx, row_errors) in sparse.iter() {
+            if let Some(slot) = errors_per_row.get_mut(*row_idx) {
+                slot.extend(row_errors.clone());
             }
         }
-
         Ok(errors_per_row)
     }
 
     pub fn apply_sparse(
         &mut self,
         df: &DataFrame,
-        columns: &[config::ColumnConfig],
+        _columns: &[config::ColumnConfig],
     ) -> FloeResult<SparseRowErrors> {
         let mut errors = SparseRowErrors::new(df.height());
-        if df.height() == 0 {
-            return Ok(errors);
-        }
-        let unique_columns: Vec<&config::ColumnConfig> = columns
-            .iter()
-            .filter(|col| col.unique == Some(true))
-            .collect();
-        if unique_columns.is_empty() {
+        if df.height() == 0 || self.states.is_empty() {
             return Ok(errors);
         }
 
-        for column in unique_columns {
-            let series = df.column(&column.name).map_err(|err| {
-                Box::new(RunError(format!(
-                    "unique column {} not found: {err}",
-                    column.name
-                )))
-            })?;
-            let series = series.as_materialized_series().rechunk();
-            let seen = self.seen.get_mut(&column.name).ok_or_else(|| {
-                Box::new(RunError(format!(
-                    "unique column {} not tracked",
-                    column.name
-                )))
-            })?;
-            for (row_idx, value) in series.iter().enumerate() {
-                let key = match unique_key(value) {
+        for state in &mut self.states {
+            let columns = load_constraint_columns(df, &state.constraint.runtime_columns)?;
+            let report_columns = state.constraint.report_columns.clone();
+            let (constraint_repr, message) = if report_columns.len() == 1 {
+                (report_columns[0].clone(), "duplicate value")
+            } else {
+                (format!("[{}]", report_columns.join(",")), "duplicate key")
+            };
+            for row_idx in 0..df.height() {
+                let key = match composite_key_from_row(&columns, row_idx)? {
                     Some(key) => key,
                     None => continue,
                 };
-                if seen.contains(&key) {
-                    errors.add_error(
-                        row_idx,
-                        RowError::new("unique", &column.name, "duplicate value"),
-                    );
+                if state.seen.contains(&key) {
+                    errors.add_error(row_idx, RowError::new("unique", &constraint_repr, message));
+                    state.duplicates_count += 1;
+                    let counter = state.sample_counts.entry(key).or_insert(0);
+                    *counter += 1;
                 } else {
-                    seen.insert(key);
+                    state.seen.insert(key);
                 }
             }
         }
 
         Ok(errors)
     }
+
+    pub fn results(&self) -> Vec<UniqueConstraintResult> {
+        self.states
+            .iter()
+            .map(|state| {
+                let mut sample_counts = state
+                    .sample_counts
+                    .iter()
+                    .map(|(key, count)| (key, *count))
+                    .collect::<Vec<_>>();
+                sample_counts.sort_by(|left, right| {
+                    right
+                        .1
+                        .cmp(&left.1)
+                        .then_with(|| format!("{:?}", left.0).cmp(&format!("{:?}", right.0)))
+                });
+                let samples = sample_counts
+                    .into_iter()
+                    .take(UNIQUE_SAMPLE_LIMIT)
+                    .map(|(key, count)| {
+                        let mut values = BTreeMap::new();
+                        for (idx, value) in key.0.iter().enumerate() {
+                            if let Some(column_name) = state.constraint.report_columns.get(idx) {
+                                values.insert(column_name.clone(), value.as_string());
+                            }
+                        }
+                        UniqueConstraintSample { values, count }
+                    })
+                    .collect::<Vec<_>>();
+                UniqueConstraintResult {
+                    columns: state.constraint.report_columns.clone(),
+                    duplicates_count: state.duplicates_count,
+                    affected_rows_count: state.duplicates_count,
+                    samples,
+                }
+            })
+            .collect()
+    }
+}
+
+pub fn unique_errors(
+    df: &DataFrame,
+    columns: &[config::ColumnConfig],
+    _indices: &ColumnIndex,
+) -> FloeResult<Vec<Vec<RowError>>> {
+    let mut tracker = UniqueTracker::new(columns);
+    tracker.apply(df, columns)
+}
+
+pub fn unique_errors_sparse(
+    df: &DataFrame,
+    columns: &[config::ColumnConfig],
+    _indices: &ColumnIndex,
+) -> FloeResult<SparseRowErrors> {
+    let mut tracker = UniqueTracker::new(columns);
+    tracker.apply_sparse(df, columns)
 }
 
 pub fn unique_counts(
@@ -350,4 +274,92 @@ pub fn unique_counts(
     }
 
     Ok(counts)
+}
+
+pub fn resolve_schema_unique_keys(schema: &config::SchemaConfig) -> Vec<Vec<String>> {
+    if let Some(unique_keys) = schema.unique_keys.as_ref() {
+        let mut seen = HashSet::new();
+        let mut deduped = Vec::new();
+        for key in unique_keys {
+            let normalized = key
+                .iter()
+                .map(|column| column.trim().to_string())
+                .collect::<Vec<_>>();
+            if normalized.is_empty() {
+                continue;
+            }
+            let signature = normalized.join("\u{1f}");
+            if seen.insert(signature) {
+                deduped.push(normalized);
+            }
+        }
+        return deduped;
+    }
+
+    legacy_unique_constraints(&schema.columns)
+        .into_iter()
+        .map(|column| vec![column])
+        .collect()
+}
+
+fn legacy_unique_constraints(columns: &[config::ColumnConfig]) -> Vec<String> {
+    columns
+        .iter()
+        .filter(|col| col.unique == Some(true))
+        .map(|col| col.name.trim().to_string())
+        .filter(|name| !name.is_empty())
+        .collect()
+}
+
+fn load_constraint_columns(df: &DataFrame, columns: &[String]) -> FloeResult<Vec<Series>> {
+    let mut output = Vec::with_capacity(columns.len());
+    for column in columns {
+        let series = df.column(column).map_err(|err| {
+            Box::new(RunError(format!(
+                "unique constraint column {} not found: {err}",
+                column
+            )))
+        })?;
+        output.push(series.as_materialized_series().rechunk());
+    }
+    Ok(output)
+}
+
+fn composite_key_from_row(columns: &[Series], row_idx: usize) -> FloeResult<Option<CompositeKey>> {
+    let mut key = Vec::with_capacity(columns.len());
+    for series in columns {
+        let value = series.get(row_idx).map_err(|err| {
+            Box::new(RunError(format!(
+                "unique constraint read failed at row {}: {err}",
+                row_idx
+            )))
+        })?;
+        let Some(value) = unique_key(value) else {
+            return Ok(None);
+        };
+        key.push(value);
+    }
+    Ok(Some(CompositeKey(key)))
+}
+
+fn unique_key(value: AnyValue) -> Option<UniqueKey> {
+    match value {
+        AnyValue::Null => None,
+        AnyValue::Boolean(value) => Some(UniqueKey::Bool(value)),
+        AnyValue::Int8(value) => Some(UniqueKey::I64(value as i64)),
+        AnyValue::Int16(value) => Some(UniqueKey::I64(value as i64)),
+        AnyValue::Int32(value) => Some(UniqueKey::I64(value as i64)),
+        AnyValue::Int64(value) => Some(UniqueKey::I64(value)),
+        AnyValue::Int128(value) => Some(UniqueKey::Other(value.to_string())),
+        AnyValue::UInt8(value) => Some(UniqueKey::U64(value as u64)),
+        AnyValue::UInt16(value) => Some(UniqueKey::U64(value as u64)),
+        AnyValue::UInt32(value) => Some(UniqueKey::U64(value as u64)),
+        AnyValue::UInt64(value) => Some(UniqueKey::U64(value)),
+        AnyValue::UInt128(value) => Some(UniqueKey::Other(value.to_string())),
+        AnyValue::Float32(value) => Some(UniqueKey::F64((value as f64).to_bits())),
+        AnyValue::Float64(value) => Some(UniqueKey::F64(value.to_bits())),
+        AnyValue::String(value) => Some(UniqueKey::String(value.to_string())),
+        AnyValue::StringOwned(value) => Some(UniqueKey::String(value.to_string())),
+        other => Some(UniqueKey::Other(other.to_string())),
+    }
 }

--- a/crates/floe-core/src/config/parse.rs
+++ b/crates/floe-core/src/config/parse.rs
@@ -591,7 +591,13 @@ fn parse_schema(value: &Yaml) -> FloeResult<SchemaConfig> {
     validate_known_keys(
         hash,
         "schema",
-        &["normalize_columns", "mismatch", "columns"],
+        &[
+            "normalize_columns",
+            "mismatch",
+            "primary_key",
+            "unique_keys",
+            "columns",
+        ],
     )?;
     let normalize_columns = match hash_get(hash, "normalize_columns") {
         Some(value) => Some(parse_normalize_columns(value)?),
@@ -601,6 +607,8 @@ fn parse_schema(value: &Yaml) -> FloeResult<SchemaConfig> {
         Some(value) => Some(parse_mismatch(value)?),
         None => None,
     };
+    let primary_key = opt_vec_string(hash, "primary_key", "schema")?;
+    let unique_keys = opt_vec_vec_string(hash, "unique_keys", "schema")?;
     let columns_yaml = get_array(hash, "columns", "schema")?;
 
     let mut columns = Vec::with_capacity(columns_yaml.len());
@@ -613,6 +621,8 @@ fn parse_schema(value: &Yaml) -> FloeResult<SchemaConfig> {
     Ok(SchemaConfig {
         normalize_columns,
         mismatch,
+        primary_key,
+        unique_keys,
         columns,
     })
 }
@@ -695,6 +705,26 @@ fn opt_vec_string(hash: &Hash, key: &str, ctx: &str) -> FloeResult<Option<Vec<St
     for (index, item) in list.iter().enumerate() {
         let item_ctx = format!("{ctx}.{key}[{index}]");
         values.push(yaml_string(item, &item_ctx)?);
+    }
+    Ok(Some(values))
+}
+
+fn opt_vec_vec_string(hash: &Hash, key: &str, ctx: &str) -> FloeResult<Option<Vec<Vec<String>>>> {
+    let value = match hash_get(hash, key) {
+        None | Some(Yaml::Null) | Some(Yaml::BadValue) => return Ok(None),
+        Some(value) => value,
+    };
+    let list = yaml_array(value, &format!("{ctx}.{key}"))?;
+    let mut values = Vec::with_capacity(list.len());
+    for (index, item) in list.iter().enumerate() {
+        let item_ctx = format!("{ctx}.{key}[{index}]");
+        let item_array = yaml_array(item, &item_ctx)?;
+        let mut tuple = Vec::with_capacity(item_array.len());
+        for (inner_idx, inner_item) in item_array.iter().enumerate() {
+            let inner_ctx = format!("{item_ctx}[{inner_idx}]");
+            tuple.push(yaml_string(inner_item, &inner_ctx)?);
+        }
+        values.push(tuple);
     }
     Ok(Some(values))
 }

--- a/crates/floe-core/src/config/types.rs
+++ b/crates/floe-core/src/config/types.rs
@@ -296,6 +296,8 @@ pub struct PolicyConfig {
 pub struct SchemaConfig {
     pub normalize_columns: Option<NormalizeColumnsConfig>,
     pub mismatch: Option<SchemaMismatchConfig>,
+    pub primary_key: Option<Vec<String>>,
+    pub unique_keys: Option<Vec<Vec<String>>>,
     pub columns: Vec<ColumnConfig>,
 }
 

--- a/crates/floe-core/src/config/validate.rs
+++ b/crates/floe-core/src/config/validate.rs
@@ -6,7 +6,7 @@ use crate::config::{
 use crate::io::format;
 use crate::io::read::json_selector::parse_selector;
 use crate::io::read::xml_selector;
-use crate::{ConfigError, FloeResult};
+use crate::{warnings, ConfigError, FloeResult};
 
 const ALLOWED_COLUMN_TYPES: &[&str] = &["string", "number", "boolean", "datetime", "date", "time"];
 const ALLOWED_CAST_MODES: &[&str] = &["strict", "coerce"];
@@ -526,6 +526,145 @@ fn validate_schema(entity: &EntityConfig) -> FloeResult<()> {
                 ))));
             }
         }
+    }
+
+    validate_schema_primary_key(entity)?;
+    validate_schema_unique_keys(entity)?;
+
+    Ok(())
+}
+
+fn validate_schema_primary_key(entity: &EntityConfig) -> FloeResult<()> {
+    let Some(primary_key) = entity.schema.primary_key.as_ref() else {
+        return Ok(());
+    };
+    if primary_key.is_empty() {
+        return Err(Box::new(ConfigError(format!(
+            "entity.name={} schema.primary_key must not be empty",
+            entity.name
+        ))));
+    }
+    let mut seen = HashSet::new();
+    for (index, column_name) in primary_key.iter().enumerate() {
+        let value = column_name.trim();
+        if value.is_empty() {
+            return Err(Box::new(ConfigError(format!(
+                "entity.name={} schema.primary_key[{}] must not be empty",
+                entity.name, index
+            ))));
+        }
+        if !seen.insert(value.to_string()) {
+            return Err(Box::new(ConfigError(format!(
+                "entity.name={} schema.primary_key has duplicate column {}",
+                entity.name, value
+            ))));
+        }
+        let column = entity
+            .schema
+            .columns
+            .iter()
+            .find(|column| column.name == value)
+            .ok_or_else(|| {
+                Box::new(ConfigError(format!(
+                    "entity.name={} schema.primary_key[{}]={} references unknown schema column",
+                    entity.name, index, value
+                ))) as Box<dyn std::error::Error + Send + Sync>
+            })?;
+        if column.nullable == Some(true) {
+            return Err(Box::new(ConfigError(format!(
+                "entity.name={} schema.primary_key column {} cannot set nullable=true",
+                entity.name, value
+            ))));
+        }
+    }
+    Ok(())
+}
+
+fn validate_schema_unique_keys(entity: &EntityConfig) -> FloeResult<()> {
+    let Some(unique_keys) = entity.schema.unique_keys.as_ref() else {
+        return Ok(());
+    };
+    if unique_keys.is_empty() {
+        return Err(Box::new(ConfigError(format!(
+            "entity.name={} schema.unique_keys must not be empty",
+            entity.name
+        ))));
+    }
+
+    let has_legacy_unique = entity
+        .schema
+        .columns
+        .iter()
+        .any(|column| column.unique == Some(true));
+    if has_legacy_unique {
+        warnings::emit(
+            "validate",
+            Some(&entity.name),
+            None,
+            Some("schema_unique_keys_override"),
+            &format!(
+                "entity.name={} schema.unique_keys is set; schema.columns[].unique is ignored",
+                entity.name
+            ),
+        );
+    }
+
+    let schema_columns = entity
+        .schema
+        .columns
+        .iter()
+        .map(|column| column.name.as_str())
+        .collect::<HashSet<_>>();
+    let mut seen_constraints = HashSet::new();
+    let mut duplicate_constraints = 0_u64;
+    for (index, key) in unique_keys.iter().enumerate() {
+        if key.is_empty() {
+            return Err(Box::new(ConfigError(format!(
+                "entity.name={} schema.unique_keys[{}] must not be empty",
+                entity.name, index
+            ))));
+        }
+        let mut seen_columns = HashSet::new();
+        let mut signature_parts = Vec::with_capacity(key.len());
+        for (column_index, column_name) in key.iter().enumerate() {
+            let value = column_name.trim();
+            if value.is_empty() {
+                return Err(Box::new(ConfigError(format!(
+                    "entity.name={} schema.unique_keys[{}][{}] must not be empty",
+                    entity.name, index, column_index
+                ))));
+            }
+            if !schema_columns.contains(value) {
+                return Err(Box::new(ConfigError(format!(
+                    "entity.name={} schema.unique_keys[{}][{}]={} references unknown schema column",
+                    entity.name, index, column_index, value
+                ))));
+            }
+            if !seen_columns.insert(value.to_string()) {
+                return Err(Box::new(ConfigError(format!(
+                    "entity.name={} schema.unique_keys[{}] has duplicate column {}",
+                    entity.name, index, value
+                ))));
+            }
+            signature_parts.push(value.to_string());
+        }
+        let signature = signature_parts.join("\u{1f}");
+        if !seen_constraints.insert(signature) {
+            duplicate_constraints += 1;
+        }
+    }
+
+    if duplicate_constraints > 0 {
+        warnings::emit(
+            "validate",
+            Some(&entity.name),
+            None,
+            Some("schema_unique_keys_dedup"),
+            &format!(
+                "entity.name={} schema.unique_keys contains {} duplicated constraint(s); duplicates are ignored",
+                entity.name, duplicate_constraints
+            ),
+        );
     }
 
     Ok(())

--- a/crates/floe-core/src/report/entity.rs
+++ b/crates/floe-core/src/report/entity.rs
@@ -1,4 +1,4 @@
-use crate::{config, report};
+use crate::{check, config, report};
 
 use crate::report::build::{entity_metadata_json, source_options_json};
 use crate::run::entity::ResolvedEntityTargets;
@@ -29,6 +29,7 @@ pub(crate) struct RunReportContext<'a> {
     pub accepted_total_bytes_written: Option<u64>,
     pub accepted_avg_file_size_mb: Option<f64>,
     pub accepted_small_files_count: Option<u64>,
+    pub unique_constraints: Vec<check::UniqueConstraintResult>,
 }
 
 pub(crate) fn build_run_report(ctx: RunReportContext<'_>) -> report::RunReport {
@@ -102,7 +103,50 @@ pub(crate) fn build_run_report(ctx: RunReportContext<'_>) -> report::RunReport {
             avg_file_size_mb: ctx.accepted_avg_file_size_mb,
             small_files_count: ctx.accepted_small_files_count,
         },
+        unique_constraints: build_unique_constraint_reports(ctx.severity, &ctx.unique_constraints),
         results: ctx.totals,
         files: ctx.file_reports,
+    }
+}
+
+fn build_unique_constraint_reports(
+    severity: report::Severity,
+    results: &[check::UniqueConstraintResult],
+) -> Vec<report::UniqueConstraintReport> {
+    results
+        .iter()
+        .map(|result| {
+            let (action, status_effect) =
+                unique_constraint_effect(severity, result.duplicates_count);
+            report::UniqueConstraintReport {
+                columns: result.columns.clone(),
+                duplicates_count: result.duplicates_count,
+                affected_rows_count: result.affected_rows_count,
+                action: action.to_string(),
+                status_effect: status_effect.to_string(),
+                samples: result
+                    .samples
+                    .iter()
+                    .map(|sample| report::UniqueConstraintSampleReport {
+                        values: sample.values.clone(),
+                        count: sample.count,
+                    })
+                    .collect(),
+            }
+        })
+        .collect()
+}
+
+fn unique_constraint_effect(
+    severity: report::Severity,
+    duplicates_count: u64,
+) -> (&'static str, &'static str) {
+    if duplicates_count == 0 {
+        return ("none", "none");
+    }
+    match severity {
+        report::Severity::Warn => ("warn", "warning"),
+        report::Severity::Reject => ("reject_rows", "rows_rejected"),
+        report::Severity::Abort => ("abort_run", "run_aborted"),
     }
 }

--- a/crates/floe-core/src/report/mod.rs
+++ b/crates/floe-core/src/report/mod.rs
@@ -19,6 +19,9 @@ pub struct RunReport {
     pub sink: SinkEcho,
     pub policy: PolicyEcho,
     pub accepted_output: AcceptedOutputSummary,
+    #[serde(default)]
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub unique_constraints: Vec<UniqueConstraintReport>,
     pub results: ResultsTotals,
     pub files: Vec<FileReport>,
 }
@@ -162,6 +165,26 @@ pub struct AcceptedOutputSummary {
     #[serde(default)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub small_files_count: Option<u64>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub struct UniqueConstraintReport {
+    pub columns: Vec<String>,
+    pub duplicates_count: u64,
+    pub affected_rows_count: u64,
+    pub action: String,
+    pub status_effect: String,
+    #[serde(default)]
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub samples: Vec<UniqueConstraintSampleReport>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub struct UniqueConstraintSampleReport {
+    pub values: std::collections::BTreeMap<String, String>,
+    pub count: u64,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/floe-core/src/run/entity/mod.rs
+++ b/crates/floe-core/src/run/entity/mod.rs
@@ -1,5 +1,6 @@
 use crate::{check, io, report, ConfigError, FloeResult};
 use serde_json::json;
+use std::collections::HashSet;
 use std::time::Instant;
 
 use super::file::required_columns;
@@ -97,7 +98,9 @@ pub(super) fn run_entity(
     )?;
     let output_column_map =
         output_column_mapping(&entity.schema.columns, normalize_strategy.as_deref())?;
-    let required_cols = required_columns(&normalized_columns);
+    let mut required_cols = required_columns(&normalized_columns);
+    append_primary_key_required_columns(&mut required_cols, entity, normalize_strategy.as_deref())?;
+    let unique_constraints = resolve_unique_constraints(entity, normalize_strategy.as_deref())?;
     let accepted_target = resolved_targets.accepted.clone();
     let rejected_target = resolved_targets.rejected.clone();
     let temp_dir = plan.temp_dir;
@@ -181,7 +184,7 @@ pub(super) fn run_entity(
 
     let mut accepted_accum = Vec::new();
     let temp_dir_path = temp_dir.as_ref().map(|dir| dir.path());
-    let mut unique_tracker = check::UniqueTracker::new(&normalized_columns);
+    let mut unique_tracker = check::UniqueTracker::with_constraints(unique_constraints);
     unique_existing::seed_unique_tracker_for_append(
         &mut unique_tracker,
         write_mode,
@@ -191,7 +194,6 @@ pub(super) fn run_entity(
         runtime.storage(),
         &context.storage_resolver,
         entity,
-        &normalized_columns,
     )?;
     // Phase B: row-level validation + entity-level accumulation.
     let phase_b = run_validate_split_phase(ValidateSplitPhaseContext {
@@ -227,6 +229,7 @@ pub(super) fn run_entity(
     abort_run = phase_b.abort_run;
     let accepted_accum_rows = phase_b.accepted_accum_rows;
     let accepted_accum_frames = phase_b.accepted_accum_frames;
+    let unique_constraints = unique_tracker.results();
 
     totals.files_total = file_reports.len() as u64;
 
@@ -273,6 +276,7 @@ pub(super) fn run_entity(
         accepted_total_bytes_written: accepted_write_report.total_bytes_written,
         accepted_avg_file_size_mb: accepted_write_report.avg_file_size_mb,
         accepted_small_files_count: accepted_write_report.small_files_count,
+        unique_constraints,
     });
 
     if let Some(report_target) = &context.report_target {
@@ -315,4 +319,81 @@ pub(super) fn run_entity(
         },
         abort_run,
     })
+}
+
+fn resolve_unique_constraints(
+    entity: &crate::config::EntityConfig,
+    normalize_strategy: Option<&str>,
+) -> FloeResult<Vec<check::UniqueConstraint>> {
+    let unique_keys = check::resolve_schema_unique_keys(&entity.schema);
+    if unique_keys.is_empty() {
+        return Ok(Vec::new());
+    }
+    let mut constraints = Vec::with_capacity(unique_keys.len());
+    for key in unique_keys {
+        let mut runtime_columns = Vec::with_capacity(key.len());
+        for name in &key {
+            let column = entity
+                .schema
+                .columns
+                .iter()
+                .find(|column| column.name == *name)
+                .ok_or_else(|| {
+                    Box::new(ConfigError(format!(
+                        "entity.name={} schema unique key references unknown column {}",
+                        entity.name, name
+                    )))
+                })?;
+            runtime_columns.push(runtime_column_name(column, normalize_strategy));
+        }
+        constraints.push(check::UniqueConstraint {
+            runtime_columns,
+            report_columns: key,
+        });
+    }
+    Ok(constraints)
+}
+
+fn append_primary_key_required_columns(
+    required_cols: &mut Vec<String>,
+    entity: &crate::config::EntityConfig,
+    normalize_strategy: Option<&str>,
+) -> FloeResult<()> {
+    let Some(primary_key) = entity.schema.primary_key.as_ref() else {
+        return Ok(());
+    };
+    if primary_key.is_empty() {
+        return Ok(());
+    }
+    let mut seen = required_cols.iter().cloned().collect::<HashSet<_>>();
+    for key_column in primary_key {
+        let column = entity
+            .schema
+            .columns
+            .iter()
+            .find(|column| column.name == *key_column)
+            .ok_or_else(|| {
+                Box::new(ConfigError(format!(
+                    "entity.name={} schema.primary_key references unknown column {}",
+                    entity.name, key_column
+                )))
+            })?;
+        let runtime = runtime_column_name(column, normalize_strategy);
+        if seen.insert(runtime.clone()) {
+            required_cols.push(runtime);
+        }
+    }
+    Ok(())
+}
+
+fn runtime_column_name(
+    column: &crate::config::ColumnConfig,
+    normalize_strategy: Option<&str>,
+) -> String {
+    let source_name = column.source_or_name();
+    if let Some(strategy) = normalize_strategy {
+        check::normalize::normalize_name(source_name, strategy)
+    } else {
+        source_name.to_string()
+    }
 }

--- a/crates/floe-core/src/run/entity/unique_existing.rs
+++ b/crates/floe-core/src/run/entity/unique_existing.rs
@@ -19,12 +19,11 @@ pub fn seed_unique_tracker_for_append(
     cloud: &mut io::storage::CloudClient,
     resolver: &config::StorageResolver,
     entity: &config::EntityConfig,
-    columns: &[config::ColumnConfig],
 ) -> FloeResult<()> {
     if write_mode != config::WriteMode::Append || unique_tracker.is_empty() {
         return Ok(());
     }
-    let unique_columns = unique_column_names(columns);
+    let unique_columns = unique_tracker.runtime_columns();
     if unique_columns.is_empty() {
         return Ok(());
     }
@@ -36,7 +35,6 @@ pub fn seed_unique_tracker_for_append(
             cloud,
             resolver,
             entity,
-            columns,
             &unique_columns,
         ),
         "delta" => seed_from_delta(
@@ -46,19 +44,10 @@ pub fn seed_unique_tracker_for_append(
             cloud,
             resolver,
             entity,
-            columns,
             &unique_columns,
         ),
         _ => Ok(()),
     }
-}
-
-fn unique_column_names(columns: &[config::ColumnConfig]) -> Vec<String> {
-    columns
-        .iter()
-        .filter(|col| col.unique == Some(true))
-        .map(|col| col.name.clone())
-        .collect()
 }
 
 fn seed_from_parquet(
@@ -68,7 +57,6 @@ fn seed_from_parquet(
     cloud: &mut io::storage::CloudClient,
     resolver: &config::StorageResolver,
     entity: &config::EntityConfig,
-    columns: &[config::ColumnConfig],
     unique_columns: &[String],
 ) -> FloeResult<()> {
     match target {
@@ -76,7 +64,7 @@ fn seed_from_parquet(
             let base_path = Path::new(base_path);
             let part_files = parts::list_local_part_paths(base_path, "parquet")?;
             for part_path in part_files {
-                seed_from_parquet_path(unique_tracker, &part_path, columns, unique_columns)?;
+                seed_from_parquet_path(unique_tracker, &part_path, unique_columns)?;
             }
         }
         Target::S3 { .. } | Target::Gcs { .. } | Target::Adls { .. } => {
@@ -103,7 +91,7 @@ fn seed_from_parquet(
                 .filter(|obj| parts::is_part_key(&obj.key, spec.extension))
             {
                 let local_path = client.download_to_temp(&object.uri, temp_dir)?;
-                seed_from_parquet_path(unique_tracker, &local_path, columns, unique_columns)?;
+                seed_from_parquet_path(unique_tracker, &local_path, unique_columns)?;
             }
         }
     }
@@ -113,11 +101,10 @@ fn seed_from_parquet(
 fn seed_from_parquet_path(
     unique_tracker: &mut check::UniqueTracker,
     path: &Path,
-    columns: &[config::ColumnConfig],
     unique_columns: &[String],
 ) -> FloeResult<()> {
     let df = read_parquet_lazy(path, Some(unique_columns))?;
-    unique_tracker.seed_from_df(&df, columns)?;
+    unique_tracker.seed_from_df(&df)?;
     Ok(())
 }
 
@@ -128,7 +115,6 @@ fn seed_from_delta(
     cloud: &mut io::storage::CloudClient,
     resolver: &config::StorageResolver,
     entity: &config::EntityConfig,
-    columns: &[config::ColumnConfig],
     unique_columns: &[String],
 ) -> FloeResult<()> {
     let store = object_store::delta_store_config(target, resolver, entity)?;
@@ -173,7 +159,7 @@ fn seed_from_delta(
                 client.download_to_temp(&uri, temp_dir)?
             }
         };
-        seed_from_parquet_path(unique_tracker, &local_path, columns, unique_columns)?;
+        seed_from_parquet_path(unique_tracker, &local_path, unique_columns)?;
     }
 
     Ok(())

--- a/crates/floe-core/tests/integration/composite_unique.rs
+++ b/crates/floe-core/tests/integration/composite_unique.rs
@@ -1,0 +1,108 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use floe_core::{run, RunOptions};
+
+fn write_csv(dir: &Path, name: &str, contents: &str) -> PathBuf {
+    let path = dir.join(name);
+    fs::write(&path, contents).expect("write csv");
+    path
+}
+
+fn write_config(dir: &Path, contents: &str) -> PathBuf {
+    let path = dir.join("config.yml");
+    fs::write(&path, contents).expect("write config");
+    path
+}
+
+#[test]
+fn composite_unique_checks_across_files_and_reports_samples() {
+    let temp_dir = tempfile::TempDir::new().expect("temp dir");
+    let root = temp_dir.path();
+    let input_dir = root.join("in");
+    let accepted_dir = root.join("out/accepted/customer");
+    let rejected_dir = root.join("out/rejected/customer");
+    let report_dir = root.join("report");
+
+    fs::create_dir_all(&input_dir).expect("create input dir");
+    write_csv(
+        &input_dir,
+        "batch1.csv",
+        "id;country;email\n1;fr;alice@demo\n2;;bob@demo\n3;us;carol@demo\n",
+    );
+    write_csv(
+        &input_dir,
+        "batch2.csv",
+        "id;country;email\n1;fr;alice_new@demo\n2;;bob_new@demo\n4;us;carol@demo\n",
+    );
+
+    let yaml = format!(
+        r#"version: "0.1"
+report:
+  path: "{report_dir}"
+entities:
+  - name: "customer"
+    source:
+      format: "csv"
+      path: "{input_dir}"
+    sink:
+      accepted:
+        format: "parquet"
+        path: "{accepted_dir}"
+      rejected:
+        format: "csv"
+        path: "{rejected_dir}"
+    policy:
+      severity: "reject"
+    schema:
+      primary_key: ["id", "country"]
+      unique_keys:
+        - ["id", "country"]
+        - ["email"]
+      columns:
+        - name: "id"
+          type: "string"
+        - name: "country"
+          type: "string"
+        - name: "email"
+          type: "string"
+"#,
+        report_dir = report_dir.display(),
+        input_dir = input_dir.display(),
+        accepted_dir = accepted_dir.display(),
+        rejected_dir = rejected_dir.display(),
+    );
+    let config_path = write_config(root, &yaml);
+
+    let outcome = run(
+        &config_path,
+        RunOptions {
+            run_id: Some("it-composite-unique".to_string()),
+            entities: Vec::new(),
+            dry_run: false,
+        },
+    )
+    .expect("run config");
+
+    let report = &outcome.entity_outcomes[0].report;
+    assert_eq!(report.results.rows_total, 6);
+    assert_eq!(report.results.accepted_total, 2);
+    assert_eq!(report.results.rejected_total, 4);
+
+    assert_eq!(report.unique_constraints.len(), 2);
+    let tuple_constraint = report
+        .unique_constraints
+        .iter()
+        .find(|constraint| constraint.columns == vec!["id".to_string(), "country".to_string()])
+        .expect("tuple unique constraint");
+    assert_eq!(tuple_constraint.duplicates_count, 1);
+    assert!(!tuple_constraint.samples.is_empty());
+
+    let email_constraint = report
+        .unique_constraints
+        .iter()
+        .find(|constraint| constraint.columns == vec!["email".to_string()])
+        .expect("email unique constraint");
+    assert_eq!(email_constraint.duplicates_count, 1);
+    assert!(!email_constraint.samples.is_empty());
+}

--- a/crates/floe-core/tests/integration/mod.rs
+++ b/crates/floe-core/tests/integration/mod.rs
@@ -1,4 +1,5 @@
 pub mod archive_run;
+pub mod composite_unique;
 pub mod delta_run;
 pub mod dry_run;
 pub mod fixed_width;

--- a/crates/floe-core/tests/unit/config/adls_validation.rs
+++ b/crates/floe-core/tests/unit/config/adls_validation.rs
@@ -33,6 +33,8 @@ fn base_entity() -> config::EntityConfig {
         schema: config::SchemaConfig {
             normalize_columns: None,
             mismatch: None,
+            primary_key: None,
+            unique_keys: None,
             columns: Vec::new(),
         },
     }

--- a/crates/floe-core/tests/unit/config/catalogs.rs
+++ b/crates/floe-core/tests/unit/config/catalogs.rs
@@ -83,6 +83,8 @@ fn entity() -> config::EntityConfig {
         schema: config::SchemaConfig {
             normalize_columns: None,
             mismatch: None,
+            primary_key: None,
+            unique_keys: None,
             columns: Vec::new(),
         },
     }

--- a/crates/floe-core/tests/unit/config/config_validation.rs
+++ b/crates/floe-core/tests/unit/config/config_validation.rs
@@ -1381,3 +1381,156 @@ fn iceberg_glue_catalog_binding_rejects_unknown_catalog_reference() {
         ],
     );
 }
+
+#[test]
+fn schema_unique_keys_reject_unknown_columns() {
+    let entity = r#"  - name: "customer"
+    source:
+      format: "csv"
+      path: "/tmp/input"
+    sink:
+      accepted:
+        format: "parquet"
+        path: "/tmp/out"
+      rejected:
+        format: "csv"
+        path: "/tmp/rejected"
+    policy:
+      severity: "reject"
+    schema:
+      unique_keys:
+        - ["customer_id", "missing_col"]
+      columns:
+        - name: "customer_id"
+          type: "string"
+"#;
+    assert_validation_error(
+        &base_config(entity),
+        &[
+            "entity.name=customer",
+            "schema.unique_keys[0][1]=missing_col",
+            "unknown schema column",
+        ],
+    );
+}
+
+#[test]
+fn schema_unique_keys_reject_duplicate_columns_inside_constraint() {
+    let entity = r#"  - name: "customer"
+    source:
+      format: "csv"
+      path: "/tmp/input"
+    sink:
+      accepted:
+        format: "parquet"
+        path: "/tmp/out"
+      rejected:
+        format: "csv"
+        path: "/tmp/rejected"
+    policy:
+      severity: "reject"
+    schema:
+      unique_keys:
+        - ["customer_id", "customer_id"]
+      columns:
+        - name: "customer_id"
+          type: "string"
+"#;
+    assert_validation_error(
+        &base_config(entity),
+        &[
+            "entity.name=customer",
+            "schema.unique_keys[0] has duplicate column customer_id",
+        ],
+    );
+}
+
+#[test]
+fn schema_unique_keys_reject_empty_constraint() {
+    let entity = r#"  - name: "customer"
+    source:
+      format: "csv"
+      path: "/tmp/input"
+    sink:
+      accepted:
+        format: "parquet"
+        path: "/tmp/out"
+      rejected:
+        format: "csv"
+        path: "/tmp/rejected"
+    policy:
+      severity: "reject"
+    schema:
+      unique_keys:
+        - []
+      columns:
+        - name: "customer_id"
+          type: "string"
+"#;
+    assert_validation_error(
+        &base_config(entity),
+        &[
+            "entity.name=customer",
+            "schema.unique_keys[0] must not be empty",
+        ],
+    );
+}
+
+#[test]
+fn schema_primary_key_rejects_nullable_true_column() {
+    let entity = r#"  - name: "customer"
+    source:
+      format: "csv"
+      path: "/tmp/input"
+    sink:
+      accepted:
+        format: "parquet"
+        path: "/tmp/out"
+      rejected:
+        format: "csv"
+        path: "/tmp/rejected"
+    policy:
+      severity: "reject"
+    schema:
+      primary_key: ["customer_id"]
+      columns:
+        - name: "customer_id"
+          type: "string"
+          nullable: true
+"#;
+    assert_validation_error(
+        &base_config(entity),
+        &[
+            "entity.name=customer",
+            "schema.primary_key column customer_id cannot set nullable=true",
+        ],
+    );
+}
+
+#[test]
+fn schema_unique_keys_with_legacy_column_unique_flags_is_valid() {
+    let entity = r#"  - name: "customer"
+    source:
+      format: "csv"
+      path: "/tmp/input"
+    sink:
+      accepted:
+        format: "parquet"
+        path: "/tmp/out"
+      rejected:
+        format: "csv"
+        path: "/tmp/rejected"
+    policy:
+      severity: "reject"
+    schema:
+      unique_keys:
+        - ["customer_id", "country"]
+      columns:
+        - name: "customer_id"
+          type: "string"
+          unique: true
+        - name: "country"
+          type: "string"
+"#;
+    assert_validation_ok(&base_config(entity));
+}

--- a/crates/floe-core/tests/unit/config/parse.rs
+++ b/crates/floe-core/tests/unit/config/parse.rs
@@ -167,6 +167,94 @@ entities:
 }
 
 #[test]
+fn parse_config_supports_schema_primary_key_and_unique_keys() {
+    let yaml = r#"
+version: "0.1"
+entities:
+  - name: "users"
+    source:
+      format: "csv"
+      path: "/tmp/input"
+    sink:
+      accepted:
+        format: "parquet"
+        path: "/tmp/out"
+      rejected:
+        format: "csv"
+        path: "/tmp/rejected"
+    policy:
+      severity: "reject"
+    schema:
+      primary_key: ["id", "country"]
+      unique_keys:
+        - ["id", "country"]
+        - ["email"]
+      columns:
+        - name: "id"
+          type: "string"
+        - name: "country"
+          type: "string"
+        - name: "email"
+          type: "string"
+"#;
+    let path = write_temp_config(yaml);
+    let config = load_config(&path).expect("parse config");
+    let schema = &config.entities[0].schema;
+    assert_eq!(
+        schema.primary_key.as_ref().expect("primary key"),
+        &vec!["id".to_string(), "country".to_string()]
+    );
+    assert_eq!(
+        schema.unique_keys.as_ref().expect("unique keys"),
+        &vec![
+            vec!["id".to_string(), "country".to_string()],
+            vec!["email".to_string()]
+        ]
+    );
+}
+
+#[test]
+fn parse_config_prefers_schema_unique_keys_over_legacy_column_unique_flags() {
+    let yaml = r#"
+version: "0.1"
+entities:
+  - name: "users"
+    source:
+      format: "csv"
+      path: "/tmp/input"
+    sink:
+      accepted:
+        format: "parquet"
+        path: "/tmp/out"
+      rejected:
+        format: "csv"
+        path: "/tmp/rejected"
+    policy:
+      severity: "reject"
+    schema:
+      unique_keys:
+        - ["id", "country"]
+      columns:
+        - name: "id"
+          type: "string"
+          unique: true
+        - name: "country"
+          type: "string"
+        - name: "email"
+          type: "string"
+          unique: true
+"#;
+    let path = write_temp_config(yaml);
+    let config = load_config(&path).expect("parse config");
+    let schema = &config.entities[0].schema;
+    let constraints = floe_core::check::resolve_schema_unique_keys(schema);
+    assert_eq!(
+        constraints,
+        vec![vec!["id".to_string(), "country".to_string()]]
+    );
+}
+
+#[test]
 fn parse_config_supports_sink_partitioning_and_file_size_knobs() {
     let yaml = r#"
 version: "0.1"

--- a/crates/floe-core/tests/unit/io/storage/inputs.rs
+++ b/crates/floe-core/tests/unit/io/storage/inputs.rs
@@ -233,6 +233,8 @@ fn mock_entity(name: &str) -> config::EntityConfig {
         schema: config::SchemaConfig {
             normalize_columns: None,
             mismatch: None,
+            primary_key: None,
+            unique_keys: None,
             columns: Vec::new(),
         },
     }

--- a/crates/floe-core/tests/unit/io/write/delta_write.rs
+++ b/crates/floe-core/tests/unit/io/write/delta_write.rs
@@ -444,6 +444,8 @@ fn build_entity(
         schema: config::SchemaConfig {
             normalize_columns,
             mismatch: None,
+            primary_key: None,
+            unique_keys: None,
             columns,
         },
     }

--- a/crates/floe-core/tests/unit/io/write/iceberg_write.rs
+++ b/crates/floe-core/tests/unit/io/write/iceberg_write.rs
@@ -468,6 +468,8 @@ fn build_entity(
         schema: config::SchemaConfig {
             normalize_columns,
             mismatch: None,
+            primary_key: None,
+            unique_keys: None,
             columns,
         },
     }

--- a/crates/floe-core/tests/unit/io/write/object_store.rs
+++ b/crates/floe-core/tests/unit/io/write/object_store.rs
@@ -69,6 +69,8 @@ fn delta_store_config_builds_s3_url_and_options() -> FloeResult<()> {
         schema: config::SchemaConfig {
             normalize_columns: None,
             mismatch: None,
+            primary_key: None,
+            unique_keys: None,
             columns: Vec::new(),
         },
     };
@@ -125,6 +127,8 @@ fn iceberg_store_config_builds_s3_warehouse_and_region_props() -> FloeResult<()>
         schema: config::SchemaConfig {
             normalize_columns: None,
             mismatch: None,
+            primary_key: None,
+            unique_keys: None,
             columns: Vec::new(),
         },
     };
@@ -193,6 +197,8 @@ fn delta_store_config_builds_local_url() -> FloeResult<()> {
         schema: config::SchemaConfig {
             normalize_columns: None,
             mismatch: None,
+            primary_key: None,
+            unique_keys: None,
             columns: Vec::new(),
         },
     };
@@ -250,6 +256,8 @@ fn iceberg_store_config_builds_local_warehouse_without_props() -> FloeResult<()>
         schema: config::SchemaConfig {
             normalize_columns: None,
             mismatch: None,
+            primary_key: None,
+            unique_keys: None,
             columns: Vec::new(),
         },
     };
@@ -319,6 +327,8 @@ fn delta_store_config_builds_adls_url_and_options() -> FloeResult<()> {
         schema: config::SchemaConfig {
             normalize_columns: None,
             mismatch: None,
+            primary_key: None,
+            unique_keys: None,
             columns: Vec::new(),
         },
     };
@@ -404,6 +414,8 @@ fn iceberg_store_config_builds_gcs_warehouse_without_props() -> FloeResult<()> {
         schema: config::SchemaConfig {
             normalize_columns: None,
             mismatch: None,
+            primary_key: None,
+            unique_keys: None,
             columns: Vec::new(),
         },
     };
@@ -476,6 +488,8 @@ fn iceberg_store_config_rejects_adls_target() -> FloeResult<()> {
         schema: config::SchemaConfig {
             normalize_columns: None,
             mismatch: None,
+            primary_key: None,
+            unique_keys: None,
             columns: Vec::new(),
         },
     };
@@ -544,6 +558,8 @@ fn delta_store_config_builds_gcs_url() -> FloeResult<()> {
         schema: config::SchemaConfig {
             normalize_columns: None,
             mismatch: None,
+            primary_key: None,
+            unique_keys: None,
             columns: Vec::new(),
         },
     };

--- a/crates/floe-core/tests/unit/io/write/rejected_csv.rs
+++ b/crates/floe-core/tests/unit/io/write/rejected_csv.rs
@@ -48,6 +48,8 @@ fn sample_entity() -> config::EntityConfig {
         schema: config::SchemaConfig {
             normalize_columns: None,
             mismatch: None,
+            primary_key: None,
+            unique_keys: None,
             columns: Vec::new(),
         },
     }

--- a/crates/floe-core/tests/unit/run/report.rs
+++ b/crates/floe-core/tests/unit/run/report.rs
@@ -63,6 +63,7 @@ fn sample_report() -> RunReport {
             avg_file_size_mb: None,
             small_files_count: None,
         },
+        unique_constraints: Vec::new(),
         results: ResultsTotals {
             files_total: 1,
             rows_total: 10,

--- a/docs/config.md
+++ b/docs/config.md
@@ -260,6 +260,17 @@ is available for templating within that entity.
   - `strategy`: `snake_case`, `lower`, `camel_case`, `none`.
   - When enabled, both schema column names and input column names are normalized
     before checks. If normalization causes a name collision, the run fails.
+- `primary_key` (optional)
+  - Array of schema column names.
+  - Primary key columns are always treated as required (`not_null`) at runtime.
+  - Config validation rejects `nullable: true` on primary key columns.
+  - `primary_key` does not imply uniqueness by itself; use `unique_keys` for uniqueness checks.
+- `unique_keys` (optional)
+  - Array of unique constraints, each constraint being an array of schema column names.
+  - Supports single-column and multi-column uniqueness:
+    - `unique_keys: [["email"], ["id","country_code"]]`
+  - If `unique_keys` is present, legacy `columns[].unique` flags are ignored.
+  - Null semantics: a row is ignored for a constraint if any key component is null.
 - `columns` (required)
   - Array of column definitions.
   - `name` (required): target column name in the output schema.
@@ -276,7 +287,8 @@ is available for templating within that entity.
   - `type` (required): logical type. Accepted values are case-insensitive and
     normalized by removing `-` and `_`.
   - `nullable` (optional): default `true`.
-  - `unique` (optional): default `false`.
+  - `unique` (optional, legacy): default `false`.
+    - Legacy single-column unique. Prefer `schema.unique_keys`.
   - `width` (required for `source.format: fixed`): number of characters to read.
   - `trim` (optional, `source.format: fixed`): trim whitespace for the column (default `true`).
 


### PR DESCRIPTION
## Summary
- add `schema.primary_key` and `schema.unique_keys` to config model + parser
- keep backward compatibility with `columns[].unique`
- enforce precedence: when `schema.unique_keys` is present, legacy `columns[].unique` is ignored (warning emitted)
- validate composite key definitions (empty/unknown/duplicate column checks)
- enforce `primary_key` not-null policy:
  - config validation rejects `nullable: true` on PK columns
  - runtime not-null checks include PK columns even when `nullable` is omitted
- extend `UniqueTracker` to support multiple constraints and composite keys across files
- preserve append seeding behavior for parquet/delta using resolved unique runtime columns
- add report section `unique_constraints` with per-constraint counts + bounded samples (top 5)
- keep legacy single-column unique row-error shape (`duplicate value` on the single column)

## Docs + schema
- update `config.schema.yaml` with `schema.primary_key` and `schema.unique_keys`
- update `docs/config.md` with semantics and precedence notes

## Tests
- unit tests for parse/validate of `primary_key` and `unique_keys`
- integration test `composite_unique_checks_across_files_and_reports_samples`
- adjust existing tests for new schema/report fields

## Validation
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all`
