### PR TITLE
release: prepare floe v0.3.2 (version bumps + notes)

### DIFF
--- a/.github/release.md
+++ b/.github/release.md
@@ -3,6 +3,14 @@
 This document describes the GitHub Actions workflows and the secrets required
 to publish Floe.
 
+## Latest release draft
+
+### Floe v0.3.2
+
+- Rolls out additive Delta schema evolution across `append`, `overwrite`, `merge_scd1`, and `merge_scd2`.
+- Includes guardrails for additive-only evolution, current partitioned-table limitations, and merge-key protection so key columns cannot be introduced through schema evolution.
+- Improves observability with the entity report `schema_evolution` block and the `schema_evolution_applied` lifecycle event when columns are added.
+
 ## Workflows
 
 - `CI` (`.github/workflows/ci.yml`)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to Floe are documented in this file.
 
+## v0.3.2
+
+- Delta schema evolution rollout:
+  - added additive schema evolution support for Delta accepted writes across `append`, `overwrite`, `merge_scd1`, and `merge_scd2`
+  - enforced rollout guardrails: additive-only changes, partitioned-table limitations, and merge-key protection against schema-evolved columns
+  - added explicit observability via the entity report `schema_evolution` block and the `schema_evolution_applied` lifecycle event
+
 ## v0.3.1
 
 - Delta merge write modes:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3376,7 +3376,7 @@ dependencies = [
 
 [[package]]
 name = "floe-cli"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "assert_cmd",
  "clap",
@@ -3389,7 +3389,7 @@ dependencies = [
 
 [[package]]
 name = "floe-core"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "apache-avro 0.16.0",
  "arrow",

--- a/crates/floe-cli/Cargo.toml
+++ b/crates/floe-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "floe-cli"
-version = "0.3.1"
+version = "0.3.2"
 edition = "2021"
 description = "CLI for Floe, a YAML-driven technical ingestion tool."
 license = "MIT"
@@ -17,7 +17,7 @@ path = "src/main.rs"
 
 [dependencies]
 clap = { version = "4", features = ["derive"] }
-floe-core = { path = "../floe-core", version = "0.3.1" }
+floe-core = { path = "../floe-core", version = "0.3.2" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 

--- a/crates/floe-core/Cargo.toml
+++ b/crates/floe-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "floe-core"
-version = "0.3.1"
+version = "0.3.2"
 edition = "2021"
 description = "Core library for Floe, a YAML-driven technical ingestion tool."
 license = "MIT"


### PR DESCRIPTION
Release prep PR for v0.3.2.

Includes:
- bump crate/package versions to 0.3.2
- update changelog entry for v0.3.2
- add release draft notes highlighting latest Delta schema evolution rollout (append/overwrite/merge), guardrails, and observability improvements