### PR TITLE
Agent: Objective
Add a `## Local development` section to `README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,39 @@ If Homebrew is unavailable:
 More CLI details: [docs/cli.md](docs/cli.md)
 Full installation guide: [docs/installation.md](docs/installation.md)
 
+## Local development
+
+### Prerequisites
+
+- Rust stable toolchain (`rustup`, `cargo`)
+- A C/C++ toolchain available in `PATH`
+
+### Setup
+
+From the repository root:
+
+```bash
+cargo fetch
+cargo build -p floe-cli
+cargo run -p floe-cli -- --version
+```
+
+### Environment configuration
+
+- No extra environment variables are required for local files (`local://`).
+- For cloud storages (`s3://`, `abfs://`, `gs://`), configure provider credentials in your environment:
+  [docs/storages/s3.md](docs/storages/s3.md),
+  [docs/storages/adls.md](docs/storages/adls.md),
+  [docs/storages/gcs.md](docs/storages/gcs.md)
+
+### Run locally
+
+```bash
+cargo run -p floe-cli -- validate -c example/config.yml
+cargo run -p floe-cli -- run -c example/config.yml --entities customer --dry-run
+cargo run -p floe-cli -- run -c example/config.yml --entities customer
+```
+
 ## Run with Docker
 
 ### Pull


### PR DESCRIPTION
Automated changes by agent.\n\nInstruction:\nObjective
Add a `## Local development` section to `README.md` with accurate setup and run steps for contributors.

Scope
- Update README with prerequisites, install/setup, environment configuration, and local run commands.
- Keep wording and heading style consistent with the existing README.
- Verify documented commands exist in the repository scripts/tooling.

Non-goals
- No feature code changes.
- No broad README rewrite.
- No CI workflow redesign.

Implementation notes
- Prefer one primary local workflow; list alternatives only if already supported.
- Use concise, copy-paste-safe command blocks.
- Avoid unrelated formatting churn.

Tests
- Run markdown/doc checks that CI enforces (if present).
- Manually verify the documented local commands are valid.
- Validate any links added.

Acceptance
- README contains a clear `## Local development` section.
- Instructions are accurate and actionable for a new contributor.
- Diff remains focused on this documentation objective.