### PR TITLE
chore(release): prepare v0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to Floe are documented in this file.
 
+## v0.3.1
+
+- Delta merge write modes:
+  - added `merge_scd1` support for keyed upserts into accepted Delta outputs
+  - added `merge_scd2` support for history-preserving merges with managed current/validity columns
+- Schema/config validation:
+  - added `schema.primary_key` as the explicit merge key surface, including validation for required, known, unique, non-nullable key columns
+- Merge/reporting refinements:
+  - added configurable Delta merge options and SCD2 closed/unchanged reporting metrics
+
 ## v0.3.0
 
 - Core performance and observability:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3376,7 +3376,7 @@ dependencies = [
 
 [[package]]
 name = "floe-cli"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "assert_cmd",
  "clap",
@@ -3389,7 +3389,7 @@ dependencies = [
 
 [[package]]
 name = "floe-core"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "apache-avro 0.16.0",
  "arrow",

--- a/crates/floe-cli/Cargo.toml
+++ b/crates/floe-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "floe-cli"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 description = "CLI for Floe, a YAML-driven technical ingestion tool."
 license = "MIT"
@@ -17,7 +17,7 @@ path = "src/main.rs"
 
 [dependencies]
 clap = { version = "4", features = ["derive"] }
-floe-core = { path = "../floe-core", version = "0.3.0" }
+floe-core = { path = "../floe-core", version = "0.3.1" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 

--- a/crates/floe-core/Cargo.toml
+++ b/crates/floe-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "floe-core"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 description = "Core library for Floe, a YAML-driven technical ingestion tool."
 license = "MIT"


### PR DESCRIPTION
## Summary\n- bump floe-core and floe-cli versions to 0.3.1\n- update changelog with v0.3.1 highlights (SCD1/SCD2 merge + schema.primary_key + reporting refinements)\n- refresh Cargo.lock via cargo check\n\n## Validation\n- cargo check\n- cargo fmt --all\n- cargo clippy --workspace --all-targets -- -D warnings