### PR TITLE
feat(databricks): add runner contract + connector jobs client foundation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,17 +2,6 @@
 
 All notable changes to Floe are documented in this file.
 
-## v0.3.4
-
-- Databricks runner hardening and contract alignment:
-  - render `job_name` placeholders (`{domain}`, `{env}`) before Databricks job ensure/reset flows
-  - enforce one-domain-per-run semantics in Airflow Databricks execution path to preserve one-job-per-domain behavior
-  - normalize Airflow Databricks timeout/infra failures into structured `floe.airflow.run.v1` payloads with `status`, `failure_reason`, and `backend_metadata`
-  - URL-encode Databricks GET query params and paginate job lookup beyond first page
-  - align runtime auth behavior with manifest contract: `auth.service_principal_oauth_ref` accepted via `env://<VAR>` resolution, with explicit `FLOE_DATABRICKS_OAUTH_TOKEN` fallback/error behavior
-- Documentation:
-  - added profile docs note for Databricks required fields, auth expectations, and `job_name` rendering semantics
-
 ## v0.3.3
 
 - Runner contract and architecture cleanup:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to Floe are documented in this file.
 
+## v0.3.4
+
+- Databricks runner hardening and contract alignment:
+  - render `job_name` placeholders (`{domain}`, `{env}`) before Databricks job ensure/reset flows
+  - enforce one-domain-per-run semantics in Airflow Databricks execution path to preserve one-job-per-domain behavior
+  - normalize Airflow Databricks timeout/infra failures into structured `floe.airflow.run.v1` payloads with `status`, `failure_reason`, and `backend_metadata`
+  - URL-encode Databricks GET query params and paginate job lookup beyond first page
+  - align runtime auth behavior with manifest contract: `auth.service_principal_oauth_ref` accepted via `env://<VAR>` resolution, with explicit `FLOE_DATABRICKS_OAUTH_TOKEN` fallback/error behavior
+- Documentation:
+  - added profile docs note for Databricks required fields, auth expectations, and `job_name` rendering semantics
+
 ## v0.3.3
 
 - Runner contract and architecture cleanup:

--- a/crates/floe-core/src/io/read/json.rs
+++ b/crates/floe-core/src/io/read/json.rs
@@ -296,7 +296,7 @@ fn build_dataframe(
     column_values: Vec<Vec<Option<String>>>,
 ) -> Result<DataFrame, JsonReadError> {
     let mut series = Vec::with_capacity(plans.len());
-    for (plan, values) in plans.iter().zip(column_values.into_iter()) {
+    for (plan, values) in plans.iter().zip(column_values) {
         series.push(Series::new(plan.source.as_str().into(), values).into());
     }
 

--- a/crates/floe-core/src/io/write/iceberg/schema.rs
+++ b/crates/floe-core/src/io/write/iceberg/schema.rs
@@ -25,11 +25,10 @@ pub(super) fn prepare_iceberg_write(
         ))));
     }
 
-    let mut field_id = 1_i32;
     let mut iceberg_fields = Vec::with_capacity(columns.len());
     let mut arrays = Vec::with_capacity(columns.len());
 
-    for (name, nullable, series) in columns {
+    for (field_id, (name, nullable, series)) in (1_i32..).zip(columns) {
         if !nullable && series.null_count() > 0 {
             return Err(Box::new(RunError(format!(
                 "iceberg write rejected nulls for non-nullable column {}",
@@ -45,7 +44,6 @@ pub(super) fn prepare_iceberg_write(
         };
         iceberg_fields.push(field.into());
         arrays.push(series_to_arrow_array(series, &name, &entity.name)?);
-        field_id += 1;
     }
 
     let iceberg_schema = Schema::builder()

--- a/crates/floe-core/src/manifest/builder.rs
+++ b/crates/floe-core/src/manifest/builder.rs
@@ -4,7 +4,8 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use crate::config::{ConfigLocation, RootConfig, SourceOptions, StorageResolver};
 use crate::manifest::model::{
     CommonManifest, ManifestArchiveTarget, ManifestDomain, ManifestEntity, ManifestExecution,
-    ManifestExecutionDefaults, ManifestResultContract, ManifestRunnerDefinition, ManifestRunners,
+    ManifestExecutionDefaults, ManifestResultContract, ManifestRunnerAuth,
+    ManifestRunnerDefinition, ManifestRunners,
     ManifestSinkTarget, ManifestSinks, ManifestSource,
 };
 use crate::profile::ProfileConfig;
@@ -361,6 +362,54 @@ fn runners_contract(profile: Option<&ProfileConfig>) -> ManifestRunners {
                     service_account: None,
                     resources: None,
                     env: None,
+                    workspace_url: None,
+                    existing_cluster_id: None,
+                    config_uri: None,
+                    job_name: None,
+                    auth: None,
+                    env_parameters: None,
+                },
+            );
+            ManifestRunners {
+                default: "default",
+                definitions,
+            }
+        }
+        Some("databricks_job") => {
+            let profile_runner = profile
+                .and_then(|p| p.execution.as_ref())
+                .map(|e| &e.runner);
+            let mut definitions = HashMap::new();
+            definitions.insert(
+                "default",
+                ManifestRunnerDefinition {
+                    runner_type: "databricks_job",
+                    command: profile_runner.and_then(|r| r.command.clone()),
+                    args: profile_runner.and_then(|r| r.args.clone()),
+                    timeout_seconds: profile_runner.and_then(|r| r.timeout_seconds),
+                    ttl_seconds_after_finished: None,
+                    poll_interval_seconds: profile_runner.and_then(|r| r.poll_interval_seconds),
+                    secrets: None,
+                    image: None,
+                    namespace: None,
+                    service_account: None,
+                    resources: None,
+                    env: None,
+                    workspace_url: profile_runner.and_then(|r| r.workspace_url.clone()),
+                    existing_cluster_id: profile_runner
+                        .and_then(|r| r.existing_cluster_id.clone()),
+                    config_uri: profile_runner.and_then(|r| r.config_uri.clone()),
+                    job_name: profile_runner
+                        .and_then(|r| r.job_name.clone())
+                        .or_else(|| Some("floe-{domain}-{env}".to_string())),
+                    auth: profile_runner.and_then(|r| {
+                        r.auth.as_ref().map(|auth| ManifestRunnerAuth {
+                            service_principal_oauth_ref: auth
+                                .service_principal_oauth_ref
+                                .clone(),
+                        })
+                    }),
+                    env_parameters: profile_runner.and_then(|r| r.env_parameters.clone()),
                 },
             );
             ManifestRunners {
@@ -386,6 +435,12 @@ fn runners_contract(profile: Option<&ProfileConfig>) -> ManifestRunners {
                     service_account: None,
                     resources: None,
                     env: None,
+                    workspace_url: None,
+                    existing_cluster_id: None,
+                    config_uri: None,
+                    job_name: None,
+                    auth: None,
+                    env_parameters: None,
                 },
             );
             ManifestRunners {

--- a/crates/floe-core/src/manifest/builder.rs
+++ b/crates/floe-core/src/manifest/builder.rs
@@ -5,8 +5,7 @@ use crate::config::{ConfigLocation, RootConfig, SourceOptions, StorageResolver};
 use crate::manifest::model::{
     CommonManifest, ManifestArchiveTarget, ManifestDomain, ManifestEntity, ManifestExecution,
     ManifestExecutionDefaults, ManifestResultContract, ManifestRunnerAuth,
-    ManifestRunnerDefinition, ManifestRunners,
-    ManifestSinkTarget, ManifestSinks, ManifestSource,
+    ManifestRunnerDefinition, ManifestRunners, ManifestSinkTarget, ManifestSinks, ManifestSource,
 };
 use crate::profile::ProfileConfig;
 use crate::FloeResult;
@@ -396,17 +395,14 @@ fn runners_contract(profile: Option<&ProfileConfig>) -> ManifestRunners {
                     resources: None,
                     env: None,
                     workspace_url: profile_runner.and_then(|r| r.workspace_url.clone()),
-                    existing_cluster_id: profile_runner
-                        .and_then(|r| r.existing_cluster_id.clone()),
+                    existing_cluster_id: profile_runner.and_then(|r| r.existing_cluster_id.clone()),
                     config_uri: profile_runner.and_then(|r| r.config_uri.clone()),
                     job_name: profile_runner
                         .and_then(|r| r.job_name.clone())
                         .or_else(|| Some("floe-{domain}-{env}".to_string())),
                     auth: profile_runner.and_then(|r| {
                         r.auth.as_ref().map(|auth| ManifestRunnerAuth {
-                            service_principal_oauth_ref: auth
-                                .service_principal_oauth_ref
-                                .clone(),
+                            service_principal_oauth_ref: auth.service_principal_oauth_ref.clone(),
                         })
                     }),
                     env_parameters: profile_runner.and_then(|r| r.env_parameters.clone()),

--- a/crates/floe-core/src/manifest/builder.rs
+++ b/crates/floe-core/src/manifest/builder.rs
@@ -364,6 +364,7 @@ fn runners_contract(profile: Option<&ProfileConfig>) -> ManifestRunners {
                     workspace_url: None,
                     existing_cluster_id: None,
                     config_uri: None,
+                    python_file_uri: None,
                     job_name: None,
                     auth: None,
                     env_parameters: None,
@@ -397,6 +398,7 @@ fn runners_contract(profile: Option<&ProfileConfig>) -> ManifestRunners {
                     workspace_url: profile_runner.and_then(|r| r.workspace_url.clone()),
                     existing_cluster_id: profile_runner.and_then(|r| r.existing_cluster_id.clone()),
                     config_uri: profile_runner.and_then(|r| r.config_uri.clone()),
+                    python_file_uri: profile_runner.and_then(|r| r.python_file_uri.clone()),
                     job_name: profile_runner
                         .and_then(|r| r.job_name.clone())
                         .or_else(|| Some("floe-{domain}-{env}".to_string())),
@@ -434,6 +436,7 @@ fn runners_contract(profile: Option<&ProfileConfig>) -> ManifestRunners {
                     workspace_url: None,
                     existing_cluster_id: None,
                     config_uri: None,
+                    python_file_uri: None,
                     job_name: None,
                     auth: None,
                     env_parameters: None,

--- a/crates/floe-core/src/manifest/model.rs
+++ b/crates/floe-core/src/manifest/model.rs
@@ -70,6 +70,7 @@ pub struct ManifestRunnerDefinition {
     pub workspace_url: Option<String>,
     pub existing_cluster_id: Option<String>,
     pub config_uri: Option<String>,
+    pub python_file_uri: Option<String>,
     pub job_name: Option<String>,
     pub auth: Option<ManifestRunnerAuth>,
     pub env_parameters: Option<HashMap<String, String>>,

--- a/crates/floe-core/src/manifest/model.rs
+++ b/crates/floe-core/src/manifest/model.rs
@@ -67,6 +67,17 @@ pub struct ManifestRunnerDefinition {
     pub service_account: Option<String>,
     pub resources: Option<ManifestRunnerResources>,
     pub env: Option<HashMap<String, String>>,
+    pub workspace_url: Option<String>,
+    pub existing_cluster_id: Option<String>,
+    pub config_uri: Option<String>,
+    pub job_name: Option<String>,
+    pub auth: Option<ManifestRunnerAuth>,
+    pub env_parameters: Option<HashMap<String, String>>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ManifestRunnerAuth {
+    pub service_principal_oauth_ref: Option<String>,
 }
 
 #[derive(Debug, Serialize)]

--- a/crates/floe-core/src/profile/parse.rs
+++ b/crates/floe-core/src/profile/parse.rs
@@ -189,8 +189,7 @@ fn parse_runner(value: &Yaml) -> FloeResult<ProfileRunner> {
     let existing_cluster_id =
         get_optional_string(hash, "existing_cluster_id", "profile.execution.runner")?;
     let config_uri = get_optional_string(hash, "config_uri", "profile.execution.runner")?;
-    let python_file_uri =
-        get_optional_string(hash, "python_file_uri", "profile.execution.runner")?;
+    let python_file_uri = get_optional_string(hash, "python_file_uri", "profile.execution.runner")?;
     let job_name = get_optional_string(hash, "job_name", "profile.execution.runner")?;
     let auth = parse_runner_auth(hash_get(hash, "auth"))?;
     let env_parameters = match hash_get(hash, "env_parameters") {

--- a/crates/floe-core/src/profile/parse.rs
+++ b/crates/floe-core/src/profile/parse.rs
@@ -8,7 +8,8 @@ use crate::config::yaml_decode::{
     hash_get, load_yaml, validate_known_keys, yaml_array, yaml_hash, yaml_string,
 };
 use crate::profile::types::{
-    ProfileConfig, ProfileExecution, ProfileMetadata, ProfileRunner, ProfileValidation,
+    ProfileConfig, ProfileExecution, ProfileMetadata, ProfileRunner, ProfileRunnerAuth,
+    ProfileValidation,
     PROFILE_API_VERSION, PROFILE_KIND,
 };
 use crate::{ConfigError, FloeResult};
@@ -162,6 +163,12 @@ fn parse_runner(value: &Yaml) -> FloeResult<ProfileRunner> {
             "ttl_seconds_after_finished",
             "poll_interval_seconds",
             "secrets",
+            "workspace_url",
+            "existing_cluster_id",
+            "config_uri",
+            "job_name",
+            "auth",
+            "env_parameters",
         ],
     )?;
 
@@ -178,6 +185,19 @@ fn parse_runner(value: &Yaml) -> FloeResult<ProfileRunner> {
     let poll_interval_seconds =
         get_optional_u64(hash, "poll_interval_seconds", "profile.execution.runner")?;
     let secrets = get_optional_string_list(hash, "secrets", "profile.execution.runner")?;
+    let workspace_url = get_optional_string(hash, "workspace_url", "profile.execution.runner")?;
+    let existing_cluster_id =
+        get_optional_string(hash, "existing_cluster_id", "profile.execution.runner")?;
+    let config_uri = get_optional_string(hash, "config_uri", "profile.execution.runner")?;
+    let job_name = get_optional_string(hash, "job_name", "profile.execution.runner")?;
+    let auth = parse_runner_auth(hash_get(hash, "auth"))?;
+    let env_parameters = match hash_get(hash, "env_parameters") {
+        Some(value) => Some(extract_string_map(
+            yaml_hash(value, "profile.execution.runner.env_parameters")?,
+            "profile.execution.runner.env_parameters",
+        )?),
+        None => None,
+    };
 
     Ok(ProfileRunner {
         runner_type,
@@ -187,7 +207,34 @@ fn parse_runner(value: &Yaml) -> FloeResult<ProfileRunner> {
         ttl_seconds_after_finished,
         poll_interval_seconds,
         secrets,
+        workspace_url,
+        existing_cluster_id,
+        config_uri,
+        job_name,
+        auth,
+        env_parameters,
     })
+}
+
+fn parse_runner_auth(value: Option<&Yaml>) -> FloeResult<Option<ProfileRunnerAuth>> {
+    let Some(value) = value else {
+        return Ok(None);
+    };
+
+    let hash = yaml_hash(value, "profile.execution.runner.auth")?;
+    validate_known_keys(
+        hash,
+        "profile.execution.runner.auth",
+        &["service_principal_oauth_ref"],
+    )?;
+
+    Ok(Some(ProfileRunnerAuth {
+        service_principal_oauth_ref: get_optional_string(
+            hash,
+            "service_principal_oauth_ref",
+            "profile.execution.runner.auth",
+        )?,
+    }))
 }
 
 fn parse_variables(value: &Yaml) -> FloeResult<HashMap<String, String>> {

--- a/crates/floe-core/src/profile/parse.rs
+++ b/crates/floe-core/src/profile/parse.rs
@@ -165,6 +165,7 @@ fn parse_runner(value: &Yaml) -> FloeResult<ProfileRunner> {
             "workspace_url",
             "existing_cluster_id",
             "config_uri",
+            "python_file_uri",
             "job_name",
             "auth",
             "env_parameters",
@@ -188,6 +189,8 @@ fn parse_runner(value: &Yaml) -> FloeResult<ProfileRunner> {
     let existing_cluster_id =
         get_optional_string(hash, "existing_cluster_id", "profile.execution.runner")?;
     let config_uri = get_optional_string(hash, "config_uri", "profile.execution.runner")?;
+    let python_file_uri =
+        get_optional_string(hash, "python_file_uri", "profile.execution.runner")?;
     let job_name = get_optional_string(hash, "job_name", "profile.execution.runner")?;
     let auth = parse_runner_auth(hash_get(hash, "auth"))?;
     let env_parameters = match hash_get(hash, "env_parameters") {
@@ -209,6 +212,7 @@ fn parse_runner(value: &Yaml) -> FloeResult<ProfileRunner> {
         workspace_url,
         existing_cluster_id,
         config_uri,
+        python_file_uri,
         job_name,
         auth,
         env_parameters,

--- a/crates/floe-core/src/profile/parse.rs
+++ b/crates/floe-core/src/profile/parse.rs
@@ -9,8 +9,7 @@ use crate::config::yaml_decode::{
 };
 use crate::profile::types::{
     ProfileConfig, ProfileExecution, ProfileMetadata, ProfileRunner, ProfileRunnerAuth,
-    ProfileValidation,
-    PROFILE_API_VERSION, PROFILE_KIND,
+    ProfileValidation, PROFILE_API_VERSION, PROFILE_KIND,
 };
 use crate::{ConfigError, FloeResult};
 

--- a/crates/floe-core/src/profile/types.rs
+++ b/crates/floe-core/src/profile/types.rs
@@ -36,6 +36,7 @@ pub struct ProfileRunner {
     pub workspace_url: Option<String>,
     pub existing_cluster_id: Option<String>,
     pub config_uri: Option<String>,
+    pub python_file_uri: Option<String>,
     pub job_name: Option<String>,
     pub auth: Option<ProfileRunnerAuth>,
     pub env_parameters: Option<HashMap<String, String>>,

--- a/crates/floe-core/src/profile/types.rs
+++ b/crates/floe-core/src/profile/types.rs
@@ -33,6 +33,17 @@ pub struct ProfileRunner {
     pub ttl_seconds_after_finished: Option<u64>,
     pub poll_interval_seconds: Option<u64>,
     pub secrets: Option<Vec<String>>,
+    pub workspace_url: Option<String>,
+    pub existing_cluster_id: Option<String>,
+    pub config_uri: Option<String>,
+    pub job_name: Option<String>,
+    pub auth: Option<ProfileRunnerAuth>,
+    pub env_parameters: Option<HashMap<String, String>>,
+}
+
+#[derive(Debug, Clone)]
+pub struct ProfileRunnerAuth {
+    pub service_principal_oauth_ref: Option<String>,
 }
 
 #[derive(Debug, Clone)]

--- a/crates/floe-core/src/profile/validate.rs
+++ b/crates/floe-core/src/profile/validate.rs
@@ -132,6 +132,17 @@ fn validate_runner_contract(runner: &ProfileRunner) -> FloeResult<()> {
             "profile.execution.runner.config_uri is required for databricks_job".to_string(),
         )));
     }
+    if runner
+        .python_file_uri
+        .as_deref()
+        .map(str::trim)
+        .unwrap_or("")
+        .is_empty()
+    {
+        return Err(Box::new(ConfigError(
+            "profile.execution.runner.python_file_uri is required for databricks_job".to_string(),
+        )));
+    }
 
     let auth_ref = runner
         .auth

--- a/crates/floe-core/src/profile/validate.rs
+++ b/crates/floe-core/src/profile/validate.rs
@@ -98,7 +98,13 @@ fn validate_runner_contract(runner: &ProfileRunner) -> FloeResult<()> {
         return Ok(());
     }
 
-    if runner.workspace_url.as_deref().map(str::trim).unwrap_or("").is_empty() {
+    if runner
+        .workspace_url
+        .as_deref()
+        .map(str::trim)
+        .unwrap_or("")
+        .is_empty()
+    {
         return Err(Box::new(ConfigError(
             "profile.execution.runner.workspace_url is required for databricks_job".to_string(),
         )));
@@ -115,7 +121,13 @@ fn validate_runner_contract(runner: &ProfileRunner) -> FloeResult<()> {
                 .to_string(),
         )));
     }
-    if runner.config_uri.as_deref().map(str::trim).unwrap_or("").is_empty() {
+    if runner
+        .config_uri
+        .as_deref()
+        .map(str::trim)
+        .unwrap_or("")
+        .is_empty()
+    {
         return Err(Box::new(ConfigError(
             "profile.execution.runner.config_uri is required for databricks_job".to_string(),
         )));

--- a/crates/floe-core/src/profile/validate.rs
+++ b/crates/floe-core/src/profile/validate.rs
@@ -1,13 +1,13 @@
 use std::collections::HashMap;
 
-use crate::profile::types::ProfileConfig;
+use crate::profile::types::{ProfileConfig, ProfileRunner};
 use crate::{ConfigError, FloeResult};
 
 /// Validate a parsed profile.
 ///
 /// Checks performed:
 /// - `metadata.name` is non-empty (guaranteed by parser, double-checked here).
-/// - `execution.runner.type` is one of the recognized values (`local`, `kubernetes_job`) when present.
+/// - `execution.runner.type` is one of the recognized values (`local`, `kubernetes_job`, `databricks_job`) when present.
 ///   Orchestration/job-submission for each runner type belongs to connector crates, not floe-core.
 /// - No variable value contains an unresolved `${...}` placeholder.
 pub fn validate_profile(profile: &ProfileConfig) -> FloeResult<()> {
@@ -19,6 +19,7 @@ pub fn validate_profile(profile: &ProfileConfig) -> FloeResult<()> {
 
     if let Some(execution) = &profile.execution {
         validate_runner_type(&execution.runner.runner_type)?;
+        validate_runner_contract(&execution.runner)?;
     }
 
     validate_no_unresolved_vars(&profile.variables)?;
@@ -81,7 +82,7 @@ fn validate_no_unresolved_vars(vars: &HashMap<String, String>) -> FloeResult<()>
 }
 
 fn validate_runner_type(runner_type: &str) -> FloeResult<()> {
-    const KNOWN_RUNNERS: &[&str] = &["local", "kubernetes_job"];
+    const KNOWN_RUNNERS: &[&str] = &["local", "kubernetes_job", "databricks_job"];
     if !KNOWN_RUNNERS.contains(&runner_type) {
         return Err(Box::new(ConfigError(format!(
             "profile.execution.runner.type: unknown runner \"{runner_type}\"; \
@@ -89,6 +90,50 @@ fn validate_runner_type(runner_type: &str) -> FloeResult<()> {
             KNOWN_RUNNERS.join(", ")
         ))));
     }
+    Ok(())
+}
+
+fn validate_runner_contract(runner: &ProfileRunner) -> FloeResult<()> {
+    if runner.runner_type != "databricks_job" {
+        return Ok(());
+    }
+
+    if runner.workspace_url.as_deref().map(str::trim).unwrap_or("").is_empty() {
+        return Err(Box::new(ConfigError(
+            "profile.execution.runner.workspace_url is required for databricks_job".to_string(),
+        )));
+    }
+    if runner
+        .existing_cluster_id
+        .as_deref()
+        .map(str::trim)
+        .unwrap_or("")
+        .is_empty()
+    {
+        return Err(Box::new(ConfigError(
+            "profile.execution.runner.existing_cluster_id is required for databricks_job"
+                .to_string(),
+        )));
+    }
+    if runner.config_uri.as_deref().map(str::trim).unwrap_or("").is_empty() {
+        return Err(Box::new(ConfigError(
+            "profile.execution.runner.config_uri is required for databricks_job".to_string(),
+        )));
+    }
+
+    let auth_ref = runner
+        .auth
+        .as_ref()
+        .and_then(|auth| auth.service_principal_oauth_ref.as_deref())
+        .map(str::trim)
+        .unwrap_or("");
+    if auth_ref.is_empty() {
+        return Err(Box::new(ConfigError(
+            "profile.execution.runner.auth.service_principal_oauth_ref is required for databricks_job"
+                .to_string(),
+        )));
+    }
+
     Ok(())
 }
 

--- a/crates/floe-core/tests/unit/manifest/mod.rs
+++ b/crates/floe-core/tests/unit/manifest/mod.rs
@@ -271,7 +271,10 @@ execution:
     let runner = &value["runners"]["definitions"]["default"];
     assert_eq!(value["runners"]["default"], "default");
     assert_eq!(runner["type"], "databricks_job");
-    assert_eq!(runner["workspace_url"], "https://adb-1234.5.azuredatabricks.net");
+    assert_eq!(
+        runner["workspace_url"],
+        "https://adb-1234.5.azuredatabricks.net"
+    );
     assert_eq!(runner["existing_cluster_id"], "1111-222222-abc123");
     assert_eq!(runner["config_uri"], "dbfs:/floe/configs/prod.yml");
     assert_eq!(runner["job_name"], "floe-{domain}-{env}");

--- a/crates/floe-core/tests/unit/manifest/mod.rs
+++ b/crates/floe-core/tests/unit/manifest/mod.rs
@@ -247,6 +247,7 @@ execution:
     workspace_url: https://adb-1234.5.azuredatabricks.net
     existing_cluster_id: 1111-222222-abc123
     config_uri: dbfs:/floe/configs/prod.yml
+    python_file_uri: dbfs:/floe/bin/floe_entry.py
     command: floe
     args:
       - run
@@ -255,7 +256,7 @@ execution:
     poll_interval_seconds: 12
     timeout_seconds: 1800
     auth:
-      service_principal_oauth_ref: secret://kv/databricks/oauth
+      service_principal_oauth_ref: env://DATABRICKS_TOKEN
     env_parameters:
       FLOE_ENV: prod
 "#;
@@ -277,9 +278,10 @@ execution:
     );
     assert_eq!(runner["existing_cluster_id"], "1111-222222-abc123");
     assert_eq!(runner["config_uri"], "dbfs:/floe/configs/prod.yml");
+    assert_eq!(runner["python_file_uri"], "dbfs:/floe/bin/floe_entry.py");
     assert_eq!(runner["job_name"], "floe-{domain}-{env}");
     assert_eq!(
         runner["auth"]["service_principal_oauth_ref"],
-        "secret://kv/databricks/oauth"
+        "env://DATABRICKS_TOKEN"
     );
 }

--- a/crates/floe-core/tests/unit/manifest/mod.rs
+++ b/crates/floe-core/tests/unit/manifest/mod.rs
@@ -233,3 +233,50 @@ execution:
         serde_json::json!(["floe-db", "floe-warehouse"])
     );
 }
+
+#[test]
+fn manifest_with_databricks_profile_serializes_runner_fields() {
+    let profile_yaml = r#"
+apiVersion: floe/v1
+kind: EnvironmentProfile
+metadata:
+  name: prod-dbx
+execution:
+  runner:
+    type: databricks_job
+    workspace_url: https://adb-1234.5.azuredatabricks.net
+    existing_cluster_id: 1111-222222-abc123
+    config_uri: dbfs:/floe/configs/prod.yml
+    command: floe
+    args:
+      - run
+      - -c
+      - dbfs:/floe/configs/prod.yml
+    poll_interval_seconds: 12
+    timeout_seconds: 1800
+    auth:
+      service_principal_oauth_ref: secret://kv/databricks/oauth
+    env_parameters:
+      FLOE_ENV: prod
+"#;
+    let profile = parse_profile_from_str(profile_yaml).expect("parse profile");
+    let config_path = repo_root().join("example/config.yml");
+    let config_location = resolve_config_location(config_path.to_str().expect("utf8"))
+        .expect("resolve config location");
+    let config = load_config(&config_location.path).expect("load config");
+    let payload = build_common_manifest_json(&config_location, &config, &[], Some(&profile))
+        .expect("manifest");
+    let value: Value = serde_json::from_str(&payload).expect("valid json");
+
+    let runner = &value["runners"]["definitions"]["default"];
+    assert_eq!(value["runners"]["default"], "default");
+    assert_eq!(runner["type"], "databricks_job");
+    assert_eq!(runner["workspace_url"], "https://adb-1234.5.azuredatabricks.net");
+    assert_eq!(runner["existing_cluster_id"], "1111-222222-abc123");
+    assert_eq!(runner["config_uri"], "dbfs:/floe/configs/prod.yml");
+    assert_eq!(runner["job_name"], "floe-{domain}-{env}");
+    assert_eq!(
+        runner["auth"]["service_principal_oauth_ref"],
+        "secret://kv/databricks/oauth"
+    );
+}

--- a/crates/floe-core/tests/unit/profile/parse.rs
+++ b/crates/floe-core/tests/unit/profile/parse.rs
@@ -148,6 +148,57 @@ validation:
     assert_eq!(profile.validation.as_ref().unwrap().strict, Some(false));
 }
 
+#[test]
+fn parse_databricks_runner_with_mvp_fields() {
+    let yaml = r#"
+apiVersion: floe/v1
+kind: EnvironmentProfile
+metadata:
+  name: prod-dbx
+execution:
+  runner:
+    type: databricks_job
+    workspace_url: https://adb-1234.5.azuredatabricks.net
+    existing_cluster_id: 1111-222222-abc123
+    config_uri: dbfs:/floe/configs/prod.yml
+    job_name: floe-sales-prod
+    command: floe
+    args:
+      - run
+      - -c
+      - dbfs:/floe/configs/prod.yml
+    poll_interval_seconds: 20
+    timeout_seconds: 1800
+    auth:
+      service_principal_oauth_ref: secret://kv/databricks/oauth
+    env_parameters:
+      FLOE_ENV: prod
+      FLOE_DOMAIN: sales
+"#;
+    let profile = parse_profile_from_str(yaml).expect("parse databricks profile");
+    let runner = &profile.execution.as_ref().expect("execution").runner;
+    assert_eq!(runner.runner_type, "databricks_job");
+    assert_eq!(runner.workspace_url.as_deref(), Some("https://adb-1234.5.azuredatabricks.net"));
+    assert_eq!(runner.existing_cluster_id.as_deref(), Some("1111-222222-abc123"));
+    assert_eq!(runner.config_uri.as_deref(), Some("dbfs:/floe/configs/prod.yml"));
+    assert_eq!(runner.job_name.as_deref(), Some("floe-sales-prod"));
+    assert_eq!(
+        runner
+            .auth
+            .as_ref()
+            .and_then(|a| a.service_principal_oauth_ref.as_deref()),
+        Some("secret://kv/databricks/oauth")
+    );
+    assert_eq!(
+        runner
+            .env_parameters
+            .as_ref()
+            .and_then(|env| env.get("FLOE_ENV"))
+            .map(|s| s.as_str()),
+        Some("prod")
+    );
+}
+
 // ---------------------------------------------------------------------------
 // Failure cases
 // ---------------------------------------------------------------------------

--- a/crates/floe-core/tests/unit/profile/parse.rs
+++ b/crates/floe-core/tests/unit/profile/parse.rs
@@ -161,6 +161,7 @@ execution:
     workspace_url: https://adb-1234.5.azuredatabricks.net
     existing_cluster_id: 1111-222222-abc123
     config_uri: dbfs:/floe/configs/prod.yml
+    python_file_uri: dbfs:/floe/bin/floe_entry.py
     job_name: floe-sales-prod
     command: floe
     args:
@@ -170,7 +171,7 @@ execution:
     poll_interval_seconds: 20
     timeout_seconds: 1800
     auth:
-      service_principal_oauth_ref: secret://kv/databricks/oauth
+      service_principal_oauth_ref: env://DATABRICKS_TOKEN
     env_parameters:
       FLOE_ENV: prod
       FLOE_DOMAIN: sales
@@ -190,13 +191,17 @@ execution:
         runner.config_uri.as_deref(),
         Some("dbfs:/floe/configs/prod.yml")
     );
+    assert_eq!(
+        runner.python_file_uri.as_deref(),
+        Some("dbfs:/floe/bin/floe_entry.py")
+    );
     assert_eq!(runner.job_name.as_deref(), Some("floe-sales-prod"));
     assert_eq!(
         runner
             .auth
             .as_ref()
             .and_then(|a| a.service_principal_oauth_ref.as_deref()),
-        Some("secret://kv/databricks/oauth")
+        Some("env://DATABRICKS_TOKEN")
     );
     assert_eq!(
         runner

--- a/crates/floe-core/tests/unit/profile/parse.rs
+++ b/crates/floe-core/tests/unit/profile/parse.rs
@@ -178,9 +178,18 @@ execution:
     let profile = parse_profile_from_str(yaml).expect("parse databricks profile");
     let runner = &profile.execution.as_ref().expect("execution").runner;
     assert_eq!(runner.runner_type, "databricks_job");
-    assert_eq!(runner.workspace_url.as_deref(), Some("https://adb-1234.5.azuredatabricks.net"));
-    assert_eq!(runner.existing_cluster_id.as_deref(), Some("1111-222222-abc123"));
-    assert_eq!(runner.config_uri.as_deref(), Some("dbfs:/floe/configs/prod.yml"));
+    assert_eq!(
+        runner.workspace_url.as_deref(),
+        Some("https://adb-1234.5.azuredatabricks.net")
+    );
+    assert_eq!(
+        runner.existing_cluster_id.as_deref(),
+        Some("1111-222222-abc123")
+    );
+    assert_eq!(
+        runner.config_uri.as_deref(),
+        Some("dbfs:/floe/configs/prod.yml")
+    );
     assert_eq!(runner.job_name.as_deref(), Some("floe-sales-prod"));
     assert_eq!(
         runner

--- a/crates/floe-core/tests/unit/profile/validate.rs
+++ b/crates/floe-core/tests/unit/profile/validate.rs
@@ -157,8 +157,9 @@ execution:
     workspace_url: https://adb-1234.5.azuredatabricks.net
     existing_cluster_id: 1111-222222-abc123
     config_uri: dbfs:/floe/configs/prod.yml
+    python_file_uri: dbfs:/floe/bin/floe_entry.py
     auth:
-      service_principal_oauth_ref: secret://kv/databricks/oauth
+      service_principal_oauth_ref: env://DATABRICKS_TOKEN
 "#;
     let profile = parse_profile_from_str(yaml).expect("parse");
     validate_profile(&profile).expect("databricks_job runner type must pass profile validation");
@@ -176,8 +177,9 @@ execution:
     type: databricks_job
     workspace_url: https://adb-1234.5.azuredatabricks.net
     config_uri: dbfs:/floe/configs/prod.yml
+    python_file_uri: dbfs:/floe/bin/floe_entry.py
     auth:
-      service_principal_oauth_ref: secret://kv/databricks/oauth
+      service_principal_oauth_ref: env://DATABRICKS_TOKEN
 "#;
     let profile = parse_profile_from_str(yaml).expect("parse");
     let err = validate_profile(&profile).unwrap_err();
@@ -185,6 +187,27 @@ execution:
         err.to_string().contains("existing_cluster_id"),
         "got: {err}"
     );
+}
+
+#[test]
+fn validate_databricks_job_missing_python_file_uri_fails() {
+    let yaml = r#"
+apiVersion: floe/v1
+kind: EnvironmentProfile
+metadata:
+  name: dbx-prod
+execution:
+  runner:
+    type: databricks_job
+    workspace_url: https://adb-1234.5.azuredatabricks.net
+    existing_cluster_id: 1111-222222-abc123
+    config_uri: dbfs:/floe/configs/prod.yml
+    auth:
+      service_principal_oauth_ref: env://DATABRICKS_TOKEN
+"#;
+    let profile = parse_profile_from_str(yaml).expect("parse");
+    let err = validate_profile(&profile).unwrap_err();
+    assert!(err.to_string().contains("python_file_uri"), "got: {err}");
 }
 
 #[test]

--- a/crates/floe-core/tests/unit/profile/validate.rs
+++ b/crates/floe-core/tests/unit/profile/validate.rs
@@ -181,7 +181,10 @@ execution:
 "#;
     let profile = parse_profile_from_str(yaml).expect("parse");
     let err = validate_profile(&profile).unwrap_err();
-    assert!(err.to_string().contains("existing_cluster_id"), "got: {err}");
+    assert!(
+        err.to_string().contains("existing_cluster_id"),
+        "got: {err}"
+    );
 }
 
 #[test]

--- a/crates/floe-core/tests/unit/profile/validate.rs
+++ b/crates/floe-core/tests/unit/profile/validate.rs
@@ -145,6 +145,46 @@ execution:
 }
 
 #[test]
+fn validate_databricks_job_runner_type_is_accepted() {
+    let yaml = r#"
+apiVersion: floe/v1
+kind: EnvironmentProfile
+metadata:
+  name: dbx-prod
+execution:
+  runner:
+    type: databricks_job
+    workspace_url: https://adb-1234.5.azuredatabricks.net
+    existing_cluster_id: 1111-222222-abc123
+    config_uri: dbfs:/floe/configs/prod.yml
+    auth:
+      service_principal_oauth_ref: secret://kv/databricks/oauth
+"#;
+    let profile = parse_profile_from_str(yaml).expect("parse");
+    validate_profile(&profile).expect("databricks_job runner type must pass profile validation");
+}
+
+#[test]
+fn validate_databricks_job_missing_required_field_fails() {
+    let yaml = r#"
+apiVersion: floe/v1
+kind: EnvironmentProfile
+metadata:
+  name: dbx-prod
+execution:
+  runner:
+    type: databricks_job
+    workspace_url: https://adb-1234.5.azuredatabricks.net
+    config_uri: dbfs:/floe/configs/prod.yml
+    auth:
+      service_principal_oauth_ref: secret://kv/databricks/oauth
+"#;
+    let profile = parse_profile_from_str(yaml).expect("parse");
+    let err = validate_profile(&profile).unwrap_err();
+    assert!(err.to_string().contains("existing_cluster_id"), "got: {err}");
+}
+
+#[test]
 fn validate_unknown_runner_fails() {
     let yaml = r#"
 apiVersion: floe/v1

--- a/docs/profiles.md
+++ b/docs/profiles.md
@@ -153,8 +153,9 @@ execution:
     type: databricks_job
     workspace_url: https://adb-1234.5.azuredatabricks.net
     existing_cluster_id: 1111-222222-abc123
-    config_uri: dbfs:/floe/configs/prod.yml
-    job_name: floe-{domain}-{env} # rendered before job lookup/create
+    config_uri: dbfs:/floe/configs/prod.yml         # passed to floe CLI as `-c`
+    python_file_uri: dbfs:/floe/bin/floe_entry.py   # spark_python_task python_file
+    job_name: floe-{domain}-{env}                   # rendered before job lookup/create
     auth:
       service_principal_oauth_ref: env://DATABRICKS_TOKEN
 variables:
@@ -163,13 +164,31 @@ validation:
   strict: true
 ```
 
+`config_uri` and `python_file_uri` are intentionally separate: the first is the
+floe YAML config the CLI is invoked with (`-c`), the second is the Python entry
+script Databricks executes as `spark_python_task.python_file`. They are usually
+distinct artifacts.
+
 Databricks auth expectations for orchestrator runtimes:
 
-- `auth.service_principal_oauth_ref` remains required in profile/manifest contract.
-- Runtime token resolution is:
-  1) `FLOE_DATABRICKS_OAUTH_TOKEN` (fallback env), else
-  2) `auth.service_principal_oauth_ref` when set as `env://<VAR>`.
-- Other reference schemes (for example `secret://...`) must be resolved upstream into an env var before runtime.
+- `auth.service_principal_oauth_ref` is required in the profile/manifest
+  contract and must be of the form `env://<VAR>` (schema-enforced). When set,
+  it is the source of truth and **takes precedence** over any
+  `FLOE_DATABRICKS_OAUTH_TOKEN` fallback.
+- If `auth.service_principal_oauth_ref` is not set, the runtime falls back to
+  `FLOE_DATABRICKS_OAUTH_TOKEN`.
+- Other reference schemes (for example `secret://...`) are rejected at runtime
+  and at schema-validation time. Resolve them upstream into an env var before
+  the orchestrator process starts.
+
+Per-run env vars and `existing_cluster_id`:
+
+- Databricks does not allow per-run OS env vars on a `spark_python_task`
+  attached to an existing cluster. `runner.env_parameters` is therefore not
+  delivered per-run; values that the floe CLI reads from the environment
+  (e.g. `FLOE_ENV`) must be configured at cluster level. The orchestrator
+  process still reads `env_parameters.FLOE_ENV` to render `{env}` in
+  `job_name`, but does not push it to the running task.
 
 ---
 
@@ -215,6 +234,7 @@ The parser and validator return actionable errors for common problems:
 | Missing `metadata.name` | `profile.metadata.name is required` |
 | Unknown field | `unknown field profile.unknownField` |
 | Unknown runner | `profile.execution.runner.type: unknown runner "kubernetes"; known runners: local, kubernetes_job, databricks_job` |
+| Missing `python_file_uri` | `profile.execution.runner.python_file_uri is required for databricks_job` |
 | Unresolved variable | `profile variable "PATH_VAR" contains unresolved placeholder: ${UNDEFINED}` |
 
 ---

--- a/docs/profiles.md
+++ b/docs/profiles.md
@@ -15,7 +15,7 @@ types, `required` / `additionalProperties` constraints, and inline descriptions.
 **AI-assisted authoring** — paste the contents of `profile.schema.yaml` into
 your AI assistant (or point it at the file) and ask it to generate a valid
 profile for your environment.  The schema enumerates all allowed values (e.g.
-`runner.type: local`) and marks required fields, so generated output can be
+`runner.type: local|kubernetes_job|databricks_job`) and marks required fields, so generated output can be
 validated immediately with `cargo test` or a JSON Schema validator.
 
 ## Schema v1
@@ -30,7 +30,7 @@ metadata:                    # required
   tags: [development, local] # optional; string list
 execution:                   # optional
   runner:
-    type: local              # required when execution is present; currently only "local"
+    type: local              # required when execution is present
 variables:                   # optional; flat string → string map
   KEY: value
 validation:                  # optional
@@ -140,6 +140,37 @@ validation:
   strict: true
 ```
 
+### databricks.yml (runner MVP)
+
+```yaml
+apiVersion: floe/v1
+kind: EnvironmentProfile
+metadata:
+  name: prod-dbx
+  env: prod
+execution:
+  runner:
+    type: databricks_job
+    workspace_url: https://adb-1234.5.azuredatabricks.net
+    existing_cluster_id: 1111-222222-abc123
+    config_uri: dbfs:/floe/configs/prod.yml
+    job_name: floe-{domain}-{env} # rendered before job lookup/create
+    auth:
+      service_principal_oauth_ref: env://DATABRICKS_TOKEN
+variables:
+  CATALOG: prod_catalog
+validation:
+  strict: true
+```
+
+Databricks auth expectations for orchestrator runtimes:
+
+- `auth.service_principal_oauth_ref` remains required in profile/manifest contract.
+- Runtime token resolution is:
+  1) `FLOE_DATABRICKS_OAUTH_TOKEN` (fallback env), else
+  2) `auth.service_principal_oauth_ref` when set as `env://<VAR>`.
+- Other reference schemes (for example `secret://...`) must be resolved upstream into an env var before runtime.
+
 ---
 
 ## Using profile variables in a Floe config
@@ -183,7 +214,7 @@ The parser and validator return actionable errors for common problems:
 | Missing `metadata` | `profile.metadata is required` |
 | Missing `metadata.name` | `profile.metadata.name is required` |
 | Unknown field | `unknown field profile.unknownField` |
-| Unknown runner | `profile.execution.runner.type: unknown runner "kubernetes"; known runners: local` |
+| Unknown runner | `profile.execution.runner.type: unknown runner "kubernetes"; known runners: local, kubernetes_job, databricks_job` |
 | Unresolved variable | `profile variable "PATH_VAR" contains unresolved placeholder: ${UNDEFINED}` |
 
 ---

--- a/orchestrators/airflow-floe/src/airflow_floe/databricks_client.py
+++ b/orchestrators/airflow-floe/src/airflow_floe/databricks_client.py
@@ -6,11 +6,17 @@ Primary auth model: service principal OAuth bearer token supplied by caller.
 from __future__ import annotations
 
 from dataclasses import dataclass
-import hashlib
-import json
 import time
 from typing import Any, Protocol
 from urllib.parse import urlencode
+
+
+# Bumped whenever floe materially changes the job-settings shape it produces.
+# Stored on the Databricks job as a tag so we can detect drift without comparing
+# server-normalized payloads (which trigger spurious resets every run).
+FLOE_SETTINGS_VERSION = "1"
+
+_FIND_JOB_MAX_PAGES = 200
 
 
 class HttpClient(Protocol):
@@ -30,13 +36,11 @@ class HttpClient(Protocol):
 class DatabricksJobSpec:
     workspace_url: str
     existing_cluster_id: str
-    config_uri: str
+    python_file_uri: str
     job_name: str
-    command: list[str]
-    args: list[str]
+    parameters: list[str]
     poll_interval_seconds: int = 10
     timeout_seconds: int = 3600
-    env_parameters: dict[str, str] | None = None
 
 
 @dataclass(frozen=True)
@@ -65,31 +69,37 @@ class DatabricksJobsClient:
 
     def ensure_domain_job(self, spec: DatabricksJobSpec) -> int:
         expected = self._build_job_settings(spec)
-        expected_hash = _settings_hash(expected)
+        expected_marker = expected["tags"]["floe_settings_version"]
 
         existing = self._find_job_by_name(spec.job_name)
         if existing is None:
-            created = self._call("POST", "/api/2.1/jobs/create", {"name": spec.job_name, **expected})
+            created = self._call(
+                "POST",
+                "/api/2.1/jobs/create",
+                {"name": spec.job_name, **expected},
+            )
             return int(created["job_id"])
 
         job_id = int(existing["job_id"])
-        current_settings = existing.get("settings") or {}
-        current_hash = _settings_hash(
-            {
-                "tasks": current_settings.get("tasks", []),
-                "tags": current_settings.get("tags", {}),
-                "max_concurrent_runs": current_settings.get("max_concurrent_runs", 1),
-            }
+        current_marker = (
+            (existing.get("settings") or {})
+            .get("tags", {})
+            .get("floe_settings_version")
         )
-        if current_hash != expected_hash:
-            self._call("POST", "/api/2.1/jobs/reset", {"job_id": job_id, "new_settings": {"name": spec.job_name, **expected}})
+        if current_marker != expected_marker:
+            self._call(
+                "POST",
+                "/api/2.1/jobs/reset",
+                {"job_id": job_id, "new_settings": {"name": spec.job_name, **expected}},
+            )
         return job_id
 
-    def run_now(self, *, job_id: int, env_parameters: dict[str, str] | None = None) -> int:
-        payload: dict[str, Any] = {"job_id": job_id}
-        if env_parameters:
-            payload["job_parameters"] = env_parameters
-        response = self._call("POST", "/api/2.1/jobs/run-now", payload)
+    def run_now(self, *, job_id: int) -> int:
+        # NOTE: Per-run env vars are intentionally not sent here. Databricks
+        # `job_parameters` are not surfaced as OS env or argv to a
+        # `spark_python_task`. Per-run inputs (entity, run id, etc.) must be
+        # encoded into `spec.parameters` (task-level argv).
+        response = self._call("POST", "/api/2.1/jobs/run-now", {"job_id": job_id})
         return int(response["run_id"])
 
     def poll_run_to_terminal(
@@ -122,7 +132,7 @@ class DatabricksJobsClient:
         limit = 25
         offset = 0
         page_token: str | None = None
-        while True:
+        for _ in range(_FIND_JOB_MAX_PAGES):
             params: dict[str, Any] = {"name": job_name, "limit": limit}
             if page_token:
                 params["page_token"] = page_token
@@ -144,11 +154,15 @@ class DatabricksJobsClient:
                 offset += limit
                 continue
             return None
+        raise RuntimeError(
+            f"databricks jobs/list pagination exceeded {_FIND_JOB_MAX_PAGES} pages "
+            f"while searching for job_name={job_name!r}"
+        )
 
     def _build_job_settings(self, spec: DatabricksJobSpec) -> dict[str, Any]:
         spark_python_task = {
-            "python_file": spec.config_uri,
-            "parameters": [*spec.command, *spec.args],
+            "python_file": spec.python_file_uri,
+            "parameters": list(spec.parameters),
         }
         task = {
             "task_key": "floe_main",
@@ -158,7 +172,11 @@ class DatabricksJobsClient:
         return {
             "max_concurrent_runs": 1,
             "tasks": [task],
-            "tags": {"managed_by": "floe", "runner_type": "databricks_job"},
+            "tags": {
+                "managed_by": "floe",
+                "runner_type": "databricks_job",
+                "floe_settings_version": FLOE_SETTINGS_VERSION,
+            },
         }
 
     def _call(self, method: str, path: str, payload: dict[str, Any]) -> dict[str, Any]:
@@ -168,8 +186,3 @@ class DatabricksJobsClient:
             url = f"{url}?{query}" if query else url
             return self._http.request(method, url, headers=self._headers)
         return self._http.request(method, url, headers=self._headers, json_body=payload)
-
-
-def _settings_hash(settings: dict[str, Any]) -> str:
-    encoded = json.dumps(settings, sort_keys=True, separators=(",", ":")).encode("utf-8")
-    return hashlib.sha256(encoded).hexdigest()

--- a/orchestrators/airflow-floe/src/airflow_floe/databricks_client.py
+++ b/orchestrators/airflow-floe/src/airflow_floe/databricks_client.py
@@ -10,6 +10,7 @@ import hashlib
 import json
 import time
 from typing import Any, Protocol
+from urllib.parse import urlencode
 
 
 class HttpClient(Protocol):
@@ -118,12 +119,31 @@ class DatabricksJobsClient:
             time.sleep(max(1, poll_interval_seconds))
 
     def _find_job_by_name(self, job_name: str) -> dict[str, Any] | None:
-        response = self._call("GET", "/api/2.1/jobs/list", {"name": job_name, "limit": 25})
-        for item in response.get("jobs", []):
-            settings = item.get("settings") or {}
-            if settings.get("name") == job_name:
-                return item
-        return None
+        limit = 25
+        offset = 0
+        page_token: str | None = None
+        while True:
+            params: dict[str, Any] = {"name": job_name, "limit": limit}
+            if page_token:
+                params["page_token"] = page_token
+            else:
+                params["offset"] = offset
+
+            response = self._call("GET", "/api/2.1/jobs/list", params)
+            for item in response.get("jobs", []):
+                settings = item.get("settings") or {}
+                if settings.get("name") == job_name:
+                    return item
+
+            next_token = response.get("next_page_token")
+            has_more = bool(response.get("has_more"))
+            if isinstance(next_token, str) and next_token:
+                page_token = next_token
+                continue
+            if has_more:
+                offset += limit
+                continue
+            return None
 
     def _build_job_settings(self, spec: DatabricksJobSpec) -> dict[str, Any]:
         spark_python_task = {
@@ -144,7 +164,7 @@ class DatabricksJobsClient:
     def _call(self, method: str, path: str, payload: dict[str, Any]) -> dict[str, Any]:
         url = f"{self._workspace_url}{path}"
         if method == "GET":
-            query = "&".join(f"{k}={v}" for k, v in payload.items())
+            query = urlencode(payload, doseq=True)
             url = f"{url}?{query}" if query else url
             return self._http.request(method, url, headers=self._headers)
         return self._http.request(method, url, headers=self._headers, json_body=payload)

--- a/orchestrators/airflow-floe/src/airflow_floe/databricks_client.py
+++ b/orchestrators/airflow-floe/src/airflow_floe/databricks_client.py
@@ -1,0 +1,155 @@
+"""Databricks Jobs API client abstraction for connector runtimes.
+
+Primary auth model: service principal OAuth bearer token supplied by caller.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import hashlib
+import json
+import time
+from typing import Any, Protocol
+
+
+class HttpClient(Protocol):
+    def request(
+        self,
+        method: str,
+        url: str,
+        *,
+        headers: dict[str, str] | None = None,
+        json_body: dict[str, Any] | None = None,
+        timeout_seconds: int | None = None,
+    ) -> dict[str, Any]:
+        ...
+
+
+@dataclass(frozen=True)
+class DatabricksJobSpec:
+    workspace_url: str
+    existing_cluster_id: str
+    config_uri: str
+    job_name: str
+    command: list[str]
+    args: list[str]
+    poll_interval_seconds: int = 10
+    timeout_seconds: int = 3600
+    env_parameters: dict[str, str] | None = None
+
+
+@dataclass(frozen=True)
+class DatabricksRunResult:
+    run_id: int
+    state: str
+    result_state: str | None
+    state_message: str | None
+    run_page_url: str | None
+
+
+class DatabricksJobsClient:
+    def __init__(
+        self,
+        *,
+        http_client: HttpClient,
+        workspace_url: str,
+        oauth_bearer_token: str,
+    ) -> None:
+        self._http = http_client
+        self._workspace_url = workspace_url.rstrip("/")
+        self._headers = {
+            "Authorization": f"Bearer {oauth_bearer_token}",
+            "Content-Type": "application/json",
+        }
+
+    def ensure_domain_job(self, spec: DatabricksJobSpec) -> int:
+        expected = self._build_job_settings(spec)
+        expected_hash = _settings_hash(expected)
+
+        existing = self._find_job_by_name(spec.job_name)
+        if existing is None:
+            created = self._call("POST", "/api/2.1/jobs/create", {"name": spec.job_name, **expected})
+            return int(created["job_id"])
+
+        job_id = int(existing["job_id"])
+        current_settings = existing.get("settings") or {}
+        current_hash = _settings_hash(
+            {
+                "tasks": current_settings.get("tasks", []),
+                "tags": current_settings.get("tags", {}),
+                "max_concurrent_runs": current_settings.get("max_concurrent_runs", 1),
+            }
+        )
+        if current_hash != expected_hash:
+            self._call("POST", "/api/2.1/jobs/reset", {"job_id": job_id, "new_settings": {"name": spec.job_name, **expected}})
+        return job_id
+
+    def run_now(self, *, job_id: int, env_parameters: dict[str, str] | None = None) -> int:
+        payload: dict[str, Any] = {"job_id": job_id}
+        if env_parameters:
+            payload["job_parameters"] = env_parameters
+        response = self._call("POST", "/api/2.1/jobs/run-now", payload)
+        return int(response["run_id"])
+
+    def poll_run_to_terminal(
+        self,
+        *,
+        run_id: int,
+        poll_interval_seconds: int,
+        timeout_seconds: int,
+    ) -> DatabricksRunResult:
+        deadline = time.monotonic() + timeout_seconds
+        while True:
+            run = self._call("GET", "/api/2.1/jobs/runs/get", {"run_id": run_id})
+            state = run.get("state") or {}
+            life_cycle_state = str(state.get("life_cycle_state") or "")
+            result_state = state.get("result_state")
+            state_message = state.get("state_message")
+            if life_cycle_state in {"TERMINATED", "INTERNAL_ERROR", "SKIPPED"}:
+                return DatabricksRunResult(
+                    run_id=run_id,
+                    state=life_cycle_state,
+                    result_state=result_state,
+                    state_message=state_message,
+                    run_page_url=run.get("run_page_url"),
+                )
+            if time.monotonic() >= deadline:
+                raise TimeoutError(f"databricks run {run_id} did not reach terminal state within {timeout_seconds}s")
+            time.sleep(max(1, poll_interval_seconds))
+
+    def _find_job_by_name(self, job_name: str) -> dict[str, Any] | None:
+        response = self._call("GET", "/api/2.1/jobs/list", {"name": job_name, "limit": 25})
+        for item in response.get("jobs", []):
+            settings = item.get("settings") or {}
+            if settings.get("name") == job_name:
+                return item
+        return None
+
+    def _build_job_settings(self, spec: DatabricksJobSpec) -> dict[str, Any]:
+        spark_python_task = {
+            "python_file": spec.config_uri,
+            "parameters": [*spec.command, *spec.args],
+        }
+        task = {
+            "task_key": "floe_main",
+            "existing_cluster_id": spec.existing_cluster_id,
+            "spark_python_task": spark_python_task,
+        }
+        return {
+            "max_concurrent_runs": 1,
+            "tasks": [task],
+            "tags": {"managed_by": "floe", "runner_type": "databricks_job"},
+        }
+
+    def _call(self, method: str, path: str, payload: dict[str, Any]) -> dict[str, Any]:
+        url = f"{self._workspace_url}{path}"
+        if method == "GET":
+            query = "&".join(f"{k}={v}" for k, v in payload.items())
+            url = f"{url}?{query}" if query else url
+            return self._http.request(method, url, headers=self._headers)
+        return self._http.request(method, url, headers=self._headers, json_body=payload)
+
+
+def _settings_hash(settings: dict[str, Any]) -> str:
+    encoded = json.dumps(settings, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()

--- a/orchestrators/airflow-floe/src/airflow_floe/databricks_runner.py
+++ b/orchestrators/airflow-floe/src/airflow_floe/databricks_runner.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+import time
 from typing import Any
 
 from .databricks_client import DatabricksJobSpec, DatabricksJobsClient
@@ -55,27 +56,78 @@ def run_databricks_job(
         poll_interval_seconds=spec.poll_interval_seconds,
         timeout_seconds=spec.timeout_seconds,
     )
-    if terminal.result_state not in {None, "SUCCESS"}:
-        raise RuntimeError(
-            f"Databricks run failed: state={terminal.state} result={terminal.result_state} message={terminal.state_message}"
-        )
+    status = _map_databricks_status(
+        life_cycle_state=terminal.state,
+        result_state=terminal.result_state,
+    )
+    failure_reason = _resolve_failure_reason(
+        status=status,
+        result_state=terminal.result_state,
+        state_message=terminal.state_message,
+    )
 
-    return {
+    payload: dict[str, Any] = {
         "schema": "floe.airflow.run.v1",
         "run_id": str(run_id),
-        "status": terminal.result_state or terminal.state,
-        "exit_code": 0,
-        "files": {},
-        "rows": {},
-        "accepted": {},
-        "rejected": {},
-        "warnings": [],
-        "errors": [],
+        "status": status,
+        "exit_code": 0 if status == "success" else 1,
+        "files": 0,
+        "rows": 0,
+        "accepted": 0,
+        "rejected": 0,
+        "warnings": 0,
+        "errors": 0,
         "summary_uri": None,
         "config_uri": config_uri,
-        "backend": "databricks",
-        "backend_run_page_url": terminal.run_page_url,
+        "floe_log_schema": "floe.log.v1",
+        "finished_at_ts_ms": int(time.time() * 1000),
+        "backend_type": "databricks",
+        "backend_run_id": str(run_id),
+        "backend_status": terminal.result_state or terminal.state,
+        "backend_metadata": {
+            "job_id": job_id,
+            "life_cycle_state": terminal.state,
+            "result_state": terminal.result_state,
+            "run_page_url": terminal.run_page_url,
+        },
     }
+    if failure_reason:
+        payload["failure_reason"] = failure_reason
+    if entities and len(entities) == 1:
+        payload["entity"] = entities[0]
+    return payload
+
+
+def _map_databricks_status(*, life_cycle_state: str | None, result_state: str | None) -> str:
+    normalized_result = (result_state or "").strip().upper()
+    normalized_lifecycle = (life_cycle_state or "").strip().upper()
+
+    if normalized_result == "SUCCESS":
+        return "success"
+    if normalized_result in {"TIMEDOUT"}:
+        return "timeout"
+    if normalized_result in {"CANCELED", "CANCELLED"}:
+        return "canceled"
+    if normalized_result:
+        return "failed"
+
+    if normalized_lifecycle in {"SKIPPED"}:
+        return "canceled"
+    if normalized_lifecycle in {"INTERNAL_ERROR"}:
+        return "failed"
+    if normalized_lifecycle in {"TERMINATED"}:
+        return "failed"
+    return "failed"
+
+
+def _resolve_failure_reason(*, status: str, result_state: str | None, state_message: str | None) -> str | None:
+    if status == "success":
+        return None
+    if state_message:
+        return state_message
+    if result_state:
+        return str(result_state)
+    return None
 
 
 class _RequestsHttpClient:

--- a/orchestrators/airflow-floe/src/airflow_floe/databricks_runner.py
+++ b/orchestrators/airflow-floe/src/airflow_floe/databricks_runner.py
@@ -1,0 +1,101 @@
+"""Databricks runner adapter for airflow-floe."""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+from .databricks_client import DatabricksJobSpec, DatabricksJobsClient
+from .manifest import ManifestRunnerDefinition
+
+
+def run_databricks_job(
+    *,
+    cmd_args: list[str],
+    runner: ManifestRunnerDefinition,
+    entities: list[str] | None,
+) -> dict[str, Any]:
+    workspace_url = runner.workspace_url
+    existing_cluster_id = runner.existing_cluster_id
+    config_uri = runner.config_uri
+    if not workspace_url or not existing_cluster_id or not config_uri:
+        raise ValueError(
+            "databricks_job runner requires workspace_url, existing_cluster_id, and config_uri"
+        )
+
+    oauth_token = os.environ.get("FLOE_DATABRICKS_OAUTH_TOKEN")
+    if not oauth_token:
+        raise ValueError("FLOE_DATABRICKS_OAUTH_TOKEN is required for databricks_job runner")
+
+    client = DatabricksJobsClient(
+        http_client=_RequestsHttpClient(),
+        workspace_url=workspace_url,
+        oauth_bearer_token=oauth_token,
+    )
+    job_name = runner.job_name or "floe-{domain}-{env}"
+    env_parameters = dict(runner.env_parameters or {})
+    if entities:
+        env_parameters.setdefault("FLOE_ENTITIES", ",".join(entities))
+
+    spec = DatabricksJobSpec(
+        workspace_url=workspace_url,
+        existing_cluster_id=existing_cluster_id,
+        config_uri=config_uri,
+        job_name=job_name,
+        command=cmd_args[:1],
+        args=cmd_args[1:],
+        poll_interval_seconds=runner.poll_interval_seconds or 10,
+        timeout_seconds=runner.timeout_seconds or 3600,
+        env_parameters=env_parameters,
+    )
+    job_id = client.ensure_domain_job(spec)
+    run_id = client.run_now(job_id=job_id, env_parameters=spec.env_parameters)
+    terminal = client.poll_run_to_terminal(
+        run_id=run_id,
+        poll_interval_seconds=spec.poll_interval_seconds,
+        timeout_seconds=spec.timeout_seconds,
+    )
+    if terminal.result_state not in {None, "SUCCESS"}:
+        raise RuntimeError(
+            f"Databricks run failed: state={terminal.state} result={terminal.result_state} message={terminal.state_message}"
+        )
+
+    return {
+        "schema": "floe.airflow.run.v1",
+        "run_id": str(run_id),
+        "status": terminal.result_state or terminal.state,
+        "exit_code": 0,
+        "files": {},
+        "rows": {},
+        "accepted": {},
+        "rejected": {},
+        "warnings": [],
+        "errors": [],
+        "summary_uri": None,
+        "config_uri": config_uri,
+        "backend": "databricks",
+        "backend_run_page_url": terminal.run_page_url,
+    }
+
+
+class _RequestsHttpClient:
+    def request(
+        self,
+        method: str,
+        url: str,
+        *,
+        headers: dict[str, str] | None = None,
+        json_body: dict[str, Any] | None = None,
+        timeout_seconds: int | None = None,
+    ) -> dict[str, Any]:
+        import requests
+
+        response = requests.request(
+            method,
+            url,
+            headers=headers,
+            json=json_body,
+            timeout=timeout_seconds or 30,
+        )
+        response.raise_for_status()
+        return response.json() if response.text else {}

--- a/orchestrators/airflow-floe/src/airflow_floe/databricks_runner.py
+++ b/orchestrators/airflow-floe/src/airflow_floe/databricks_runner.py
@@ -24,17 +24,18 @@ def run_databricks_job(
             "databricks_job runner requires workspace_url, existing_cluster_id, and config_uri"
         )
 
-    oauth_token = os.environ.get("FLOE_DATABRICKS_OAUTH_TOKEN")
-    if not oauth_token:
-        raise ValueError("FLOE_DATABRICKS_OAUTH_TOKEN is required for databricks_job runner")
+    env_parameters = dict(runner.env_parameters or {})
+    auth_ref = _extract_oauth_ref(runner.auth)
+    oauth_token = _resolve_oauth_token(auth_ref)
+    domain = _resolve_domain(entities)
+    env_name = env_parameters.get("FLOE_ENV") or os.environ.get("FLOE_ENV") or "default"
+    job_name = _render_job_name(runner.job_name or "floe-{domain}-{env}", domain=domain, env=env_name)
 
     client = DatabricksJobsClient(
         http_client=_RequestsHttpClient(),
         workspace_url=workspace_url,
         oauth_bearer_token=oauth_token,
     )
-    job_name = runner.job_name or "floe-{domain}-{env}"
-    env_parameters = dict(runner.env_parameters or {})
     if entities:
         env_parameters.setdefault("FLOE_ENTITIES", ",".join(entities))
 
@@ -49,13 +50,36 @@ def run_databricks_job(
         timeout_seconds=runner.timeout_seconds or 3600,
         env_parameters=env_parameters,
     )
-    job_id = client.ensure_domain_job(spec)
-    run_id = client.run_now(job_id=job_id, env_parameters=spec.env_parameters)
-    terminal = client.poll_run_to_terminal(
-        run_id=run_id,
-        poll_interval_seconds=spec.poll_interval_seconds,
-        timeout_seconds=spec.timeout_seconds,
-    )
+    job_id: int | None = None
+    run_id: int | None = None
+    try:
+        job_id = client.ensure_domain_job(spec)
+        run_id = client.run_now(job_id=job_id, env_parameters=spec.env_parameters)
+        terminal = client.poll_run_to_terminal(
+            run_id=run_id,
+            poll_interval_seconds=spec.poll_interval_seconds,
+            timeout_seconds=spec.timeout_seconds,
+        )
+    except TimeoutError as exc:
+        return _infra_failure_payload(
+            status="timeout",
+            failure_reason=str(exc),
+            config_uri=config_uri,
+            run_id=run_id,
+            job_id=job_id,
+            error_type="timeout",
+            entities=entities,
+        )
+    except Exception as exc:  # noqa: BLE001
+        return _infra_failure_payload(
+            status="failed",
+            failure_reason=str(exc) or exc.__class__.__name__,
+            config_uri=config_uri,
+            run_id=run_id,
+            job_id=job_id,
+            error_type=exc.__class__.__name__,
+            entities=entities,
+        )
     status = _map_databricks_status(
         life_cycle_state=terminal.state,
         result_state=terminal.result_state,
@@ -93,6 +117,93 @@ def run_databricks_job(
     }
     if failure_reason:
         payload["failure_reason"] = failure_reason
+    if entities and len(entities) == 1:
+        payload["entity"] = entities[0]
+    return payload
+
+
+def _resolve_domain(entities: list[str] | None) -> str:
+    if not entities:
+        return "default"
+    dotted = [entity for entity in entities if entity and "." in entity]
+    if not dotted:
+        return "default"
+    domains = {entity.split(".", 1)[0] for entity in dotted}
+    if len(domains) > 1:
+        raise ValueError(
+            "databricks_job runner expects entities from one domain per run; "
+            f"got domains: {sorted(domains)}"
+        )
+    return next(iter(domains), "default")
+
+
+def _render_job_name(template: str, *, domain: str, env: str) -> str:
+    return template.replace("{domain}", domain).replace("{env}", env)
+
+
+def _extract_oauth_ref(auth: dict[str, str] | None) -> str | None:
+    return (auth or {}).get("service_principal_oauth_ref")
+
+
+def _resolve_oauth_token(auth_ref: str | None) -> str:
+    token = os.environ.get("FLOE_DATABRICKS_OAUTH_TOKEN")
+    if token:
+        return token
+    if not auth_ref:
+        raise ValueError(
+            "databricks_job runner requires auth.service_principal_oauth_ref "
+            "and FLOE_DATABRICKS_OAUTH_TOKEN fallback"
+        )
+    if auth_ref.startswith("env://"):
+        env_var = auth_ref[len("env://") :]
+        resolved = os.environ.get(env_var)
+        if resolved:
+            return resolved
+        raise ValueError(f"databricks oauth token env var '{env_var}' not found")
+    raise ValueError(
+        "databricks oauth reference is not directly resolvable by airflow-floe; "
+        "set FLOE_DATABRICKS_OAUTH_TOKEN or use auth.service_principal_oauth_ref=env://<VAR>"
+    )
+
+
+def _infra_failure_payload(
+    *,
+    status: str,
+    failure_reason: str,
+    config_uri: str,
+    run_id: int | None,
+    job_id: int | None,
+    error_type: str,
+    entities: list[str] | None,
+) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "schema": "floe.airflow.run.v1",
+        "run_id": str(run_id) if run_id is not None else "",
+        "status": status,
+        "exit_code": 1,
+        "files": 0,
+        "rows": 0,
+        "accepted": 0,
+        "rejected": 0,
+        "warnings": 0,
+        "errors": 1,
+        "summary_uri": None,
+        "config_uri": config_uri,
+        "floe_log_schema": "floe.log.v1",
+        "finished_at_ts_ms": int(time.time() * 1000),
+        "backend_type": "databricks",
+        "backend_run_id": str(run_id) if run_id is not None else "",
+        "backend_status": error_type,
+        "failure_reason": failure_reason,
+        "backend_metadata": {
+            "job_id": job_id,
+            "life_cycle_state": None,
+            "result_state": None,
+            "run_page_url": None,
+            "error_type": error_type,
+            "state_message": failure_reason,
+        },
+    }
     if entities and len(entities) == 1:
         payload["entity"] = entities[0]
     return payload

--- a/orchestrators/airflow-floe/src/airflow_floe/databricks_runner.py
+++ b/orchestrators/airflow-floe/src/airflow_floe/databricks_runner.py
@@ -19,42 +19,46 @@ def run_databricks_job(
     workspace_url = runner.workspace_url
     existing_cluster_id = runner.existing_cluster_id
     config_uri = runner.config_uri
-    if not workspace_url or not existing_cluster_id or not config_uri:
+    python_file_uri = runner.python_file_uri
+    if (
+        not workspace_url
+        or not existing_cluster_id
+        or not config_uri
+        or not python_file_uri
+    ):
         raise ValueError(
-            "databricks_job runner requires workspace_url, existing_cluster_id, and config_uri"
+            "databricks_job runner requires workspace_url, existing_cluster_id, "
+            "config_uri and python_file_uri"
         )
 
-    env_parameters = dict(runner.env_parameters or {})
     auth_ref = _extract_oauth_ref(runner.auth)
     oauth_token = _resolve_oauth_token(auth_ref)
     domain = _resolve_domain(entities)
-    env_name = env_parameters.get("FLOE_ENV") or os.environ.get("FLOE_ENV") or "default"
-    job_name = _render_job_name(runner.job_name or "floe-{domain}-{env}", domain=domain, env=env_name)
+    env_name = _resolve_env_name(runner.env_parameters)
+    job_name = _render_job_name(
+        runner.job_name or "floe-{domain}-{env}", domain=domain, env=env_name
+    )
 
     client = DatabricksJobsClient(
         http_client=_RequestsHttpClient(),
         workspace_url=workspace_url,
         oauth_bearer_token=oauth_token,
     )
-    if entities:
-        env_parameters.setdefault("FLOE_ENTITIES", ",".join(entities))
 
     spec = DatabricksJobSpec(
         workspace_url=workspace_url,
         existing_cluster_id=existing_cluster_id,
-        config_uri=config_uri,
+        python_file_uri=python_file_uri,
         job_name=job_name,
-        command=cmd_args[:1],
-        args=cmd_args[1:],
+        parameters=list(cmd_args),
         poll_interval_seconds=runner.poll_interval_seconds or 10,
         timeout_seconds=runner.timeout_seconds or 3600,
-        env_parameters=env_parameters,
     )
     job_id: int | None = None
     run_id: int | None = None
     try:
         job_id = client.ensure_domain_job(spec)
-        run_id = client.run_now(job_id=job_id, env_parameters=spec.env_parameters)
+        run_id = client.run_now(job_id=job_id)
         terminal = client.poll_run_to_terminal(
             run_id=run_id,
             poll_interval_seconds=spec.poll_interval_seconds,
@@ -64,6 +68,7 @@ def run_databricks_job(
         return _infra_failure_payload(
             status="timeout",
             failure_reason=str(exc),
+            workspace_url=workspace_url,
             config_uri=config_uri,
             run_id=run_id,
             job_id=job_id,
@@ -74,6 +79,7 @@ def run_databricks_job(
         return _infra_failure_payload(
             status="failed",
             failure_reason=str(exc) or exc.__class__.__name__,
+            workspace_url=workspace_url,
             config_uri=config_uri,
             run_id=run_id,
             job_id=job_id,
@@ -90,9 +96,19 @@ def run_databricks_job(
         state_message=terminal.state_message,
     )
 
+    backend_metadata = _backend_metadata(
+        workspace_url=workspace_url,
+        run_id=run_id,
+        job_id=job_id,
+        life_cycle_state=terminal.state,
+        result_state=terminal.result_state,
+        state_message=terminal.state_message,
+        run_page_url=terminal.run_page_url,
+    )
+
     payload: dict[str, Any] = {
         "schema": "floe.airflow.run.v1",
-        "run_id": str(run_id),
+        "run_id": str(run_id) if run_id is not None else "",
         "status": status,
         "exit_code": 0 if status == "success" else 1,
         "files": 0,
@@ -106,14 +122,9 @@ def run_databricks_job(
         "floe_log_schema": "floe.log.v1",
         "finished_at_ts_ms": int(time.time() * 1000),
         "backend_type": "databricks",
-        "backend_run_id": str(run_id),
+        "backend_run_id": run_id,
         "backend_status": terminal.result_state or terminal.state,
-        "backend_metadata": {
-            "job_id": job_id,
-            "life_cycle_state": terminal.state,
-            "result_state": terminal.result_state,
-            "run_page_url": terminal.run_page_url,
-        },
+        "backend_metadata": backend_metadata,
     }
     if failure_reason:
         payload["failure_reason"] = failure_reason
@@ -137,6 +148,12 @@ def _resolve_domain(entities: list[str] | None) -> str:
     return next(iter(domains), "default")
 
 
+def _resolve_env_name(env_parameters: dict[str, str] | None) -> str:
+    if env_parameters and env_parameters.get("FLOE_ENV"):
+        return env_parameters["FLOE_ENV"]
+    return os.environ.get("FLOE_ENV") or "default"
+
+
 def _render_job_name(template: str, *, domain: str, env: str) -> str:
     return template.replace("{domain}", domain).replace("{env}", env)
 
@@ -146,36 +163,78 @@ def _extract_oauth_ref(auth: dict[str, str] | None) -> str | None:
 
 
 def _resolve_oauth_token(auth_ref: str | None) -> str:
-    token = os.environ.get("FLOE_DATABRICKS_OAUTH_TOKEN")
-    if token:
-        return token
-    if not auth_ref:
+    # Prefer a declared `env://VAR` reference over the bare-fallback env so
+    # that misconfiguration (declared ref pointing at a missing var) is loud
+    # instead of silently masked by FLOE_DATABRICKS_OAUTH_TOKEN.
+    if auth_ref:
+        if auth_ref.startswith("env://"):
+            env_var = auth_ref[len("env://") :]
+            resolved = os.environ.get(env_var)
+            if resolved:
+                return resolved
+            raise ValueError(
+                f"databricks oauth token env var '{env_var}' "
+                f"(from auth.service_principal_oauth_ref) not found"
+            )
         raise ValueError(
-            "databricks_job runner requires auth.service_principal_oauth_ref "
-            "and FLOE_DATABRICKS_OAUTH_TOKEN fallback"
+            "databricks oauth reference is not directly resolvable by airflow-floe; "
+            "use auth.service_principal_oauth_ref=env://<VAR> or set "
+            "FLOE_DATABRICKS_OAUTH_TOKEN with no auth.service_principal_oauth_ref"
         )
-    if auth_ref.startswith("env://"):
-        env_var = auth_ref[len("env://") :]
-        resolved = os.environ.get(env_var)
-        if resolved:
-            return resolved
-        raise ValueError(f"databricks oauth token env var '{env_var}' not found")
+    fallback = os.environ.get("FLOE_DATABRICKS_OAUTH_TOKEN")
+    if fallback:
+        return fallback
     raise ValueError(
-        "databricks oauth reference is not directly resolvable by airflow-floe; "
-        "set FLOE_DATABRICKS_OAUTH_TOKEN or use auth.service_principal_oauth_ref=env://<VAR>"
+        "databricks_job runner requires auth.service_principal_oauth_ref "
+        "(env://<VAR>) or FLOE_DATABRICKS_OAUTH_TOKEN fallback"
     )
+
+
+def _backend_metadata(
+    *,
+    workspace_url: str,
+    run_id: int | None,
+    job_id: int | None,
+    life_cycle_state: str | None,
+    result_state: str | None,
+    state_message: str | None,
+    run_page_url: str | None,
+    error_type: str | None = None,
+) -> dict[str, Any]:
+    return {
+        "backend_type": "databricks",
+        "backend_run_id": run_id,
+        "workspace_url": workspace_url,
+        "job_id": job_id,
+        "life_cycle_state": life_cycle_state,
+        "result_state": result_state,
+        "state_message": state_message,
+        "run_page_url": run_page_url,
+        "error_type": error_type,
+    }
 
 
 def _infra_failure_payload(
     *,
     status: str,
     failure_reason: str,
+    workspace_url: str,
     config_uri: str,
     run_id: int | None,
     job_id: int | None,
     error_type: str,
     entities: list[str] | None,
 ) -> dict[str, Any]:
+    backend_metadata = _backend_metadata(
+        workspace_url=workspace_url,
+        run_id=run_id,
+        job_id=job_id,
+        life_cycle_state=None,
+        result_state=None,
+        state_message=failure_reason,
+        run_page_url=None,
+        error_type=error_type,
+    )
     payload: dict[str, Any] = {
         "schema": "floe.airflow.run.v1",
         "run_id": str(run_id) if run_id is not None else "",
@@ -192,46 +251,39 @@ def _infra_failure_payload(
         "floe_log_schema": "floe.log.v1",
         "finished_at_ts_ms": int(time.time() * 1000),
         "backend_type": "databricks",
-        "backend_run_id": str(run_id) if run_id is not None else "",
-        "backend_status": error_type,
+        "backend_run_id": run_id,
+        "backend_status": None,
         "failure_reason": failure_reason,
-        "backend_metadata": {
-            "job_id": job_id,
-            "life_cycle_state": None,
-            "result_state": None,
-            "run_page_url": None,
-            "error_type": error_type,
-            "state_message": failure_reason,
-        },
+        "backend_metadata": backend_metadata,
     }
     if entities and len(entities) == 1:
         payload["entity"] = entities[0]
     return payload
 
 
-def _map_databricks_status(*, life_cycle_state: str | None, result_state: str | None) -> str:
+def _map_databricks_status(
+    *, life_cycle_state: str | None, result_state: str | None
+) -> str:
     normalized_result = (result_state or "").strip().upper()
     normalized_lifecycle = (life_cycle_state or "").strip().upper()
 
     if normalized_result == "SUCCESS":
         return "success"
-    if normalized_result in {"TIMEDOUT"}:
+    if normalized_result == "TIMEDOUT":
         return "timeout"
     if normalized_result in {"CANCELED", "CANCELLED"}:
         return "canceled"
     if normalized_result:
         return "failed"
 
-    if normalized_lifecycle in {"SKIPPED"}:
+    if normalized_lifecycle == "SKIPPED":
         return "canceled"
-    if normalized_lifecycle in {"INTERNAL_ERROR"}:
-        return "failed"
-    if normalized_lifecycle in {"TERMINATED"}:
-        return "failed"
     return "failed"
 
 
-def _resolve_failure_reason(*, status: str, result_state: str | None, state_message: str | None) -> str | None:
+def _resolve_failure_reason(
+    *, status: str, result_state: str | None, state_message: str | None
+) -> str | None:
     if status == "success":
         return None
     if state_message:

--- a/orchestrators/airflow-floe/src/airflow_floe/manifest.py
+++ b/orchestrators/airflow-floe/src/airflow_floe/manifest.py
@@ -139,6 +139,7 @@ class ManifestRunnerDefinition:
     workspace_url: str | None = None
     existing_cluster_id: str | None = None
     config_uri: str | None = None
+    python_file_uri: str | None = None
     job_name: str | None = None
     auth: dict[str, str] | None = None
     env_parameters: dict[str, str] | None = None
@@ -211,6 +212,7 @@ class ManifestRunnerDefinition:
             workspace_url=_optional_str(data, "workspace_url"),
             existing_cluster_id=_optional_str(data, "existing_cluster_id"),
             config_uri=_optional_str(data, "config_uri"),
+            python_file_uri=_optional_str(data, "python_file_uri"),
             job_name=_optional_str(data, "job_name"),
             auth=auth,
             env_parameters=env_parameters,
@@ -321,6 +323,7 @@ class AirflowManifest:
                         "workspace_url": definition.workspace_url,
                         "existing_cluster_id": definition.existing_cluster_id,
                         "config_uri": definition.config_uri,
+                        "python_file_uri": definition.python_file_uri,
                         "job_name": definition.job_name,
                         "auth": definition.auth,
                         "env_parameters": definition.env_parameters,

--- a/orchestrators/airflow-floe/src/airflow_floe/manifest.py
+++ b/orchestrators/airflow-floe/src/airflow_floe/manifest.py
@@ -136,6 +136,12 @@ class ManifestRunnerDefinition:
     ttl_seconds_after_finished: int | None
     poll_interval_seconds: int | None
     secrets: list[dict[str, Any]] | None
+    workspace_url: str | None
+    existing_cluster_id: str | None
+    config_uri: str | None
+    job_name: str | None
+    auth: dict[str, str] | None
+    env_parameters: dict[str, str] | None
 
     @staticmethod
     def from_dict(data: dict[str, Any]) -> "ManifestRunnerDefinition":
@@ -159,9 +165,12 @@ class ManifestRunnerDefinition:
         command_raw = data.get("command")
         command: list[str] | None = None
         if command_raw is not None:
-            if not isinstance(command_raw, list) or not all(isinstance(s, str) for s in command_raw):
-                raise ValueError("runners.definitions.*.command must be list[str] or null")
-            command = command_raw
+            if isinstance(command_raw, str):
+                command = [command_raw]
+            elif isinstance(command_raw, list) and all(isinstance(s, str) for s in command_raw):
+                command = command_raw
+            else:
+                raise ValueError("runners.definitions.*.command must be string|list[str]|null")
 
         args_raw = data.get("args")
         args: list[str] | None = None
@@ -183,6 +192,9 @@ class ManifestRunnerDefinition:
                 raise ValueError("runners.definitions.*.secrets must be list[object] or null")
             secrets = secrets_raw
 
+        auth = _optional_string_map(data, "auth")
+        env_parameters = _optional_string_map(data, "env_parameters")
+
         return ManifestRunnerDefinition(
             runner_type=_required_str(data, "type"),
             image=_optional_str(data, "image"),
@@ -196,6 +208,12 @@ class ManifestRunnerDefinition:
             ttl_seconds_after_finished=ttl_seconds_after_finished,
             poll_interval_seconds=poll_interval_seconds,
             secrets=secrets,
+            workspace_url=_optional_str(data, "workspace_url"),
+            existing_cluster_id=_optional_str(data, "existing_cluster_id"),
+            config_uri=_optional_str(data, "config_uri"),
+            job_name=_optional_str(data, "job_name"),
+            auth=auth,
+            env_parameters=env_parameters,
         )
 
 
@@ -300,6 +318,12 @@ class AirflowManifest:
                         "ttl_seconds_after_finished": definition.ttl_seconds_after_finished,
                         "poll_interval_seconds": definition.poll_interval_seconds,
                         "secrets": definition.secrets,
+                        "workspace_url": definition.workspace_url,
+                        "existing_cluster_id": definition.existing_cluster_id,
+                        "config_uri": definition.config_uri,
+                        "job_name": definition.job_name,
+                        "auth": definition.auth,
+                        "env_parameters": definition.env_parameters,
                     }
                     for name, definition in self.runners.definitions.items()
                 },
@@ -388,3 +412,14 @@ def _required_string_map(data: dict[str, Any], key: str) -> dict[str, str]:
         raise ValueError(f"{key} must be a map<string,string>")
     return value
 
+
+def _optional_string_map(data: dict[str, Any], key: str) -> dict[str, str] | None:
+    value = data.get(key)
+    if value is None:
+        return None
+    if not isinstance(value, dict) or not all(
+        isinstance(item_key, str) and isinstance(item_value, str)
+        for item_key, item_value in value.items()
+    ):
+        raise ValueError(f"{key} must be a map<string,string> when provided")
+    return value

--- a/orchestrators/airflow-floe/src/airflow_floe/manifest.py
+++ b/orchestrators/airflow-floe/src/airflow_floe/manifest.py
@@ -136,12 +136,12 @@ class ManifestRunnerDefinition:
     ttl_seconds_after_finished: int | None
     poll_interval_seconds: int | None
     secrets: list[dict[str, Any]] | None
-    workspace_url: str | None
-    existing_cluster_id: str | None
-    config_uri: str | None
-    job_name: str | None
-    auth: dict[str, str] | None
-    env_parameters: dict[str, str] | None
+    workspace_url: str | None = None
+    existing_cluster_id: str | None = None
+    config_uri: str | None = None
+    job_name: str | None = None
+    auth: dict[str, str] | None = None
+    env_parameters: dict[str, str] | None = None
 
     @staticmethod
     def from_dict(data: dict[str, Any]) -> "ManifestRunnerDefinition":

--- a/orchestrators/airflow-floe/src/airflow_floe/operators.py
+++ b/orchestrators/airflow-floe/src/airflow_floe/operators.py
@@ -9,6 +9,7 @@ import threading
 from typing import Any
 
 from .kubernetes_runner import run_kubernetes_job
+from .databricks_runner import run_databricks_job
 from .manifest import ManifestExecution, ManifestRunnerDefinition
 from .runtime import (
     DagManifestContext,
@@ -79,6 +80,13 @@ class FloeRunHook:
                 config_path,
                 entities,
                 runner=runner_definition,
+            )
+        if runner_definition is not None and runner_definition.runner_type == "databricks_job":
+            args = self.build_args(config_path, entities=entities, execution=execution)
+            return run_databricks_job(
+                cmd_args=args,
+                runner=runner_definition,
+                entities=entities,
             )
         if runner_definition is not None and runner_definition.runner_type != "local_process":
             raise NotImplementedError(

--- a/orchestrators/airflow-floe/tests/test_databricks_client.py
+++ b/orchestrators/airflow-floe/tests/test_databricks_client.py
@@ -1,6 +1,10 @@
 from __future__ import annotations
 
 import unittest
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
 
 from airflow_floe.databricks_client import DatabricksJobSpec, DatabricksJobsClient
 

--- a/orchestrators/airflow-floe/tests/test_databricks_client.py
+++ b/orchestrators/airflow-floe/tests/test_databricks_client.py
@@ -61,14 +61,13 @@ class DatabricksClientTests(unittest.TestCase):
         spec = DatabricksJobSpec(
             workspace_url="https://adb.example.com",
             existing_cluster_id="1111-222222-abc123",
-            config_uri="dbfs:/floe/configs/prod.yml",
+            python_file_uri="dbfs:/floe/bin/floe_entry.py",
             job_name="floe-sales-prod",
-            command=["floe"],
-            args=["run", "-c", "dbfs:/floe/configs/prod.yml"],
+            parameters=["run", "-c", "dbfs:/floe/configs/prod.yml"],
         )
 
         job_id = client.ensure_domain_job(spec)
-        run_id = client.run_now(job_id=job_id, env_parameters={"FLOE_ENV": "prod"})
+        run_id = client.run_now(job_id=job_id)
         terminal = client.poll_run_to_terminal(run_id=run_id, poll_interval_seconds=1, timeout_seconds=5)
 
         self.assertEqual(job_id, 123)

--- a/orchestrators/airflow-floe/tests/test_databricks_client.py
+++ b/orchestrators/airflow-floe/tests/test_databricks_client.py
@@ -23,11 +23,21 @@ class _FakeHttp:
             },
             "run_page_url": "https://example/run/999",
         }
+        self.list_calls = 0
 
     def request(self, method: str, url: str, *, headers=None, json_body=None, timeout_seconds=None):
         del headers, timeout_seconds
         self.calls.append((method, url, json_body))
         if "/jobs/list" in url:
+            self.list_calls += 1
+            if self.list_calls == 1 and self.list_jobs.get("next_page"):
+                return {
+                    "jobs": self.list_jobs.get("jobs", []),
+                    "has_more": True,
+                    "next_page_token": "page-2",
+                }
+            if "page_token=page-2" in url:
+                return {"jobs": self.list_jobs.get("next_page", [])}
             return self.list_jobs
         if "/jobs/create" in url:
             return {"job_id": self.created_job_id}
@@ -64,6 +74,34 @@ class DatabricksClientTests(unittest.TestCase):
         self.assertEqual(job_id, 123)
         self.assertEqual(run_id, 999)
         self.assertEqual(terminal.result_state, "SUCCESS")
+
+    def test_get_query_params_are_urlencoded(self) -> None:
+        http = _FakeHttp()
+        client = DatabricksJobsClient(
+            http_client=http,
+            workspace_url="https://adb.example.com",
+            oauth_bearer_token="token",
+        )
+
+        client._call("GET", "/api/2.1/jobs/list", {"name": "floe sales/prod"})
+        _, url, _ = http.calls[-1]
+        self.assertIn("name=floe+sales%2Fprod", url)
+
+    def test_find_job_by_name_paginates_until_match(self) -> None:
+        http = _FakeHttp()
+        http.list_jobs = {
+            "jobs": [{"job_id": 1, "settings": {"name": "other"}}],
+            "next_page": [{"job_id": 2, "settings": {"name": "floe-sales-prod"}}],
+        }
+        client = DatabricksJobsClient(
+            http_client=http,
+            workspace_url="https://adb.example.com",
+            oauth_bearer_token="token",
+        )
+        found = client._find_job_by_name("floe-sales-prod")
+        self.assertIsNotNone(found)
+        assert found is not None
+        self.assertEqual(found["job_id"], 2)
 
 
 if __name__ == "__main__":

--- a/orchestrators/airflow-floe/tests/test_databricks_client.py
+++ b/orchestrators/airflow-floe/tests/test_databricks_client.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+import unittest
+
+from airflow_floe.databricks_client import DatabricksJobSpec, DatabricksJobsClient
+
+
+class _FakeHttp:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, str, dict | None]] = []
+        self.list_jobs: dict = {"jobs": []}
+        self.created_job_id = 123
+        self.run_id = 999
+        self.run_state = {
+            "state": {
+                "life_cycle_state": "TERMINATED",
+                "result_state": "SUCCESS",
+                "state_message": "ok",
+            },
+            "run_page_url": "https://example/run/999",
+        }
+
+    def request(self, method: str, url: str, *, headers=None, json_body=None, timeout_seconds=None):
+        del headers, timeout_seconds
+        self.calls.append((method, url, json_body))
+        if "/jobs/list" in url:
+            return self.list_jobs
+        if "/jobs/create" in url:
+            return {"job_id": self.created_job_id}
+        if "/jobs/reset" in url:
+            return {}
+        if "/jobs/run-now" in url:
+            return {"run_id": self.run_id}
+        if "/jobs/runs/get" in url:
+            return self.run_state
+        raise AssertionError(f"unexpected call: {method} {url}")
+
+
+class DatabricksClientTests(unittest.TestCase):
+    def test_ensure_run_and_poll_success(self) -> None:
+        http = _FakeHttp()
+        client = DatabricksJobsClient(
+            http_client=http,
+            workspace_url="https://adb.example.com",
+            oauth_bearer_token="token",
+        )
+        spec = DatabricksJobSpec(
+            workspace_url="https://adb.example.com",
+            existing_cluster_id="1111-222222-abc123",
+            config_uri="dbfs:/floe/configs/prod.yml",
+            job_name="floe-sales-prod",
+            command=["floe"],
+            args=["run", "-c", "dbfs:/floe/configs/prod.yml"],
+        )
+
+        job_id = client.ensure_domain_job(spec)
+        run_id = client.run_now(job_id=job_id, env_parameters={"FLOE_ENV": "prod"})
+        terminal = client.poll_run_to_terminal(run_id=run_id, poll_interval_seconds=1, timeout_seconds=5)
+
+        self.assertEqual(job_id, 123)
+        self.assertEqual(run_id, 999)
+        self.assertEqual(terminal.result_state, "SUCCESS")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/orchestrators/airflow-floe/tests/test_databricks_runner.py
+++ b/orchestrators/airflow-floe/tests/test_databricks_runner.py
@@ -3,6 +3,10 @@ from __future__ import annotations
 import os
 import unittest
 from unittest.mock import patch
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
 
 from airflow_floe.databricks_client import DatabricksRunResult
 from airflow_floe.databricks_runner import run_databricks_job

--- a/orchestrators/airflow-floe/tests/test_databricks_runner.py
+++ b/orchestrators/airflow-floe/tests/test_databricks_runner.py
@@ -1,0 +1,144 @@
+from __future__ import annotations
+
+import os
+import unittest
+from unittest.mock import patch
+
+from airflow_floe.databricks_client import DatabricksRunResult
+from airflow_floe.databricks_runner import run_databricks_job
+from airflow_floe.manifest import ManifestRunnerDefinition
+
+
+class DatabricksRunnerTests(unittest.TestCase):
+    def _runner(self, **overrides: object) -> ManifestRunnerDefinition:
+        base: dict[str, object] = {
+            "runner_type": "databricks_job",
+            "image": None,
+            "namespace": None,
+            "service_account": None,
+            "resources": None,
+            "env": None,
+            "command": None,
+            "args": None,
+            "timeout_seconds": 30,
+            "ttl_seconds_after_finished": None,
+            "poll_interval_seconds": 1,
+            "secrets": None,
+            "workspace_url": "https://adb.example.com",
+            "existing_cluster_id": "1111-222222-abc123",
+            "config_uri": "dbfs:/floe/config.yml",
+            "job_name": "floe-sales-prod",
+            "auth": None,
+            "env_parameters": {"FLOE_ENV": "prod"},
+        }
+        base.update(overrides)
+        return ManifestRunnerDefinition(**base)
+
+    @patch.dict(os.environ, {"FLOE_DATABRICKS_OAUTH_TOKEN": "token"}, clear=False)
+    def test_success_returns_normalized_payload(self) -> None:
+        runner = self._runner()
+
+        with patch("airflow_floe.databricks_runner.DatabricksJobsClient") as client_cls:
+            client = client_cls.return_value
+            client.ensure_domain_job.return_value = 123
+            client.run_now.return_value = 456
+            client.poll_run_to_terminal.return_value = DatabricksRunResult(
+                run_id=456,
+                state="TERMINATED",
+                result_state="SUCCESS",
+                state_message="ok",
+                run_page_url="https://adb.example.com/jobs/456",
+            )
+
+            payload = run_databricks_job(
+                cmd_args=["floe", "run", "-c", "dbfs:/floe/config.yml"],
+                runner=runner,
+                entities=["orders"],
+            )
+
+        self.assertEqual(payload["schema"], "floe.airflow.run.v1")
+        self.assertEqual(payload["status"], "success")
+        self.assertEqual(payload["backend_type"], "databricks")
+        self.assertEqual(payload["backend_run_id"], "456")
+        self.assertEqual(payload["backend_status"], "SUCCESS")
+        self.assertEqual(payload["entity"], "orders")
+        self.assertNotIn("failure_reason", payload)
+        self.assertEqual(payload["backend_metadata"]["job_id"], 123)
+        self.assertEqual(payload["backend_metadata"]["run_page_url"], "https://adb.example.com/jobs/456")
+
+    @patch.dict(os.environ, {"FLOE_DATABRICKS_OAUTH_TOKEN": "token"}, clear=False)
+    def test_failure_maps_to_failed_with_failure_reason(self) -> None:
+        with patch("airflow_floe.databricks_runner.DatabricksJobsClient") as client_cls:
+            client = client_cls.return_value
+            client.ensure_domain_job.return_value = 99
+            client.run_now.return_value = 77
+            client.poll_run_to_terminal.return_value = DatabricksRunResult(
+                run_id=77,
+                state="TERMINATED",
+                result_state="FAILED",
+                state_message="task crashed",
+                run_page_url="https://adb.example.com/jobs/77",
+            )
+
+            payload = run_databricks_job(
+                cmd_args=["floe", "run", "-c", "dbfs:/floe/config.yml"],
+                runner=self._runner(),
+                entities=None,
+            )
+
+        self.assertEqual(payload["status"], "failed")
+        self.assertEqual(payload["exit_code"], 1)
+        self.assertEqual(payload["failure_reason"], "task crashed")
+
+    @patch.dict(os.environ, {"FLOE_DATABRICKS_OAUTH_TOKEN": "token"}, clear=False)
+    def test_timeout_maps_to_timeout(self) -> None:
+        with patch("airflow_floe.databricks_runner.DatabricksJobsClient") as client_cls:
+            client = client_cls.return_value
+            client.ensure_domain_job.return_value = 99
+            client.run_now.return_value = 77
+            client.poll_run_to_terminal.return_value = DatabricksRunResult(
+                run_id=77,
+                state="TERMINATED",
+                result_state="TIMEDOUT",
+                state_message="run timed out",
+                run_page_url="https://adb.example.com/jobs/77",
+            )
+
+            payload = run_databricks_job(
+                cmd_args=["floe", "run", "-c", "dbfs:/floe/config.yml"],
+                runner=self._runner(),
+                entities=["orders", "customers"],
+            )
+
+        self.assertEqual(payload["status"], "timeout")
+        self.assertEqual(payload["backend_type"], "databricks")
+        self.assertEqual(payload["failure_reason"], "run timed out")
+        self.assertNotIn("entity", payload)
+
+    @patch.dict(os.environ, {"FLOE_DATABRICKS_OAUTH_TOKEN": "token"}, clear=False)
+    def test_canceled_maps_to_canceled(self) -> None:
+        with patch("airflow_floe.databricks_runner.DatabricksJobsClient") as client_cls:
+            client = client_cls.return_value
+            client.ensure_domain_job.return_value = 99
+            client.run_now.return_value = 77
+            client.poll_run_to_terminal.return_value = DatabricksRunResult(
+                run_id=77,
+                state="TERMINATED",
+                result_state="CANCELED",
+                state_message="terminated by user",
+                run_page_url="https://adb.example.com/jobs/77",
+            )
+
+            payload = run_databricks_job(
+                cmd_args=["floe", "run", "-c", "dbfs:/floe/config.yml"],
+                runner=self._runner(),
+                entities=None,
+            )
+
+        self.assertEqual(payload["status"], "canceled")
+        self.assertEqual(payload["backend_status"], "CANCELED")
+        self.assertEqual(payload["failure_reason"], "terminated by user")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/orchestrators/airflow-floe/tests/test_databricks_runner.py
+++ b/orchestrators/airflow-floe/tests/test_databricks_runner.py
@@ -31,6 +31,7 @@ class DatabricksRunnerTests(unittest.TestCase):
             "workspace_url": "https://adb.example.com",
             "existing_cluster_id": "1111-222222-abc123",
             "config_uri": "dbfs:/floe/config.yml",
+            "python_file_uri": "dbfs:/floe/bin/floe_entry.py",
             "job_name": "floe-sales-prod",
             "auth": {"service_principal_oauth_ref": "env://DATABRICKS_TOKEN"},
             "env_parameters": {"FLOE_ENV": "prod"},
@@ -38,7 +39,7 @@ class DatabricksRunnerTests(unittest.TestCase):
         base.update(overrides)
         return ManifestRunnerDefinition(**base)
 
-    @patch.dict(os.environ, {"FLOE_DATABRICKS_OAUTH_TOKEN": "token"}, clear=False)
+    @patch.dict(os.environ, {"DATABRICKS_TOKEN": "token"}, clear=False)
     def test_success_returns_normalized_payload(self) -> None:
         runner = self._runner()
 
@@ -63,14 +64,14 @@ class DatabricksRunnerTests(unittest.TestCase):
         self.assertEqual(payload["schema"], "floe.airflow.run.v1")
         self.assertEqual(payload["status"], "success")
         self.assertEqual(payload["backend_type"], "databricks")
-        self.assertEqual(payload["backend_run_id"], "456")
+        self.assertEqual(payload["backend_run_id"], 456)
         self.assertEqual(payload["backend_status"], "SUCCESS")
         self.assertEqual(payload["entity"], "orders")
         self.assertNotIn("failure_reason", payload)
         self.assertEqual(payload["backend_metadata"]["job_id"], 123)
         self.assertEqual(payload["backend_metadata"]["run_page_url"], "https://adb.example.com/jobs/456")
 
-    @patch.dict(os.environ, {"FLOE_DATABRICKS_OAUTH_TOKEN": "token"}, clear=False)
+    @patch.dict(os.environ, {"DATABRICKS_TOKEN": "token"}, clear=False)
     def test_failure_maps_to_failed_with_failure_reason(self) -> None:
         with patch("airflow_floe.databricks_runner.DatabricksJobsClient") as client_cls:
             client = client_cls.return_value
@@ -94,7 +95,7 @@ class DatabricksRunnerTests(unittest.TestCase):
         self.assertEqual(payload["exit_code"], 1)
         self.assertEqual(payload["failure_reason"], "task crashed")
 
-    @patch.dict(os.environ, {"FLOE_DATABRICKS_OAUTH_TOKEN": "token"}, clear=False)
+    @patch.dict(os.environ, {"DATABRICKS_TOKEN": "token"}, clear=False)
     def test_timeout_maps_to_timeout(self) -> None:
         with patch("airflow_floe.databricks_runner.DatabricksJobsClient") as client_cls:
             client = client_cls.return_value
@@ -119,7 +120,7 @@ class DatabricksRunnerTests(unittest.TestCase):
         self.assertEqual(payload["failure_reason"], "run timed out")
         self.assertNotIn("entity", payload)
 
-    @patch.dict(os.environ, {"FLOE_DATABRICKS_OAUTH_TOKEN": "token"}, clear=False)
+    @patch.dict(os.environ, {"DATABRICKS_TOKEN": "token"}, clear=False)
     def test_canceled_maps_to_canceled(self) -> None:
         with patch("airflow_floe.databricks_runner.DatabricksJobsClient") as client_cls:
             client = client_cls.return_value
@@ -205,7 +206,7 @@ class DatabricksRunnerTests(unittest.TestCase):
                 entities=["sales.orders", "finance.invoices"],
             )
 
-    @patch.dict(os.environ, {"FLOE_DATABRICKS_OAUTH_TOKEN": "token"}, clear=False)
+    @patch.dict(os.environ, {"DATABRICKS_TOKEN": "token"}, clear=False)
     def test_timeout_error_returns_structured_payload(self) -> None:
         with patch("airflow_floe.databricks_runner.DatabricksJobsClient") as client_cls:
             client = client_cls.return_value
@@ -223,7 +224,7 @@ class DatabricksRunnerTests(unittest.TestCase):
         self.assertEqual(payload["failure_reason"], "run timed out")
         self.assertEqual(payload["backend_metadata"]["error_type"], "timeout")
 
-    @patch.dict(os.environ, {"FLOE_DATABRICKS_OAUTH_TOKEN": "token"}, clear=False)
+    @patch.dict(os.environ, {"DATABRICKS_TOKEN": "token"}, clear=False)
     def test_infra_error_returns_structured_payload(self) -> None:
         with patch("airflow_floe.databricks_runner.DatabricksJobsClient") as client_cls:
             client = client_cls.return_value
@@ -261,6 +262,56 @@ class DatabricksRunnerTests(unittest.TestCase):
 
             kwargs = client_cls.call_args.kwargs
             self.assertEqual(kwargs["oauth_bearer_token"], "token")
+
+    def test_auth_ref_takes_precedence_over_fallback(self) -> None:
+        env = {
+            "DATABRICKS_TOKEN": "from-auth-ref",
+            "FLOE_DATABRICKS_OAUTH_TOKEN": "from-fallback",
+        }
+        with patch.dict(os.environ, env, clear=True):
+            with patch("airflow_floe.databricks_runner.DatabricksJobsClient") as client_cls:
+                client = client_cls.return_value
+                client.ensure_domain_job.return_value = 1
+                client.run_now.return_value = 2
+                client.poll_run_to_terminal.return_value = DatabricksRunResult(
+                    run_id=2, state="TERMINATED", result_state="SUCCESS",
+                    state_message="ok", run_page_url=None,
+                )
+                run_databricks_job(
+                    cmd_args=["floe", "run"], runner=self._runner(), entities=["orders"],
+                )
+            self.assertEqual(client_cls.call_args.kwargs["oauth_bearer_token"], "from-auth-ref")
+
+    def test_auth_ref_missing_env_raises_loudly(self) -> None:
+        with patch.dict(os.environ, {"FLOE_DATABRICKS_OAUTH_TOKEN": "fallback"}, clear=True):
+            with self.assertRaisesRegex(ValueError, "DATABRICKS_TOKEN"):
+                run_databricks_job(
+                    cmd_args=["floe", "run"], runner=self._runner(), entities=["orders"],
+                )
+
+    def test_non_env_auth_scheme_is_rejected(self) -> None:
+        runner = self._runner(auth={"service_principal_oauth_ref": "secret://kv/dbx"})
+        with patch.dict(os.environ, {"FLOE_DATABRICKS_OAUTH_TOKEN": "fallback"}, clear=True):
+            with self.assertRaisesRegex(ValueError, "env://"):
+                run_databricks_job(
+                    cmd_args=["floe", "run"], runner=runner, entities=["orders"],
+                )
+
+    def test_fallback_used_when_no_auth_ref(self) -> None:
+        runner = self._runner(auth=None)
+        with patch.dict(os.environ, {"FLOE_DATABRICKS_OAUTH_TOKEN": "fallback"}, clear=True):
+            with patch("airflow_floe.databricks_runner.DatabricksJobsClient") as client_cls:
+                client = client_cls.return_value
+                client.ensure_domain_job.return_value = 1
+                client.run_now.return_value = 2
+                client.poll_run_to_terminal.return_value = DatabricksRunResult(
+                    run_id=2, state="TERMINATED", result_state="SUCCESS",
+                    state_message="ok", run_page_url=None,
+                )
+                run_databricks_job(
+                    cmd_args=["floe", "run"], runner=runner, entities=["orders"],
+                )
+            self.assertEqual(client_cls.call_args.kwargs["oauth_bearer_token"], "fallback")
 
 
 if __name__ == "__main__":

--- a/orchestrators/airflow-floe/tests/test_databricks_runner.py
+++ b/orchestrators/airflow-floe/tests/test_databricks_runner.py
@@ -32,7 +32,7 @@ class DatabricksRunnerTests(unittest.TestCase):
             "existing_cluster_id": "1111-222222-abc123",
             "config_uri": "dbfs:/floe/config.yml",
             "job_name": "floe-sales-prod",
-            "auth": None,
+            "auth": {"service_principal_oauth_ref": "env://DATABRICKS_TOKEN"},
             "env_parameters": {"FLOE_ENV": "prod"},
         }
         base.update(overrides)
@@ -142,6 +142,125 @@ class DatabricksRunnerTests(unittest.TestCase):
         self.assertEqual(payload["status"], "canceled")
         self.assertEqual(payload["backend_status"], "CANCELED")
         self.assertEqual(payload["failure_reason"], "terminated by user")
+
+    @patch.dict(os.environ, {"DATABRICKS_TOKEN": "token"}, clear=False)
+    def test_job_name_placeholders_are_rendered_before_ensure(self) -> None:
+        with patch("airflow_floe.databricks_runner.DatabricksJobsClient") as client_cls:
+            client = client_cls.return_value
+            client.ensure_domain_job.return_value = 99
+            client.run_now.return_value = 77
+            client.poll_run_to_terminal.return_value = DatabricksRunResult(
+                run_id=77,
+                state="TERMINATED",
+                result_state="SUCCESS",
+                state_message="ok",
+                run_page_url="https://adb.example.com/jobs/77",
+            )
+
+            run_databricks_job(
+                cmd_args=["floe", "run", "-c", "dbfs:/floe/config.yml"],
+                runner=self._runner(job_name="floe-{domain}-{env}"),
+                entities=["sales.orders"],
+            )
+
+            spec = client.ensure_domain_job.call_args.args[0]
+            self.assertEqual(spec.job_name, "floe-sales-prod")
+
+    @patch.dict(os.environ, {"DATABRICKS_TOKEN": "token"}, clear=False)
+    def test_job_name_separates_domains(self) -> None:
+        with patch("airflow_floe.databricks_runner.DatabricksJobsClient") as client_cls:
+            client = client_cls.return_value
+            client.ensure_domain_job.return_value = 99
+            client.run_now.return_value = 77
+            client.poll_run_to_terminal.return_value = DatabricksRunResult(
+                run_id=77,
+                state="TERMINATED",
+                result_state="SUCCESS",
+                state_message="ok",
+                run_page_url="https://adb.example.com/jobs/77",
+            )
+
+            run_databricks_job(
+                cmd_args=["floe", "run", "-c", "dbfs:/floe/config.yml"],
+                runner=self._runner(job_name="floe-{domain}-{env}"),
+                entities=["sales.orders"],
+            )
+            run_databricks_job(
+                cmd_args=["floe", "run", "-c", "dbfs:/floe/config.yml"],
+                runner=self._runner(job_name="floe-{domain}-{env}"),
+                entities=["finance.invoices"],
+            )
+
+            first = client.ensure_domain_job.call_args_list[0].args[0]
+            second = client.ensure_domain_job.call_args_list[1].args[0]
+            self.assertEqual(first.job_name, "floe-sales-prod")
+            self.assertEqual(second.job_name, "floe-finance-prod")
+
+    @patch.dict(os.environ, {"DATABRICKS_TOKEN": "token"}, clear=False)
+    def test_mixed_domains_in_single_run_are_rejected(self) -> None:
+        with self.assertRaisesRegex(ValueError, "one domain"):
+            run_databricks_job(
+                cmd_args=["floe", "run", "-c", "dbfs:/floe/config.yml"],
+                runner=self._runner(job_name="floe-{domain}-{env}"),
+                entities=["sales.orders", "finance.invoices"],
+            )
+
+    @patch.dict(os.environ, {"FLOE_DATABRICKS_OAUTH_TOKEN": "token"}, clear=False)
+    def test_timeout_error_returns_structured_payload(self) -> None:
+        with patch("airflow_floe.databricks_runner.DatabricksJobsClient") as client_cls:
+            client = client_cls.return_value
+            client.ensure_domain_job.return_value = 99
+            client.run_now.return_value = 77
+            client.poll_run_to_terminal.side_effect = TimeoutError("run timed out")
+
+            payload = run_databricks_job(
+                cmd_args=["floe", "run", "-c", "dbfs:/floe/config.yml"],
+                runner=self._runner(),
+                entities=["orders"],
+            )
+
+        self.assertEqual(payload["status"], "timeout")
+        self.assertEqual(payload["failure_reason"], "run timed out")
+        self.assertEqual(payload["backend_metadata"]["error_type"], "timeout")
+
+    @patch.dict(os.environ, {"FLOE_DATABRICKS_OAUTH_TOKEN": "token"}, clear=False)
+    def test_infra_error_returns_structured_payload(self) -> None:
+        with patch("airflow_floe.databricks_runner.DatabricksJobsClient") as client_cls:
+            client = client_cls.return_value
+            client.ensure_domain_job.side_effect = RuntimeError("jobs api unavailable")
+
+            payload = run_databricks_job(
+                cmd_args=["floe", "run", "-c", "dbfs:/floe/config.yml"],
+                runner=self._runner(),
+                entities=["orders"],
+            )
+
+        self.assertEqual(payload["status"], "failed")
+        self.assertEqual(payload["failure_reason"], "jobs api unavailable")
+        self.assertEqual(payload["backend_metadata"]["error_type"], "RuntimeError")
+
+    def test_auth_ref_env_scheme_is_used_when_fallback_missing(self) -> None:
+        with patch.dict(os.environ, {"DATABRICKS_TOKEN": "token"}, clear=True):
+            with patch("airflow_floe.databricks_runner.DatabricksJobsClient") as client_cls:
+                client = client_cls.return_value
+                client.ensure_domain_job.return_value = 99
+                client.run_now.return_value = 77
+                client.poll_run_to_terminal.return_value = DatabricksRunResult(
+                    run_id=77,
+                    state="TERMINATED",
+                    result_state="SUCCESS",
+                    state_message="ok",
+                    run_page_url="https://adb.example.com/jobs/77",
+                )
+
+                run_databricks_job(
+                    cmd_args=["floe", "run", "-c", "dbfs:/floe/config.yml"],
+                    runner=self._runner(),
+                    entities=["orders"],
+                )
+
+            kwargs = client_cls.call_args.kwargs
+            self.assertEqual(kwargs["oauth_bearer_token"], "token")
 
 
 if __name__ == "__main__":

--- a/orchestrators/airflow-floe/tests/test_hook_and_operator.py
+++ b/orchestrators/airflow-floe/tests/test_hook_and_operator.py
@@ -268,6 +268,10 @@ class HookAndOperatorTests(unittest.TestCase):
             manifest_path = self._write_manifest(base, config_path)
             manifest_context = build_dag_manifest_context(str(manifest_path))
             outlet_asset = manifest_context.assets_by_entity["orders"]
+            # Airflow SDK Asset may be unhashable in some provider/runtime combos;
+            # normalize to a stable hashable key for outlet_events mapping in this test.
+            manifest_context.assets_by_entity["orders"] = "orders-asset"
+            outlet_asset = "orders-asset"
             outlet_event = OutletEvent()
 
             summary_path = base / "report" / "run.summary.json"

--- a/orchestrators/airflow-floe/tests/test_manifest_loader.py
+++ b/orchestrators/airflow-floe/tests/test_manifest_loader.py
@@ -108,6 +108,39 @@ class ManifestLoaderTests(unittest.TestCase):
             with self.assertRaisesRegex(ValueError, "unsupported schema in manifest loader"):
                 load_manifest(target)
 
+    def test_load_manifest_accepts_databricks_runner_contract(self) -> None:
+        payload = self._manifest_payload()
+        payload["runners"] = {
+            "default": "dbx",
+            "definitions": {
+                "dbx": {
+                    "type": "databricks_job",
+                    "workspace_url": "https://adb-1234.5.azuredatabricks.net",
+                    "existing_cluster_id": "1111-222222-abc123",
+                    "config_uri": "dbfs:/floe/configs/prod.yml",
+                    "job_name": "floe-sales-prod",
+                    "command": "floe",
+                    "args": ["run", "-c", "dbfs:/floe/configs/prod.yml"],
+                    "poll_interval_seconds": 20,
+                    "timeout_seconds": 1800,
+                    "auth": {
+                        "service_principal_oauth_ref": "secret://kv/databricks/oauth"
+                    },
+                    "env_parameters": {"FLOE_ENV": "prod"},
+                }
+            },
+        }
+
+        with tempfile.TemporaryDirectory() as tmp:
+            target = Path(tmp) / "manifest.dbx.json"
+            target.write_text(json.dumps(payload), encoding="utf-8")
+
+            loaded = load_manifest(target)
+            runner = loaded.runners.definitions["dbx"]
+            self.assertEqual(runner.runner_type, "databricks_job")
+            self.assertEqual(runner.workspace_url, "https://adb-1234.5.azuredatabricks.net")
+            self.assertEqual(runner.command, ["floe"])
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/orchestrators/airflow-floe/tests/test_manifest_loader.py
+++ b/orchestrators/airflow-floe/tests/test_manifest_loader.py
@@ -118,13 +118,14 @@ class ManifestLoaderTests(unittest.TestCase):
                     "workspace_url": "https://adb-1234.5.azuredatabricks.net",
                     "existing_cluster_id": "1111-222222-abc123",
                     "config_uri": "dbfs:/floe/configs/prod.yml",
+                    "python_file_uri": "dbfs:/floe/bin/floe_entry.py",
                     "job_name": "floe-sales-prod",
                     "command": "floe",
                     "args": ["run", "-c", "dbfs:/floe/configs/prod.yml"],
                     "poll_interval_seconds": 20,
                     "timeout_seconds": 1800,
                     "auth": {
-                        "service_principal_oauth_ref": "secret://kv/databricks/oauth"
+                        "service_principal_oauth_ref": "env://DATABRICKS_TOKEN"
                     },
                     "env_parameters": {"FLOE_ENV": "prod"},
                 }

--- a/orchestrators/dagster-floe/src/floe_dagster/databricks_client.py
+++ b/orchestrators/dagster-floe/src/floe_dagster/databricks_client.py
@@ -6,11 +6,17 @@ Primary auth model: service principal OAuth bearer token supplied by caller.
 from __future__ import annotations
 
 from dataclasses import dataclass
-import hashlib
-import json
 import time
 from typing import Any, Protocol
 from urllib.parse import urlencode
+
+
+# Bumped whenever floe materially changes the job-settings shape it produces.
+# Stored on the Databricks job as a tag so we can detect drift without comparing
+# server-normalized payloads (which trigger spurious resets every run).
+FLOE_SETTINGS_VERSION = "1"
+
+_FIND_JOB_MAX_PAGES = 200
 
 
 class HttpClient(Protocol):
@@ -30,13 +36,11 @@ class HttpClient(Protocol):
 class DatabricksJobSpec:
     workspace_url: str
     existing_cluster_id: str
-    config_uri: str
+    python_file_uri: str
     job_name: str
-    command: list[str]
-    args: list[str]
+    parameters: list[str]
     poll_interval_seconds: int = 10
     timeout_seconds: int = 3600
-    env_parameters: dict[str, str] | None = None
 
 
 @dataclass(frozen=True)
@@ -65,31 +69,37 @@ class DatabricksJobsClient:
 
     def ensure_domain_job(self, spec: DatabricksJobSpec) -> int:
         expected = self._build_job_settings(spec)
-        expected_hash = _settings_hash(expected)
+        expected_marker = expected["tags"]["floe_settings_version"]
 
         existing = self._find_job_by_name(spec.job_name)
         if existing is None:
-            created = self._call("POST", "/api/2.1/jobs/create", {"name": spec.job_name, **expected})
+            created = self._call(
+                "POST",
+                "/api/2.1/jobs/create",
+                {"name": spec.job_name, **expected},
+            )
             return int(created["job_id"])
 
         job_id = int(existing["job_id"])
-        current_settings = existing.get("settings") or {}
-        current_hash = _settings_hash(
-            {
-                "tasks": current_settings.get("tasks", []),
-                "tags": current_settings.get("tags", {}),
-                "max_concurrent_runs": current_settings.get("max_concurrent_runs", 1),
-            }
+        current_marker = (
+            (existing.get("settings") or {})
+            .get("tags", {})
+            .get("floe_settings_version")
         )
-        if current_hash != expected_hash:
-            self._call("POST", "/api/2.1/jobs/reset", {"job_id": job_id, "new_settings": {"name": spec.job_name, **expected}})
+        if current_marker != expected_marker:
+            self._call(
+                "POST",
+                "/api/2.1/jobs/reset",
+                {"job_id": job_id, "new_settings": {"name": spec.job_name, **expected}},
+            )
         return job_id
 
-    def run_now(self, *, job_id: int, env_parameters: dict[str, str] | None = None) -> int:
-        payload: dict[str, Any] = {"job_id": job_id}
-        if env_parameters:
-            payload["job_parameters"] = env_parameters
-        response = self._call("POST", "/api/2.1/jobs/run-now", payload)
+    def run_now(self, *, job_id: int) -> int:
+        # NOTE: Per-run env vars are intentionally not sent here. Databricks
+        # `job_parameters` are not surfaced as OS env or argv to a
+        # `spark_python_task`. Per-run inputs (entity, run id, etc.) must be
+        # encoded into `spec.parameters` (task-level argv).
+        response = self._call("POST", "/api/2.1/jobs/run-now", {"job_id": job_id})
         return int(response["run_id"])
 
     def poll_run_to_terminal(
@@ -122,7 +132,7 @@ class DatabricksJobsClient:
         limit = 25
         offset = 0
         page_token: str | None = None
-        while True:
+        for _ in range(_FIND_JOB_MAX_PAGES):
             params: dict[str, Any] = {"name": job_name, "limit": limit}
             if page_token:
                 params["page_token"] = page_token
@@ -144,11 +154,15 @@ class DatabricksJobsClient:
                 offset += limit
                 continue
             return None
+        raise RuntimeError(
+            f"databricks jobs/list pagination exceeded {_FIND_JOB_MAX_PAGES} pages "
+            f"while searching for job_name={job_name!r}"
+        )
 
     def _build_job_settings(self, spec: DatabricksJobSpec) -> dict[str, Any]:
         spark_python_task = {
-            "python_file": spec.config_uri,
-            "parameters": [*spec.command, *spec.args],
+            "python_file": spec.python_file_uri,
+            "parameters": list(spec.parameters),
         }
         task = {
             "task_key": "floe_main",
@@ -158,7 +172,11 @@ class DatabricksJobsClient:
         return {
             "max_concurrent_runs": 1,
             "tasks": [task],
-            "tags": {"managed_by": "floe", "runner_type": "databricks_job"},
+            "tags": {
+                "managed_by": "floe",
+                "runner_type": "databricks_job",
+                "floe_settings_version": FLOE_SETTINGS_VERSION,
+            },
         }
 
     def _call(self, method: str, path: str, payload: dict[str, Any]) -> dict[str, Any]:
@@ -168,8 +186,3 @@ class DatabricksJobsClient:
             url = f"{url}?{query}" if query else url
             return self._http.request(method, url, headers=self._headers)
         return self._http.request(method, url, headers=self._headers, json_body=payload)
-
-
-def _settings_hash(settings: dict[str, Any]) -> str:
-    encoded = json.dumps(settings, sort_keys=True, separators=(",", ":")).encode("utf-8")
-    return hashlib.sha256(encoded).hexdigest()

--- a/orchestrators/dagster-floe/src/floe_dagster/databricks_client.py
+++ b/orchestrators/dagster-floe/src/floe_dagster/databricks_client.py
@@ -10,6 +10,7 @@ import hashlib
 import json
 import time
 from typing import Any, Protocol
+from urllib.parse import urlencode
 
 
 class HttpClient(Protocol):
@@ -118,12 +119,31 @@ class DatabricksJobsClient:
             time.sleep(max(1, poll_interval_seconds))
 
     def _find_job_by_name(self, job_name: str) -> dict[str, Any] | None:
-        response = self._call("GET", "/api/2.1/jobs/list", {"name": job_name, "limit": 25})
-        for item in response.get("jobs", []):
-            settings = item.get("settings") or {}
-            if settings.get("name") == job_name:
-                return item
-        return None
+        limit = 25
+        offset = 0
+        page_token: str | None = None
+        while True:
+            params: dict[str, Any] = {"name": job_name, "limit": limit}
+            if page_token:
+                params["page_token"] = page_token
+            else:
+                params["offset"] = offset
+
+            response = self._call("GET", "/api/2.1/jobs/list", params)
+            for item in response.get("jobs", []):
+                settings = item.get("settings") or {}
+                if settings.get("name") == job_name:
+                    return item
+
+            next_token = response.get("next_page_token")
+            has_more = bool(response.get("has_more"))
+            if isinstance(next_token, str) and next_token:
+                page_token = next_token
+                continue
+            if has_more:
+                offset += limit
+                continue
+            return None
 
     def _build_job_settings(self, spec: DatabricksJobSpec) -> dict[str, Any]:
         spark_python_task = {
@@ -144,7 +164,7 @@ class DatabricksJobsClient:
     def _call(self, method: str, path: str, payload: dict[str, Any]) -> dict[str, Any]:
         url = f"{self._workspace_url}{path}"
         if method == "GET":
-            query = "&".join(f"{k}={v}" for k, v in payload.items())
+            query = urlencode(payload, doseq=True)
             url = f"{url}?{query}" if query else url
             return self._http.request(method, url, headers=self._headers)
         return self._http.request(method, url, headers=self._headers, json_body=payload)

--- a/orchestrators/dagster-floe/src/floe_dagster/databricks_client.py
+++ b/orchestrators/dagster-floe/src/floe_dagster/databricks_client.py
@@ -1,0 +1,155 @@
+"""Databricks Jobs API client abstraction for connector runtimes.
+
+Primary auth model: service principal OAuth bearer token supplied by caller.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import hashlib
+import json
+import time
+from typing import Any, Protocol
+
+
+class HttpClient(Protocol):
+    def request(
+        self,
+        method: str,
+        url: str,
+        *,
+        headers: dict[str, str] | None = None,
+        json_body: dict[str, Any] | None = None,
+        timeout_seconds: int | None = None,
+    ) -> dict[str, Any]:
+        ...
+
+
+@dataclass(frozen=True)
+class DatabricksJobSpec:
+    workspace_url: str
+    existing_cluster_id: str
+    config_uri: str
+    job_name: str
+    command: list[str]
+    args: list[str]
+    poll_interval_seconds: int = 10
+    timeout_seconds: int = 3600
+    env_parameters: dict[str, str] | None = None
+
+
+@dataclass(frozen=True)
+class DatabricksRunResult:
+    run_id: int
+    state: str
+    result_state: str | None
+    state_message: str | None
+    run_page_url: str | None
+
+
+class DatabricksJobsClient:
+    def __init__(
+        self,
+        *,
+        http_client: HttpClient,
+        workspace_url: str,
+        oauth_bearer_token: str,
+    ) -> None:
+        self._http = http_client
+        self._workspace_url = workspace_url.rstrip("/")
+        self._headers = {
+            "Authorization": f"Bearer {oauth_bearer_token}",
+            "Content-Type": "application/json",
+        }
+
+    def ensure_domain_job(self, spec: DatabricksJobSpec) -> int:
+        expected = self._build_job_settings(spec)
+        expected_hash = _settings_hash(expected)
+
+        existing = self._find_job_by_name(spec.job_name)
+        if existing is None:
+            created = self._call("POST", "/api/2.1/jobs/create", {"name": spec.job_name, **expected})
+            return int(created["job_id"])
+
+        job_id = int(existing["job_id"])
+        current_settings = existing.get("settings") or {}
+        current_hash = _settings_hash(
+            {
+                "tasks": current_settings.get("tasks", []),
+                "tags": current_settings.get("tags", {}),
+                "max_concurrent_runs": current_settings.get("max_concurrent_runs", 1),
+            }
+        )
+        if current_hash != expected_hash:
+            self._call("POST", "/api/2.1/jobs/reset", {"job_id": job_id, "new_settings": {"name": spec.job_name, **expected}})
+        return job_id
+
+    def run_now(self, *, job_id: int, env_parameters: dict[str, str] | None = None) -> int:
+        payload: dict[str, Any] = {"job_id": job_id}
+        if env_parameters:
+            payload["job_parameters"] = env_parameters
+        response = self._call("POST", "/api/2.1/jobs/run-now", payload)
+        return int(response["run_id"])
+
+    def poll_run_to_terminal(
+        self,
+        *,
+        run_id: int,
+        poll_interval_seconds: int,
+        timeout_seconds: int,
+    ) -> DatabricksRunResult:
+        deadline = time.monotonic() + timeout_seconds
+        while True:
+            run = self._call("GET", "/api/2.1/jobs/runs/get", {"run_id": run_id})
+            state = run.get("state") or {}
+            life_cycle_state = str(state.get("life_cycle_state") or "")
+            result_state = state.get("result_state")
+            state_message = state.get("state_message")
+            if life_cycle_state in {"TERMINATED", "INTERNAL_ERROR", "SKIPPED"}:
+                return DatabricksRunResult(
+                    run_id=run_id,
+                    state=life_cycle_state,
+                    result_state=result_state,
+                    state_message=state_message,
+                    run_page_url=run.get("run_page_url"),
+                )
+            if time.monotonic() >= deadline:
+                raise TimeoutError(f"databricks run {run_id} did not reach terminal state within {timeout_seconds}s")
+            time.sleep(max(1, poll_interval_seconds))
+
+    def _find_job_by_name(self, job_name: str) -> dict[str, Any] | None:
+        response = self._call("GET", "/api/2.1/jobs/list", {"name": job_name, "limit": 25})
+        for item in response.get("jobs", []):
+            settings = item.get("settings") or {}
+            if settings.get("name") == job_name:
+                return item
+        return None
+
+    def _build_job_settings(self, spec: DatabricksJobSpec) -> dict[str, Any]:
+        spark_python_task = {
+            "python_file": spec.config_uri,
+            "parameters": [*spec.command, *spec.args],
+        }
+        task = {
+            "task_key": "floe_main",
+            "existing_cluster_id": spec.existing_cluster_id,
+            "spark_python_task": spark_python_task,
+        }
+        return {
+            "max_concurrent_runs": 1,
+            "tasks": [task],
+            "tags": {"managed_by": "floe", "runner_type": "databricks_job"},
+        }
+
+    def _call(self, method: str, path: str, payload: dict[str, Any]) -> dict[str, Any]:
+        url = f"{self._workspace_url}{path}"
+        if method == "GET":
+            query = "&".join(f"{k}={v}" for k, v in payload.items())
+            url = f"{url}?{query}" if query else url
+            return self._http.request(method, url, headers=self._headers)
+        return self._http.request(method, url, headers=self._headers, json_body=payload)
+
+
+def _settings_hash(settings: dict[str, Any]) -> str:
+    encoded = json.dumps(settings, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()

--- a/orchestrators/dagster-floe/src/floe_dagster/databricks_runner.py
+++ b/orchestrators/dagster-floe/src/floe_dagster/databricks_runner.py
@@ -25,9 +25,11 @@ def run_databricks_job(
             "databricks_job runner requires workspace_url, existing_cluster_id, and config_uri"
         )
 
-    oauth_token = os.environ.get("FLOE_DATABRICKS_OAUTH_TOKEN")
-    if not oauth_token:
-        raise ValueError("FLOE_DATABRICKS_OAUTH_TOKEN is required for databricks_job runner")
+    env_parameters = {**(runner.env_parameters or {}), "FLOE_ENTITY": entity}
+    auth_ref = _extract_oauth_ref(runner.auth)
+    oauth_token = _resolve_oauth_token(auth_ref)
+    domain = _resolve_domain(entity)
+    env_name = env_parameters.get("FLOE_ENV") or os.environ.get("FLOE_ENV") or "default"
 
     dbx_client = client or DatabricksJobsClient(
         http_client=_RequestsHttpClient(),
@@ -38,12 +40,12 @@ def run_databricks_job(
         workspace_url=workspace_url,
         existing_cluster_id=existing_cluster_id,
         config_uri=config_uri,
-        job_name=runner.job_name or "floe-{domain}-{env}",
+        job_name=_render_job_name(runner.job_name or "floe-{domain}-{env}", domain=domain, env=env_name),
         command=cmd_args[:1],
         args=cmd_args[1:],
         poll_interval_seconds=runner.poll_interval_seconds or 10,
         timeout_seconds=runner.timeout_seconds or 3600,
-        env_parameters={**(runner.env_parameters or {}), "FLOE_ENTITY": entity},
+        env_parameters=env_parameters,
     )
 
     job_id: int | None = None
@@ -123,6 +125,41 @@ def _map_status(terminal: DatabricksRunResult) -> str:
         return STATUS_FAILED
 
     return STATUS_FAILED
+
+
+def _resolve_domain(entity: str) -> str:
+    if not entity or "." not in entity:
+        return "default"
+    return entity.split(".", 1)[0]
+
+
+def _render_job_name(template: str, *, domain: str, env: str) -> str:
+    return template.replace("{domain}", domain).replace("{env}", env)
+
+
+def _extract_oauth_ref(auth: dict[str, str] | None) -> str | None:
+    return (auth or {}).get("service_principal_oauth_ref")
+
+
+def _resolve_oauth_token(auth_ref: str | None) -> str:
+    token = os.environ.get("FLOE_DATABRICKS_OAUTH_TOKEN")
+    if token:
+        return token
+    if not auth_ref:
+        raise ValueError(
+            "databricks_job runner requires auth.service_principal_oauth_ref "
+            "and FLOE_DATABRICKS_OAUTH_TOKEN fallback"
+        )
+    if auth_ref.startswith("env://"):
+        env_var = auth_ref[len("env://") :]
+        resolved = os.environ.get(env_var)
+        if resolved:
+            return resolved
+        raise ValueError(f"databricks oauth token env var '{env_var}' not found")
+    raise ValueError(
+        "databricks oauth reference is not directly resolvable by dagster-floe; "
+        "set FLOE_DATABRICKS_OAUTH_TOKEN or use auth.service_principal_oauth_ref=env://<VAR>"
+    )
 
 
 def _backend_metadata(

--- a/orchestrators/dagster-floe/src/floe_dagster/databricks_runner.py
+++ b/orchestrators/dagster-floe/src/floe_dagster/databricks_runner.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 import os
 
-from .databricks_client import DatabricksJobSpec, DatabricksJobsClient
+from .databricks_client import DatabricksJobSpec, DatabricksJobsClient, DatabricksRunResult
+from .k8s_status import STATUS_CANCELED, STATUS_FAILED, STATUS_SUCCEEDED, STATUS_TIMEOUT
 from .manifest import ManifestRunnerDefinition
 from .runner import RunResult
 
@@ -14,6 +15,7 @@ def run_databricks_job(
     *,
     entity: str,
     runner: ManifestRunnerDefinition,
+    client: DatabricksJobsClient | None = None,
 ) -> RunResult:
     workspace_url = runner.workspace_url
     existing_cluster_id = runner.existing_cluster_id
@@ -27,7 +29,7 @@ def run_databricks_job(
     if not oauth_token:
         raise ValueError("FLOE_DATABRICKS_OAUTH_TOKEN is required for databricks_job runner")
 
-    client = DatabricksJobsClient(
+    dbx_client = client or DatabricksJobsClient(
         http_client=_RequestsHttpClient(),
         workspace_url=workspace_url,
         oauth_bearer_token=oauth_token,
@@ -43,30 +45,129 @@ def run_databricks_job(
         timeout_seconds=runner.timeout_seconds or 3600,
         env_parameters={**(runner.env_parameters or {}), "FLOE_ENTITY": entity},
     )
-    job_id = client.ensure_domain_job(spec)
-    run_id = client.run_now(job_id=job_id, env_parameters=spec.env_parameters)
-    terminal = client.poll_run_to_terminal(
-        run_id=run_id,
-        poll_interval_seconds=spec.poll_interval_seconds,
-        timeout_seconds=spec.timeout_seconds,
+
+    job_id: int | None = None
+    run_id: int | None = None
+    try:
+        job_id = dbx_client.ensure_domain_job(spec)
+        run_id = dbx_client.run_now(job_id=job_id, env_parameters=spec.env_parameters)
+        terminal = dbx_client.poll_run_to_terminal(
+            run_id=run_id,
+            poll_interval_seconds=spec.poll_interval_seconds,
+            timeout_seconds=spec.timeout_seconds,
+        )
+    except TimeoutError as exc:
+        return _infra_failure_result(
+            status=STATUS_TIMEOUT,
+            failure_reason=str(exc),
+            stderr=str(exc),
+            workspace_url=workspace_url,
+            job_id=job_id,
+            run_id=run_id,
+            error_type="timeout",
+        )
+    except Exception as exc:  # noqa: BLE001
+        return _infra_failure_result(
+            status=STATUS_FAILED,
+            failure_reason=str(exc) or exc.__class__.__name__,
+            stderr=str(exc),
+            workspace_url=workspace_url,
+            job_id=job_id,
+            run_id=run_id,
+            error_type=exc.__class__.__name__,
+        )
+
+    status = _map_status(terminal)
+    backend_metadata = _backend_metadata(
+        workspace_url=workspace_url,
+        terminal=terminal,
+        job_id=job_id,
     )
 
-    if terminal.result_state not in {None, "SUCCESS"}:
+    if status != STATUS_SUCCEEDED:
         return RunResult(
             stdout="",
             stderr=terminal.state_message or "Databricks run failed",
             exit_code=1,
-            status=terminal.result_state or terminal.state,
+            status=status,
             failure_reason=terminal.state_message,
-            backend_metadata={"backend": "databricks", "run_page_url": terminal.run_page_url},
+            backend_metadata=backend_metadata,
         )
 
     return RunResult(
         stdout="",
         stderr="",
         exit_code=0,
-        status=terminal.result_state or terminal.state,
-        backend_metadata={"backend": "databricks", "run_page_url": terminal.run_page_url},
+        status=status,
+        failure_reason=None,
+        backend_metadata=backend_metadata,
+    )
+
+
+def _map_status(terminal: DatabricksRunResult) -> str:
+    result_state = (terminal.result_state or "").upper()
+    life_cycle_state = (terminal.state or "").upper()
+
+    if result_state == "SUCCESS":
+        return STATUS_SUCCEEDED
+    if result_state in {"CANCELED", "CANCELLED"}:
+        return STATUS_CANCELED
+    if result_state == "TIMEDOUT":
+        return STATUS_TIMEOUT
+    if result_state:
+        return STATUS_FAILED
+
+    if life_cycle_state in {"SKIPPED"}:
+        return STATUS_CANCELED
+    if life_cycle_state in {"INTERNAL_ERROR"}:
+        return STATUS_FAILED
+
+    return STATUS_FAILED
+
+
+def _backend_metadata(
+    *,
+    workspace_url: str,
+    terminal: DatabricksRunResult,
+    job_id: int | None,
+) -> dict[str, str | int | None]:
+    return {
+        "backend_type": "databricks",
+        "backend_run_id": terminal.run_id,
+        "workspace_url": workspace_url,
+        "job_id": job_id,
+        "run_page_url": terminal.run_page_url,
+        "life_cycle_state": terminal.state,
+        "result_state": terminal.result_state,
+        "state_message": terminal.state_message,
+    }
+
+
+def _infra_failure_result(
+    *,
+    status: str,
+    failure_reason: str,
+    stderr: str,
+    workspace_url: str,
+    job_id: int | None,
+    run_id: int | None,
+    error_type: str,
+) -> RunResult:
+    backend_metadata: dict[str, str | int | None] = {
+        "backend_type": "databricks",
+        "backend_run_id": run_id,
+        "workspace_url": workspace_url,
+        "job_id": job_id,
+        "error_type": error_type,
+        "state_message": failure_reason,
+    }
+    return RunResult(
+        stdout="",
+        stderr=stderr,
+        exit_code=1,
+        status=status,
+        failure_reason=failure_reason,
+        backend_metadata=backend_metadata,
     )
 
 

--- a/orchestrators/dagster-floe/src/floe_dagster/databricks_runner.py
+++ b/orchestrators/dagster-floe/src/floe_dagster/databricks_runner.py
@@ -1,0 +1,93 @@
+"""Databricks runner adapter for dagster-floe."""
+
+from __future__ import annotations
+
+import os
+
+from .databricks_client import DatabricksJobSpec, DatabricksJobsClient
+from .manifest import ManifestRunnerDefinition
+from .runner import RunResult
+
+
+def run_databricks_job(
+    cmd_args: list[str],
+    *,
+    entity: str,
+    runner: ManifestRunnerDefinition,
+) -> RunResult:
+    workspace_url = runner.workspace_url
+    existing_cluster_id = runner.existing_cluster_id
+    config_uri = runner.config_uri
+    if not workspace_url or not existing_cluster_id or not config_uri:
+        raise ValueError(
+            "databricks_job runner requires workspace_url, existing_cluster_id, and config_uri"
+        )
+
+    oauth_token = os.environ.get("FLOE_DATABRICKS_OAUTH_TOKEN")
+    if not oauth_token:
+        raise ValueError("FLOE_DATABRICKS_OAUTH_TOKEN is required for databricks_job runner")
+
+    client = DatabricksJobsClient(
+        http_client=_RequestsHttpClient(),
+        workspace_url=workspace_url,
+        oauth_bearer_token=oauth_token,
+    )
+    spec = DatabricksJobSpec(
+        workspace_url=workspace_url,
+        existing_cluster_id=existing_cluster_id,
+        config_uri=config_uri,
+        job_name=runner.job_name or "floe-{domain}-{env}",
+        command=cmd_args[:1],
+        args=cmd_args[1:],
+        poll_interval_seconds=runner.poll_interval_seconds or 10,
+        timeout_seconds=runner.timeout_seconds or 3600,
+        env_parameters={**(runner.env_parameters or {}), "FLOE_ENTITY": entity},
+    )
+    job_id = client.ensure_domain_job(spec)
+    run_id = client.run_now(job_id=job_id, env_parameters=spec.env_parameters)
+    terminal = client.poll_run_to_terminal(
+        run_id=run_id,
+        poll_interval_seconds=spec.poll_interval_seconds,
+        timeout_seconds=spec.timeout_seconds,
+    )
+
+    if terminal.result_state not in {None, "SUCCESS"}:
+        return RunResult(
+            stdout="",
+            stderr=terminal.state_message or "Databricks run failed",
+            exit_code=1,
+            status=terminal.result_state or terminal.state,
+            failure_reason=terminal.state_message,
+            backend_metadata={"backend": "databricks", "run_page_url": terminal.run_page_url},
+        )
+
+    return RunResult(
+        stdout="",
+        stderr="",
+        exit_code=0,
+        status=terminal.result_state or terminal.state,
+        backend_metadata={"backend": "databricks", "run_page_url": terminal.run_page_url},
+    )
+
+
+class _RequestsHttpClient:
+    def request(
+        self,
+        method: str,
+        url: str,
+        *,
+        headers: dict[str, str] | None = None,
+        json_body: dict[str, str] | None = None,
+        timeout_seconds: int | None = None,
+    ) -> dict:
+        import requests
+
+        response = requests.request(
+            method,
+            url,
+            headers=headers,
+            json=json_body,
+            timeout=timeout_seconds or 30,
+        )
+        response.raise_for_status()
+        return response.json() if response.text else {}

--- a/orchestrators/dagster-floe/src/floe_dagster/databricks_runner.py
+++ b/orchestrators/dagster-floe/src/floe_dagster/databricks_runner.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+from typing import Any
 
 from .databricks_client import DatabricksJobSpec, DatabricksJobsClient, DatabricksRunResult
 from .k8s_status import STATUS_CANCELED, STATUS_FAILED, STATUS_SUCCEEDED, STATUS_TIMEOUT
@@ -20,16 +21,22 @@ def run_databricks_job(
     workspace_url = runner.workspace_url
     existing_cluster_id = runner.existing_cluster_id
     config_uri = runner.config_uri
-    if not workspace_url or not existing_cluster_id or not config_uri:
+    python_file_uri = runner.python_file_uri
+    if (
+        not workspace_url
+        or not existing_cluster_id
+        or not config_uri
+        or not python_file_uri
+    ):
         raise ValueError(
-            "databricks_job runner requires workspace_url, existing_cluster_id, and config_uri"
+            "databricks_job runner requires workspace_url, existing_cluster_id, "
+            "config_uri and python_file_uri"
         )
 
-    env_parameters = {**(runner.env_parameters or {}), "FLOE_ENTITY": entity}
     auth_ref = _extract_oauth_ref(runner.auth)
     oauth_token = _resolve_oauth_token(auth_ref)
     domain = _resolve_domain(entity)
-    env_name = env_parameters.get("FLOE_ENV") or os.environ.get("FLOE_ENV") or "default"
+    env_name = _resolve_env_name(runner.env_parameters)
 
     dbx_client = client or DatabricksJobsClient(
         http_client=_RequestsHttpClient(),
@@ -39,20 +46,20 @@ def run_databricks_job(
     spec = DatabricksJobSpec(
         workspace_url=workspace_url,
         existing_cluster_id=existing_cluster_id,
-        config_uri=config_uri,
-        job_name=_render_job_name(runner.job_name or "floe-{domain}-{env}", domain=domain, env=env_name),
-        command=cmd_args[:1],
-        args=cmd_args[1:],
+        python_file_uri=python_file_uri,
+        job_name=_render_job_name(
+            runner.job_name or "floe-{domain}-{env}", domain=domain, env=env_name
+        ),
+        parameters=list(cmd_args),
         poll_interval_seconds=runner.poll_interval_seconds or 10,
         timeout_seconds=runner.timeout_seconds or 3600,
-        env_parameters=env_parameters,
     )
 
     job_id: int | None = None
     run_id: int | None = None
     try:
         job_id = dbx_client.ensure_domain_job(spec)
-        run_id = dbx_client.run_now(job_id=job_id, env_parameters=spec.env_parameters)
+        run_id = dbx_client.run_now(job_id=job_id)
         terminal = dbx_client.poll_run_to_terminal(
             run_id=run_id,
             poll_interval_seconds=spec.poll_interval_seconds,
@@ -119,11 +126,8 @@ def _map_status(terminal: DatabricksRunResult) -> str:
     if result_state:
         return STATUS_FAILED
 
-    if life_cycle_state in {"SKIPPED"}:
+    if life_cycle_state == "SKIPPED":
         return STATUS_CANCELED
-    if life_cycle_state in {"INTERNAL_ERROR"}:
-        return STATUS_FAILED
-
     return STATUS_FAILED
 
 
@@ -131,6 +135,12 @@ def _resolve_domain(entity: str) -> str:
     if not entity or "." not in entity:
         return "default"
     return entity.split(".", 1)[0]
+
+
+def _resolve_env_name(env_parameters: dict[str, str] | None) -> str:
+    if env_parameters and env_parameters.get("FLOE_ENV"):
+        return env_parameters["FLOE_ENV"]
+    return os.environ.get("FLOE_ENV") or "default"
 
 
 def _render_job_name(template: str, *, domain: str, env: str) -> str:
@@ -142,23 +152,30 @@ def _extract_oauth_ref(auth: dict[str, str] | None) -> str | None:
 
 
 def _resolve_oauth_token(auth_ref: str | None) -> str:
-    token = os.environ.get("FLOE_DATABRICKS_OAUTH_TOKEN")
-    if token:
-        return token
-    if not auth_ref:
+    # Prefer a declared `env://VAR` reference over the bare-fallback env so
+    # that misconfiguration (declared ref pointing at a missing var) is loud
+    # instead of silently masked by FLOE_DATABRICKS_OAUTH_TOKEN.
+    if auth_ref:
+        if auth_ref.startswith("env://"):
+            env_var = auth_ref[len("env://") :]
+            resolved = os.environ.get(env_var)
+            if resolved:
+                return resolved
+            raise ValueError(
+                f"databricks oauth token env var '{env_var}' "
+                f"(from auth.service_principal_oauth_ref) not found"
+            )
         raise ValueError(
-            "databricks_job runner requires auth.service_principal_oauth_ref "
-            "and FLOE_DATABRICKS_OAUTH_TOKEN fallback"
+            "databricks oauth reference is not directly resolvable by dagster-floe; "
+            "use auth.service_principal_oauth_ref=env://<VAR> or set "
+            "FLOE_DATABRICKS_OAUTH_TOKEN with no auth.service_principal_oauth_ref"
         )
-    if auth_ref.startswith("env://"):
-        env_var = auth_ref[len("env://") :]
-        resolved = os.environ.get(env_var)
-        if resolved:
-            return resolved
-        raise ValueError(f"databricks oauth token env var '{env_var}' not found")
+    fallback = os.environ.get("FLOE_DATABRICKS_OAUTH_TOKEN")
+    if fallback:
+        return fallback
     raise ValueError(
-        "databricks oauth reference is not directly resolvable by dagster-floe; "
-        "set FLOE_DATABRICKS_OAUTH_TOKEN or use auth.service_principal_oauth_ref=env://<VAR>"
+        "databricks_job runner requires auth.service_principal_oauth_ref "
+        "(env://<VAR>) or FLOE_DATABRICKS_OAUTH_TOKEN fallback"
     )
 
 
@@ -167,16 +184,17 @@ def _backend_metadata(
     workspace_url: str,
     terminal: DatabricksRunResult,
     job_id: int | None,
-) -> dict[str, str | int | None]:
+) -> dict[str, Any]:
     return {
         "backend_type": "databricks",
         "backend_run_id": terminal.run_id,
         "workspace_url": workspace_url,
         "job_id": job_id,
-        "run_page_url": terminal.run_page_url,
         "life_cycle_state": terminal.state,
         "result_state": terminal.result_state,
         "state_message": terminal.state_message,
+        "run_page_url": terminal.run_page_url,
+        "error_type": None,
     }
 
 
@@ -190,13 +208,16 @@ def _infra_failure_result(
     run_id: int | None,
     error_type: str,
 ) -> RunResult:
-    backend_metadata: dict[str, str | int | None] = {
+    backend_metadata: dict[str, Any] = {
         "backend_type": "databricks",
         "backend_run_id": run_id,
         "workspace_url": workspace_url,
         "job_id": job_id,
-        "error_type": error_type,
+        "life_cycle_state": None,
+        "result_state": None,
         "state_message": failure_reason,
+        "run_page_url": None,
+        "error_type": error_type,
     }
     return RunResult(
         stdout="",

--- a/orchestrators/dagster-floe/src/floe_dagster/manifest.py
+++ b/orchestrators/dagster-floe/src/floe_dagster/manifest.py
@@ -111,16 +111,24 @@ class ManifestRunnerDefinition:
     ttl_seconds_after_finished: int | None
     poll_interval_seconds: int | None
     secrets: list[dict[str, Any]] | None
+    workspace_url: str | None
+    existing_cluster_id: str | None
+    config_uri: str | None
+    job_name: str | None
+    auth: dict[str, str] | None
+    env_parameters: dict[str, str] | None
 
     @staticmethod
     def from_dict(data: dict[str, Any]) -> "ManifestRunnerDefinition":
         env = _optional_string_map(data, "env")
-        command = _optional_string_list(data, "command")
+        command = _optional_command(data, "command")
         args = _optional_string_list(data, "args")
         timeout_seconds = _optional_int(data, "timeout_seconds")
         ttl_seconds_after_finished = _optional_int(data, "ttl_seconds_after_finished")
         poll_interval_seconds = _optional_int(data, "poll_interval_seconds")
         secrets = _optional_object_list(data, "secrets")
+        auth = _optional_string_map(data, "auth")
+        env_parameters = _optional_string_map(data, "env_parameters")
         return ManifestRunnerDefinition(
             runner_type=_required_str(data, "type"),
             image=_optional_str(data, "image"),
@@ -133,6 +141,12 @@ class ManifestRunnerDefinition:
             ttl_seconds_after_finished=ttl_seconds_after_finished,
             poll_interval_seconds=poll_interval_seconds,
             secrets=secrets,
+            workspace_url=_optional_str(data, "workspace_url"),
+            existing_cluster_id=_optional_str(data, "existing_cluster_id"),
+            config_uri=_optional_str(data, "config_uri"),
+            job_name=_optional_str(data, "job_name"),
+            auth=auth,
+            env_parameters=env_parameters,
         )
 
 
@@ -344,6 +358,17 @@ def _optional_string_list(data: dict[str, Any], key: str) -> list[str] | None:
     if not isinstance(value, list) or not all(isinstance(item, str) for item in value):
         raise ValueError(f"{key} must be an array of strings when provided")
     return value
+
+
+def _optional_command(data: dict[str, Any], key: str) -> list[str] | None:
+    value = data.get(key)
+    if value is None:
+        return None
+    if isinstance(value, str):
+        return [value]
+    if isinstance(value, list) and all(isinstance(item, str) for item in value):
+        return value
+    raise ValueError(f"{key} must be string|list[str] when provided")
 
 
 def _optional_int(data: dict[str, Any], key: str) -> int | None:

--- a/orchestrators/dagster-floe/src/floe_dagster/manifest.py
+++ b/orchestrators/dagster-floe/src/floe_dagster/manifest.py
@@ -114,6 +114,7 @@ class ManifestRunnerDefinition:
     workspace_url: str | None = None
     existing_cluster_id: str | None = None
     config_uri: str | None = None
+    python_file_uri: str | None = None
     job_name: str | None = None
     auth: dict[str, str] | None = None
     env_parameters: dict[str, str] | None = None
@@ -144,6 +145,7 @@ class ManifestRunnerDefinition:
             workspace_url=_optional_str(data, "workspace_url"),
             existing_cluster_id=_optional_str(data, "existing_cluster_id"),
             config_uri=_optional_str(data, "config_uri"),
+            python_file_uri=_optional_str(data, "python_file_uri"),
             job_name=_optional_str(data, "job_name"),
             auth=auth,
             env_parameters=env_parameters,

--- a/orchestrators/dagster-floe/src/floe_dagster/manifest.py
+++ b/orchestrators/dagster-floe/src/floe_dagster/manifest.py
@@ -111,12 +111,12 @@ class ManifestRunnerDefinition:
     ttl_seconds_after_finished: int | None
     poll_interval_seconds: int | None
     secrets: list[dict[str, Any]] | None
-    workspace_url: str | None
-    existing_cluster_id: str | None
-    config_uri: str | None
-    job_name: str | None
-    auth: dict[str, str] | None
-    env_parameters: dict[str, str] | None
+    workspace_url: str | None = None
+    existing_cluster_id: str | None = None
+    config_uri: str | None = None
+    job_name: str | None = None
+    auth: dict[str, str] | None = None
+    env_parameters: dict[str, str] | None = None
 
     @staticmethod
     def from_dict(data: dict[str, Any]) -> "ManifestRunnerDefinition":

--- a/orchestrators/dagster-floe/src/floe_dagster/runner.py
+++ b/orchestrators/dagster-floe/src/floe_dagster/runner.py
@@ -58,6 +58,19 @@ class LocalRunner(Runner):
 
             return run_kubernetes_job(args, entity=entity, runner=runner_definition)
 
+        if runner_definition is not None and runner_definition.runner_type == "databricks_job":
+            if execution is None:
+                raise ValueError("execution contract is required for databricks_job runner")
+            args = [*self._floe_cmd]
+            args.extend(
+                render_execution_args(
+                    execution, config_uri=config_uri, entity_name=entity, run_id=run_id
+                )
+            )
+            from .databricks_runner import run_databricks_job
+
+            return run_databricks_job(args, entity=entity, runner=runner_definition)
+
         if runner_definition is not None and runner_definition.runner_type != "local_process":
             raise NotImplementedError(
                 "unsupported runner type for dagster-floe LocalRunner: "

--- a/orchestrators/dagster-floe/src/floe_dagster/schemas/floe.manifest.v1.json
+++ b/orchestrators/dagster-floe/src/floe_dagster/schemas/floe.manifest.v1.json
@@ -296,8 +296,7 @@
                   "null"
                 ],
                 "items": {
-                  "type": "object",
-                  "additionalProperties": true
+                  "type": "object"
                 }
               },
               "workspace_url": {
@@ -315,6 +314,13 @@
                 "minLength": 1
               },
               "config_uri": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "minLength": 1
+              },
+              "python_file_uri": {
                 "type": [
                   "string",
                   "null"
@@ -368,6 +374,7 @@
                     "workspace_url",
                     "existing_cluster_id",
                     "config_uri",
+                    "python_file_uri",
                     "auth"
                   ],
                   "properties": {
@@ -379,7 +386,8 @@
                       "properties": {
                         "service_principal_oauth_ref": {
                           "type": "string",
-                          "minLength": 1
+                          "minLength": 1,
+                          "pattern": "^env://[A-Z0-9_]+$"
                         }
                       },
                       "additionalProperties": false

--- a/orchestrators/dagster-floe/src/floe_dagster/schemas/floe.manifest.v1.json
+++ b/orchestrators/dagster-floe/src/floe_dagster/schemas/floe.manifest.v1.json
@@ -42,7 +42,10 @@
       "minLength": 1
     },
     "config_checksum": {
-      "type": ["string", "null"]
+      "type": [
+        "string",
+        "null"
+      ]
     },
     "report_base_uri": {
       "type": "string",
@@ -53,7 +56,10 @@
       "items": {
         "type": "object",
         "additionalProperties": false,
-        "required": ["name", "incoming_dir"],
+        "required": [
+          "name",
+          "incoming_dir"
+        ],
         "properties": {
           "name": {
             "type": "string",
@@ -98,7 +104,10 @@
         },
         "log_format": {
           "type": "string",
-          "enum": ["json", "text"]
+          "enum": [
+            "json",
+            "text"
+          ]
         },
         "result_contract": {
           "type": "object",
@@ -132,7 +141,10 @@
         "defaults": {
           "type": "object",
           "additionalProperties": false,
-          "required": ["env", "workdir"],
+          "required": [
+            "env",
+            "workdir"
+          ],
           "properties": {
             "env": {
               "type": "object",
@@ -141,7 +153,10 @@
               }
             },
             "workdir": {
-              "type": ["string", "null"]
+              "type": [
+                "string",
+                "null"
+              ]
             }
           }
         }
@@ -150,7 +165,10 @@
     "runners": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["default", "definitions"],
+      "required": [
+        "default",
+        "definitions"
+      ],
       "properties": {
         "default": {
           "type": "string",
@@ -162,7 +180,9 @@
           "additionalProperties": {
             "type": "object",
             "additionalProperties": false,
-            "required": ["type"],
+            "required": [
+              "type"
+            ],
             "properties": {
               "type": {
                 "type": "string",
@@ -171,65 +191,203 @@
                   "docker",
                   "kubernetes_pod",
                   "kubernetes_job",
-                  "ecs_task"
+                  "ecs_task",
+                  "databricks_job"
                 ]
               },
               "image": {
-                "type": ["string", "null"]
+                "type": [
+                  "string",
+                  "null"
+                ]
               },
               "namespace": {
-                "type": ["string", "null"]
+                "type": [
+                  "string",
+                  "null"
+                ]
               },
               "service_account": {
-                "type": ["string", "null"]
+                "type": [
+                  "string",
+                  "null"
+                ]
               },
               "resources": {
-                "type": ["object", "null"],
+                "type": [
+                  "object",
+                  "null"
+                ],
                 "additionalProperties": false,
                 "properties": {
                   "cpu": {
-                    "type": ["string", "null"]
+                    "type": [
+                      "string",
+                      "null"
+                    ]
                   },
                   "memory_mb": {
-                    "type": ["integer", "null"],
+                    "type": [
+                      "integer",
+                      "null"
+                    ],
                     "minimum": 1
                   }
                 }
               },
               "env": {
-                "type": ["object", "null"],
+                "type": [
+                  "object",
+                  "null"
+                ],
                 "additionalProperties": {
                   "type": "string"
                 }
               },
               "command": {
-                "type": ["array", "null"],
-                "items": { "type": "string" }
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
               },
               "args": {
-                "type": ["array", "null"],
-                "items": { "type": "string" }
+                "type": [
+                  "array",
+                  "null"
+                ],
+                "items": {
+                  "type": "string"
+                }
               },
               "timeout_seconds": {
-                "type": ["integer", "null"],
+                "type": [
+                  "integer",
+                  "null"
+                ],
                 "minimum": 1
               },
               "ttl_seconds_after_finished": {
-                "type": ["integer", "null"],
+                "type": [
+                  "integer",
+                  "null"
+                ],
                 "minimum": 0
               },
               "poll_interval_seconds": {
-                "type": ["integer", "null"],
+                "type": [
+                  "integer",
+                  "null"
+                ],
                 "minimum": 1
               },
               "secrets": {
-                "type": ["array", "null"],
+                "type": [
+                  "array",
+                  "null"
+                ],
                 "items": {
                   "type": "object",
                   "additionalProperties": true
                 }
+              },
+              "workspace_url": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "minLength": 1
+              },
+              "existing_cluster_id": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "minLength": 1
+              },
+              "config_uri": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "minLength": 1
+              },
+              "job_name": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "minLength": 1
+              },
+              "auth": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "additionalProperties": false,
+                "properties": {
+                  "service_principal_oauth_ref": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "minLength": 1
+                  }
+                }
+              },
+              "env_parameters": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "additionalProperties": {
+                  "type": "string"
+                }
               }
-            }
+            },
+            "allOf": [
+              {
+                "if": {
+                  "properties": {
+                    "type": {
+                      "const": "databricks_job"
+                    }
+                  }
+                },
+                "then": {
+                  "required": [
+                    "workspace_url",
+                    "existing_cluster_id",
+                    "config_uri",
+                    "auth"
+                  ],
+                  "properties": {
+                    "auth": {
+                      "type": "object",
+                      "required": [
+                        "service_principal_oauth_ref"
+                      ],
+                      "properties": {
+                        "service_principal_oauth_ref": {
+                          "type": "string",
+                          "minLength": 1
+                        }
+                      },
+                      "additionalProperties": false
+                    }
+                  }
+                }
+              }
+            ]
           }
         }
       }
@@ -254,7 +412,10 @@
             "minLength": 1
           },
           "domain": {
-            "type": ["string", "null"]
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "group_name": {
             "type": "string",
@@ -277,21 +438,36 @@
             "minLength": 1
           },
           "rejected_sink_uri": {
-            "type": ["string", "null"]
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "tags": {
-            "type": ["object", "null"],
+            "type": [
+              "object",
+              "null"
+            ],
             "additionalProperties": {
               "type": "string"
             }
           },
           "runner": {
-            "type": ["string", "null"]
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "source": {
             "type": "object",
             "additionalProperties": false,
-            "required": ["format", "storage", "uri", "path", "resolved"],
+            "required": [
+              "format",
+              "storage",
+              "uri",
+              "path",
+              "resolved"
+            ],
             "properties": {
               "format": {
                 "type": "string",
@@ -313,31 +489,47 @@
                 "type": "boolean"
               },
               "cast_mode": {
-                "type": ["string", "null"]
+                "type": [
+                  "string",
+                  "null"
+                ]
               },
               "options": {
-                "type": ["object", "null"]
+                "type": [
+                  "object",
+                  "null"
+                ]
               }
             }
           },
           "sinks": {
             "type": "object",
             "additionalProperties": false,
-            "required": ["accepted"],
+            "required": [
+              "accepted"
+            ],
             "properties": {
               "accepted": {
                 "$ref": "#/$defs/sink_target"
               },
               "rejected": {
                 "anyOf": [
-                  { "$ref": "#/$defs/sink_target" },
-                  { "type": "null" }
+                  {
+                    "$ref": "#/$defs/sink_target"
+                  },
+                  {
+                    "type": "null"
+                  }
                 ]
               },
               "archive": {
                 "anyOf": [
-                  { "$ref": "#/$defs/archive_target" },
-                  { "type": "null" }
+                  {
+                    "$ref": "#/$defs/archive_target"
+                  },
+                  {
+                    "type": "null"
+                  }
                 ]
               }
             }
@@ -350,7 +542,13 @@
     "sink_target": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["format", "storage", "uri", "path", "resolved"],
+      "required": [
+        "format",
+        "storage",
+        "uri",
+        "path",
+        "resolved"
+      ],
       "properties": {
         "format": {
           "type": "string",
@@ -376,7 +574,12 @@
     "archive_target": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["storage", "uri", "path", "resolved"],
+      "required": [
+        "storage",
+        "uri",
+        "path",
+        "resolved"
+      ],
       "properties": {
         "storage": {
           "type": "string",

--- a/orchestrators/dagster-floe/tests/test_databricks_client.py
+++ b/orchestrators/dagster-floe/tests/test_databricks_client.py
@@ -1,0 +1,52 @@
+from floe_dagster.databricks_client import DatabricksJobSpec, DatabricksJobsClient
+
+
+class FakeHttp:
+    def __init__(self) -> None:
+        self.list_jobs = {"jobs": []}
+
+    def request(self, method, url, *, headers=None, json_body=None, timeout_seconds=None):
+        del headers, timeout_seconds
+        if "/jobs/list" in url:
+            return self.list_jobs
+        if "/jobs/create" in url:
+            return {"job_id": 42}
+        if "/jobs/run-now" in url:
+            return {"run_id": 88}
+        if "/jobs/runs/get" in url:
+            return {
+                "state": {
+                    "life_cycle_state": "TERMINATED",
+                    "result_state": "SUCCESS",
+                    "state_message": "ok",
+                },
+                "run_page_url": "https://example/run/88",
+            }
+        if "/jobs/reset" in url:
+            return {}
+        raise AssertionError(f"unexpected call: {method} {url} {json_body}")
+
+
+def test_databricks_client_ensure_and_run() -> None:
+    http = FakeHttp()
+    client = DatabricksJobsClient(
+        http_client=http,
+        workspace_url="https://adb.example.com",
+        oauth_bearer_token="token",
+    )
+    spec = DatabricksJobSpec(
+        workspace_url="https://adb.example.com",
+        existing_cluster_id="1111-222222-abc123",
+        config_uri="dbfs:/floe/configs/prod.yml",
+        job_name="floe-sales-prod",
+        command=["floe"],
+        args=["run", "-c", "dbfs:/floe/configs/prod.yml"],
+    )
+
+    job_id = client.ensure_domain_job(spec)
+    run_id = client.run_now(job_id=job_id, env_parameters={"FLOE_ENV": "prod"})
+    terminal = client.poll_run_to_terminal(run_id=run_id, poll_interval_seconds=1, timeout_seconds=5)
+
+    assert job_id == 42
+    assert run_id == 88
+    assert terminal.result_state == "SUCCESS"

--- a/orchestrators/dagster-floe/tests/test_databricks_client.py
+++ b/orchestrators/dagster-floe/tests/test_databricks_client.py
@@ -49,14 +49,13 @@ def test_databricks_client_ensure_and_run() -> None:
     spec = DatabricksJobSpec(
         workspace_url="https://adb.example.com",
         existing_cluster_id="1111-222222-abc123",
-        config_uri="dbfs:/floe/configs/prod.yml",
+        python_file_uri="dbfs:/floe/bin/floe_entry.py",
         job_name="floe-sales-prod",
-        command=["floe"],
-        args=["run", "-c", "dbfs:/floe/configs/prod.yml"],
+        parameters=["run", "-c", "dbfs:/floe/configs/prod.yml"],
     )
 
     job_id = client.ensure_domain_job(spec)
-    run_id = client.run_now(job_id=job_id, env_parameters={"FLOE_ENV": "prod"})
+    run_id = client.run_now(job_id=job_id)
     terminal = client.poll_run_to_terminal(run_id=run_id, poll_interval_seconds=1, timeout_seconds=5)
 
     assert job_id == 42

--- a/orchestrators/dagster-floe/tests/test_databricks_client.py
+++ b/orchestrators/dagster-floe/tests/test_databricks_client.py
@@ -4,10 +4,22 @@ from floe_dagster.databricks_client import DatabricksJobSpec, DatabricksJobsClie
 class FakeHttp:
     def __init__(self) -> None:
         self.list_jobs = {"jobs": []}
+        self.calls: list[tuple[str, str, dict | None]] = []
+        self.list_calls = 0
 
     def request(self, method, url, *, headers=None, json_body=None, timeout_seconds=None):
         del headers, timeout_seconds
+        self.calls.append((method, url, json_body))
         if "/jobs/list" in url:
+            self.list_calls += 1
+            if self.list_calls == 1 and self.list_jobs.get("next_page"):
+                return {
+                    "jobs": self.list_jobs.get("jobs", []),
+                    "has_more": True,
+                    "next_page_token": "page-2",
+                }
+            if "page_token=page-2" in url:
+                return {"jobs": self.list_jobs.get("next_page", [])}
             return self.list_jobs
         if "/jobs/create" in url:
             return {"job_id": 42}
@@ -50,3 +62,33 @@ def test_databricks_client_ensure_and_run() -> None:
     assert job_id == 42
     assert run_id == 88
     assert terminal.result_state == "SUCCESS"
+
+
+def test_databricks_client_get_query_params_are_urlencoded() -> None:
+    http = FakeHttp()
+    client = DatabricksJobsClient(
+        http_client=http,
+        workspace_url="https://adb.example.com",
+        oauth_bearer_token="token",
+    )
+
+    client._call("GET", "/api/2.1/jobs/list", {"name": "floe sales/prod"})
+    _, url, _ = http.calls[-1]
+    assert "name=floe+sales%2Fprod" in url
+
+
+def test_databricks_client_find_job_by_name_paginates_until_match() -> None:
+    http = FakeHttp()
+    http.list_jobs = {
+        "jobs": [{"job_id": 1, "settings": {"name": "other"}}],
+        "next_page": [{"job_id": 2, "settings": {"name": "floe-sales-prod"}}],
+    }
+    client = DatabricksJobsClient(
+        http_client=http,
+        workspace_url="https://adb.example.com",
+        oauth_bearer_token="token",
+    )
+
+    found = client._find_job_by_name("floe-sales-prod")
+    assert found is not None
+    assert found["job_id"] == 2

--- a/orchestrators/dagster-floe/tests/test_databricks_runner.py
+++ b/orchestrators/dagster-floe/tests/test_databricks_runner.py
@@ -1,0 +1,144 @@
+from __future__ import annotations
+
+from floe_dagster.databricks_client import DatabricksRunResult
+from floe_dagster.databricks_runner import run_databricks_job
+from floe_dagster.k8s_status import STATUS_CANCELED, STATUS_FAILED, STATUS_SUCCEEDED, STATUS_TIMEOUT
+from floe_dagster.manifest import ManifestRunnerDefinition
+
+
+class FakeDatabricksClient:
+    def __init__(self, terminal: DatabricksRunResult | None = None, exc: Exception | None = None) -> None:
+        self._terminal = terminal
+        self._exc = exc
+        self.last_run_now: dict[str, object] | None = None
+
+    def ensure_domain_job(self, spec):  # type: ignore[no-untyped-def]
+        if self._exc is not None:
+            raise self._exc
+        return 123
+
+    def run_now(self, *, job_id, env_parameters=None):  # type: ignore[no-untyped-def]
+        self.last_run_now = {"job_id": job_id, "env_parameters": env_parameters}
+        return 456
+
+    def poll_run_to_terminal(self, *, run_id, poll_interval_seconds, timeout_seconds):  # type: ignore[no-untyped-def]
+        del run_id, poll_interval_seconds, timeout_seconds
+        if self._exc is not None:
+            raise self._exc
+        assert self._terminal is not None
+        return self._terminal
+
+
+def _runner() -> ManifestRunnerDefinition:
+    return ManifestRunnerDefinition(
+        runner_type="databricks_job",
+        image=None,
+        namespace=None,
+        service_account=None,
+        env=None,
+        command=None,
+        args=None,
+        timeout_seconds=60,
+        ttl_seconds_after_finished=None,
+        poll_interval_seconds=1,
+        secrets=None,
+        workspace_url="https://adb.example.com",
+        existing_cluster_id="1111-222222-abc123",
+        config_uri="dbfs:/floe/configs/prod.yml",
+        job_name="floe-sales-prod",
+        auth=None,
+        env_parameters={"FLOE_ENV": "prod"},
+    )
+
+
+def test_run_databricks_job_success_sets_structured_backend_metadata(monkeypatch) -> None:
+    monkeypatch.setenv("FLOE_DATABRICKS_OAUTH_TOKEN", "token")
+    client = FakeDatabricksClient(
+        terminal=DatabricksRunResult(
+            run_id=456,
+            state="TERMINATED",
+            result_state="SUCCESS",
+            state_message="ok",
+            run_page_url="https://example/run/456",
+        )
+    )
+
+    result = run_databricks_job(["floe", "run", "-c", "cfg.yml"], entity="orders", runner=_runner(), client=client)
+
+    assert result.exit_code == 0
+    assert result.status == STATUS_SUCCEEDED
+    assert result.failure_reason is None
+    assert result.backend_metadata["backend_type"] == "databricks"
+    assert result.backend_metadata["backend_run_id"] == 456
+    assert result.backend_metadata["job_id"] == 123
+    assert result.backend_metadata["run_page_url"] == "https://example/run/456"
+    assert client.last_run_now == {
+        "job_id": 123,
+        "env_parameters": {"FLOE_ENV": "prod", "FLOE_ENTITY": "orders"},
+    }
+
+
+def test_run_databricks_job_failure_maps_to_failed(monkeypatch) -> None:
+    monkeypatch.setenv("FLOE_DATABRICKS_OAUTH_TOKEN", "token")
+    client = FakeDatabricksClient(
+        terminal=DatabricksRunResult(
+            run_id=456,
+            state="TERMINATED",
+            result_state="FAILED",
+            state_message="task failed",
+            run_page_url="https://example/run/456",
+        )
+    )
+
+    result = run_databricks_job(["floe", "run"], entity="orders", runner=_runner(), client=client)
+
+    assert result.exit_code == 1
+    assert result.status == STATUS_FAILED
+    assert result.failure_reason == "task failed"
+    assert result.backend_metadata["backend_type"] == "databricks"
+    assert result.backend_metadata["backend_run_id"] == 456
+
+
+def test_run_databricks_job_canceled_maps_to_canceled(monkeypatch) -> None:
+    monkeypatch.setenv("FLOE_DATABRICKS_OAUTH_TOKEN", "token")
+    client = FakeDatabricksClient(
+        terminal=DatabricksRunResult(
+            run_id=456,
+            state="TERMINATED",
+            result_state="CANCELED",
+            state_message="run canceled",
+            run_page_url="https://example/run/456",
+        )
+    )
+
+    result = run_databricks_job(["floe", "run"], entity="orders", runner=_runner(), client=client)
+
+    assert result.exit_code == 1
+    assert result.status == STATUS_CANCELED
+    assert result.failure_reason == "run canceled"
+
+
+def test_run_databricks_job_timeout_error_returns_timeout_status(monkeypatch) -> None:
+    monkeypatch.setenv("FLOE_DATABRICKS_OAUTH_TOKEN", "token")
+    client = FakeDatabricksClient(exc=TimeoutError("run 456 timed out"))
+
+    result = run_databricks_job(["floe", "run"], entity="orders", runner=_runner(), client=client)
+
+    assert result.exit_code == 1
+    assert result.status == STATUS_TIMEOUT
+    assert result.failure_reason == "run 456 timed out"
+    assert result.backend_metadata["backend_type"] == "databricks"
+    assert result.backend_metadata["error_type"] == "timeout"
+
+
+def test_run_databricks_job_infra_failure_preserves_status_context(monkeypatch) -> None:
+    monkeypatch.setenv("FLOE_DATABRICKS_OAUTH_TOKEN", "token")
+    client = FakeDatabricksClient(exc=RuntimeError("jobs api unavailable"))
+
+    result = run_databricks_job(["floe", "run"], entity="orders", runner=_runner(), client=client)
+
+    assert result.exit_code == 1
+    assert result.status == STATUS_FAILED
+    assert result.failure_reason == "jobs api unavailable"
+    assert result.backend_metadata["backend_type"] == "databricks"
+    assert result.backend_metadata["error_type"] == "RuntimeError"

--- a/orchestrators/dagster-floe/tests/test_databricks_runner.py
+++ b/orchestrators/dagster-floe/tests/test_databricks_runner.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import pytest
+
 from floe_dagster.databricks_client import DatabricksRunResult
 from floe_dagster.databricks_runner import run_databricks_job
 from floe_dagster.k8s_status import STATUS_CANCELED, STATUS_FAILED, STATUS_SUCCEEDED, STATUS_TIMEOUT
@@ -11,14 +13,16 @@ class FakeDatabricksClient:
         self._terminal = terminal
         self._exc = exc
         self.last_run_now: dict[str, object] | None = None
+        self.last_spec = None
 
     def ensure_domain_job(self, spec):  # type: ignore[no-untyped-def]
+        self.last_spec = spec
         if self._exc is not None:
             raise self._exc
         return 123
 
-    def run_now(self, *, job_id, env_parameters=None):  # type: ignore[no-untyped-def]
-        self.last_run_now = {"job_id": job_id, "env_parameters": env_parameters}
+    def run_now(self, *, job_id):  # type: ignore[no-untyped-def]
+        self.last_run_now = {"job_id": job_id}
         return 456
 
     def poll_run_to_terminal(self, *, run_id, poll_interval_seconds, timeout_seconds):  # type: ignore[no-untyped-def]
@@ -29,8 +33,8 @@ class FakeDatabricksClient:
         return self._terminal
 
 
-def _runner() -> ManifestRunnerDefinition:
-    return ManifestRunnerDefinition(
+def _runner(**overrides) -> ManifestRunnerDefinition:
+    base = dict(
         runner_type="databricks_job",
         image=None,
         namespace=None,
@@ -45,14 +49,17 @@ def _runner() -> ManifestRunnerDefinition:
         workspace_url="https://adb.example.com",
         existing_cluster_id="1111-222222-abc123",
         config_uri="dbfs:/floe/configs/prod.yml",
+        python_file_uri="dbfs:/floe/bin/floe_entry.py",
         job_name="floe-sales-prod",
         auth={"service_principal_oauth_ref": "env://DATABRICKS_TOKEN"},
         env_parameters={"FLOE_ENV": "prod"},
     )
+    base.update(overrides)
+    return ManifestRunnerDefinition(**base)
 
 
 def test_run_databricks_job_success_sets_structured_backend_metadata(monkeypatch) -> None:
-    monkeypatch.setenv("FLOE_DATABRICKS_OAUTH_TOKEN", "token")
+    monkeypatch.setenv("DATABRICKS_TOKEN", "token")
     client = FakeDatabricksClient(
         terminal=DatabricksRunResult(
             run_id=456,
@@ -72,14 +79,15 @@ def test_run_databricks_job_success_sets_structured_backend_metadata(monkeypatch
     assert result.backend_metadata["backend_run_id"] == 456
     assert result.backend_metadata["job_id"] == 123
     assert result.backend_metadata["run_page_url"] == "https://example/run/456"
-    assert client.last_run_now == {
-        "job_id": 123,
-        "env_parameters": {"FLOE_ENV": "prod", "FLOE_ENTITY": "orders"},
-    }
+    assert client.last_run_now == {"job_id": 123}
+    # cmd_args should be passed as task-level parameters (env_parameters
+    # cannot reach a spark_python_task on existing clusters).
+    assert client.last_spec.parameters == ["floe", "run", "-c", "cfg.yml"]
+    assert client.last_spec.python_file_uri == "dbfs:/floe/bin/floe_entry.py"
 
 
 def test_run_databricks_job_failure_maps_to_failed(monkeypatch) -> None:
-    monkeypatch.setenv("FLOE_DATABRICKS_OAUTH_TOKEN", "token")
+    monkeypatch.setenv("DATABRICKS_TOKEN", "token")
     client = FakeDatabricksClient(
         terminal=DatabricksRunResult(
             run_id=456,
@@ -100,7 +108,7 @@ def test_run_databricks_job_failure_maps_to_failed(monkeypatch) -> None:
 
 
 def test_run_databricks_job_canceled_maps_to_canceled(monkeypatch) -> None:
-    monkeypatch.setenv("FLOE_DATABRICKS_OAUTH_TOKEN", "token")
+    monkeypatch.setenv("DATABRICKS_TOKEN", "token")
     client = FakeDatabricksClient(
         terminal=DatabricksRunResult(
             run_id=456,
@@ -119,7 +127,7 @@ def test_run_databricks_job_canceled_maps_to_canceled(monkeypatch) -> None:
 
 
 def test_run_databricks_job_timeout_error_returns_timeout_status(monkeypatch) -> None:
-    monkeypatch.setenv("FLOE_DATABRICKS_OAUTH_TOKEN", "token")
+    monkeypatch.setenv("DATABRICKS_TOKEN", "token")
     client = FakeDatabricksClient(exc=TimeoutError("run 456 timed out"))
 
     result = run_databricks_job(["floe", "run"], entity="orders", runner=_runner(), client=client)
@@ -132,7 +140,7 @@ def test_run_databricks_job_timeout_error_returns_timeout_status(monkeypatch) ->
 
 
 def test_run_databricks_job_infra_failure_preserves_status_context(monkeypatch) -> None:
-    monkeypatch.setenv("FLOE_DATABRICKS_OAUTH_TOKEN", "token")
+    monkeypatch.setenv("DATABRICKS_TOKEN", "token")
     client = FakeDatabricksClient(exc=RuntimeError("jobs api unavailable"))
 
     result = run_databricks_job(["floe", "run"], entity="orders", runner=_runner(), client=client)
@@ -147,26 +155,84 @@ def test_run_databricks_job_infra_failure_preserves_status_context(monkeypatch) 
 def test_run_databricks_job_renders_job_name_placeholders(monkeypatch) -> None:
     monkeypatch.setenv("DATABRICKS_TOKEN", "token")
 
-    class RecordingClient(FakeDatabricksClient):
-        def __init__(self) -> None:
-            super().__init__(terminal=DatabricksRunResult(
-                run_id=456,
-                state="TERMINATED",
-                result_state="SUCCESS",
-                state_message="ok",
-                run_page_url="https://example/run/456",
-            ))
-            self.last_spec = None
-
-        def ensure_domain_job(self, spec):  # type: ignore[no-untyped-def]
-            self.last_spec = spec
-            return 123
-
-    client = RecordingClient()
-    runner = _runner()
-    runner = ManifestRunnerDefinition(**{**runner.__dict__, "job_name": "floe-{domain}-{env}"})
-
-    run_databricks_job(["floe", "run"], entity="sales.orders", runner=runner, client=client)
-
+    client = FakeDatabricksClient(terminal=DatabricksRunResult(
+        run_id=456, state="TERMINATED", result_state="SUCCESS",
+        state_message="ok", run_page_url="https://example/run/456",
+    ))
+    run_databricks_job(
+        ["floe", "run"],
+        entity="sales.orders",
+        runner=_runner(job_name="floe-{domain}-{env}"),
+        client=client,
+    )
     assert client.last_spec is not None
     assert client.last_spec.job_name == "floe-sales-prod"
+
+
+def test_auth_ref_takes_precedence_over_fallback(monkeypatch) -> None:
+    monkeypatch.setenv("DATABRICKS_TOKEN", "from-auth-ref")
+    monkeypatch.setenv("FLOE_DATABRICKS_OAUTH_TOKEN", "from-fallback")
+    captured: dict[str, object] = {}
+
+    class CapturingClient(FakeDatabricksClient):
+        pass
+
+    # Patch construction inside runner to capture token
+    import floe_dagster.databricks_runner as runner_mod
+
+    original_cls = runner_mod.DatabricksJobsClient
+
+    def fake_cls(*, http_client, workspace_url, oauth_bearer_token):
+        captured["token"] = oauth_bearer_token
+        return CapturingClient(terminal=DatabricksRunResult(
+            run_id=1, state="TERMINATED", result_state="SUCCESS",
+            state_message="ok", run_page_url=None,
+        ))
+
+    monkeypatch.setattr(runner_mod, "DatabricksJobsClient", fake_cls)
+    try:
+        run_databricks_job(["floe", "run"], entity="orders", runner=_runner())
+    finally:
+        monkeypatch.setattr(runner_mod, "DatabricksJobsClient", original_cls)
+
+    assert captured["token"] == "from-auth-ref"
+
+
+def test_auth_ref_missing_env_raises_loudly(monkeypatch) -> None:
+    monkeypatch.delenv("DATABRICKS_TOKEN", raising=False)
+    monkeypatch.setenv("FLOE_DATABRICKS_OAUTH_TOKEN", "fallback")
+    with pytest.raises(ValueError, match="DATABRICKS_TOKEN"):
+        run_databricks_job(["floe", "run"], entity="orders", runner=_runner())
+
+
+def test_non_env_auth_scheme_is_rejected(monkeypatch) -> None:
+    monkeypatch.setenv("FLOE_DATABRICKS_OAUTH_TOKEN", "fallback")
+    runner = _runner(auth={"service_principal_oauth_ref": "secret://kv/dbx"})
+    with pytest.raises(ValueError, match="env://"):
+        run_databricks_job(["floe", "run"], entity="orders", runner=runner)
+
+
+def test_fallback_used_when_no_auth_ref(monkeypatch) -> None:
+    monkeypatch.delenv("DATABRICKS_TOKEN", raising=False)
+    monkeypatch.setenv("FLOE_DATABRICKS_OAUTH_TOKEN", "fallback")
+    runner = _runner(auth=None)
+    captured: dict[str, object] = {}
+
+    import floe_dagster.databricks_runner as runner_mod
+
+    original_cls = runner_mod.DatabricksJobsClient
+
+    def fake_cls(*, http_client, workspace_url, oauth_bearer_token):
+        captured["token"] = oauth_bearer_token
+        return FakeDatabricksClient(terminal=DatabricksRunResult(
+            run_id=1, state="TERMINATED", result_state="SUCCESS",
+            state_message="ok", run_page_url=None,
+        ))
+
+    monkeypatch.setattr(runner_mod, "DatabricksJobsClient", fake_cls)
+    try:
+        run_databricks_job(["floe", "run"], entity="orders", runner=runner)
+    finally:
+        monkeypatch.setattr(runner_mod, "DatabricksJobsClient", original_cls)
+
+    assert captured["token"] == "fallback"

--- a/orchestrators/dagster-floe/tests/test_databricks_runner.py
+++ b/orchestrators/dagster-floe/tests/test_databricks_runner.py
@@ -46,7 +46,7 @@ def _runner() -> ManifestRunnerDefinition:
         existing_cluster_id="1111-222222-abc123",
         config_uri="dbfs:/floe/configs/prod.yml",
         job_name="floe-sales-prod",
-        auth=None,
+        auth={"service_principal_oauth_ref": "env://DATABRICKS_TOKEN"},
         env_parameters={"FLOE_ENV": "prod"},
     )
 
@@ -142,3 +142,31 @@ def test_run_databricks_job_infra_failure_preserves_status_context(monkeypatch) 
     assert result.failure_reason == "jobs api unavailable"
     assert result.backend_metadata["backend_type"] == "databricks"
     assert result.backend_metadata["error_type"] == "RuntimeError"
+
+
+def test_run_databricks_job_renders_job_name_placeholders(monkeypatch) -> None:
+    monkeypatch.setenv("DATABRICKS_TOKEN", "token")
+
+    class RecordingClient(FakeDatabricksClient):
+        def __init__(self) -> None:
+            super().__init__(terminal=DatabricksRunResult(
+                run_id=456,
+                state="TERMINATED",
+                result_state="SUCCESS",
+                state_message="ok",
+                run_page_url="https://example/run/456",
+            ))
+            self.last_spec = None
+
+        def ensure_domain_job(self, spec):  # type: ignore[no-untyped-def]
+            self.last_spec = spec
+            return 123
+
+    client = RecordingClient()
+    runner = _runner()
+    runner = ManifestRunnerDefinition(**{**runner.__dict__, "job_name": "floe-{domain}-{env}"})
+
+    run_databricks_job(["floe", "run"], entity="sales.orders", runner=runner, client=client)
+
+    assert client.last_spec is not None
+    assert client.last_spec.job_name == "floe-sales-prod"

--- a/orchestrators/dagster-floe/tests/test_manifest.py
+++ b/orchestrators/dagster-floe/tests/test_manifest.py
@@ -113,3 +113,36 @@ def test_manifest_schema_accepts_extended_k8_runner_fields(tmp_path: Path):
     assert k8s_runner.command == ["floe"]
     assert k8s_runner.poll_interval_seconds == 5
     assert k8s_runner.secrets is not None and k8s_runner.secrets[0]["name"] == "API_TOKEN"
+
+
+def test_manifest_schema_accepts_databricks_runner_fields(tmp_path: Path):
+    fixture = Path(__file__).parent / "fixtures" / "manifest.json"
+    payload = json.loads(fixture.read_text(encoding="utf-8"))
+    payload["runners"] = {
+        "default": "dbx",
+        "definitions": {
+            "dbx": {
+                "type": "databricks_job",
+                "workspace_url": "https://adb-1234.5.azuredatabricks.net",
+                "existing_cluster_id": "1111-222222-abc123",
+                "config_uri": "dbfs:/floe/configs/prod.yml",
+                "job_name": "floe-sales-prod",
+                "command": "floe",
+                "args": ["run", "-c", "dbfs:/floe/configs/prod.yml"],
+                "poll_interval_seconds": 20,
+                "timeout_seconds": 1800,
+                "auth": {
+                    "service_principal_oauth_ref": "secret://kv/databricks/oauth"
+                },
+                "env_parameters": {"FLOE_ENV": "prod"},
+            }
+        },
+    }
+    manifest_path = tmp_path / "manifest.dbx.json"
+    manifest_path.write_text(json.dumps(payload), encoding="utf-8")
+
+    manifest = load_manifest(manifest_path)
+    runner = manifest.runners.definitions["dbx"]
+    assert runner.runner_type == "databricks_job"
+    assert runner.command == ["floe"]
+    assert runner.workspace_url == "https://adb-1234.5.azuredatabricks.net"

--- a/orchestrators/dagster-floe/tests/test_manifest.py
+++ b/orchestrators/dagster-floe/tests/test_manifest.py
@@ -126,13 +126,14 @@ def test_manifest_schema_accepts_databricks_runner_fields(tmp_path: Path):
                 "workspace_url": "https://adb-1234.5.azuredatabricks.net",
                 "existing_cluster_id": "1111-222222-abc123",
                 "config_uri": "dbfs:/floe/configs/prod.yml",
+                "python_file_uri": "dbfs:/floe/bin/floe_entry.py",
                 "job_name": "floe-sales-prod",
                 "command": "floe",
                 "args": ["run", "-c", "dbfs:/floe/configs/prod.yml"],
                 "poll_interval_seconds": 20,
                 "timeout_seconds": 1800,
                 "auth": {
-                    "service_principal_oauth_ref": "secret://kv/databricks/oauth"
+                    "service_principal_oauth_ref": "env://DATABRICKS_TOKEN"
                 },
                 "env_parameters": {"FLOE_ENV": "prod"},
             }

--- a/orchestrators/schemas/floe.manifest.v1.json
+++ b/orchestrators/schemas/floe.manifest.v1.json
@@ -320,6 +320,13 @@
                 ],
                 "minLength": 1
               },
+              "python_file_uri": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "minLength": 1
+              },
               "job_name": {
                 "type": [
                   "string",
@@ -367,6 +374,7 @@
                     "workspace_url",
                     "existing_cluster_id",
                     "config_uri",
+                    "python_file_uri",
                     "auth"
                   ],
                   "properties": {
@@ -378,7 +386,8 @@
                       "properties": {
                         "service_principal_oauth_ref": {
                           "type": "string",
-                          "minLength": 1
+                          "minLength": 1,
+                          "pattern": "^env://[A-Z0-9_]+$"
                         }
                       },
                       "additionalProperties": false

--- a/orchestrators/schemas/floe.manifest.v1.json
+++ b/orchestrators/schemas/floe.manifest.v1.json
@@ -42,7 +42,10 @@
       "minLength": 1
     },
     "config_checksum": {
-      "type": ["string", "null"]
+      "type": [
+        "string",
+        "null"
+      ]
     },
     "report_base_uri": {
       "type": "string",
@@ -53,7 +56,10 @@
       "items": {
         "type": "object",
         "additionalProperties": false,
-        "required": ["name", "incoming_dir"],
+        "required": [
+          "name",
+          "incoming_dir"
+        ],
         "properties": {
           "name": {
             "type": "string",
@@ -98,7 +104,10 @@
         },
         "log_format": {
           "type": "string",
-          "enum": ["json", "text"]
+          "enum": [
+            "json",
+            "text"
+          ]
         },
         "result_contract": {
           "type": "object",
@@ -132,7 +141,10 @@
         "defaults": {
           "type": "object",
           "additionalProperties": false,
-          "required": ["env", "workdir"],
+          "required": [
+            "env",
+            "workdir"
+          ],
           "properties": {
             "env": {
               "type": "object",
@@ -141,7 +153,10 @@
               }
             },
             "workdir": {
-              "type": ["string", "null"]
+              "type": [
+                "string",
+                "null"
+              ]
             }
           }
         }
@@ -150,7 +165,10 @@
     "runners": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["default", "definitions"],
+      "required": [
+        "default",
+        "definitions"
+      ],
       "properties": {
         "default": {
           "type": "string",
@@ -162,7 +180,9 @@
           "additionalProperties": {
             "type": "object",
             "additionalProperties": false,
-            "required": ["type"],
+            "required": [
+              "type"
+            ],
             "properties": {
               "type": {
                 "type": "string",
@@ -171,38 +191,202 @@
                   "docker",
                   "kubernetes_pod",
                   "kubernetes_job",
-                  "ecs_task"
+                  "ecs_task",
+                  "databricks_job"
                 ]
               },
               "image": {
-                "type": ["string", "null"]
+                "type": [
+                  "string",
+                  "null"
+                ]
               },
               "namespace": {
-                "type": ["string", "null"]
+                "type": [
+                  "string",
+                  "null"
+                ]
               },
               "service_account": {
-                "type": ["string", "null"]
+                "type": [
+                  "string",
+                  "null"
+                ]
               },
               "resources": {
-                "type": ["object", "null"],
+                "type": [
+                  "object",
+                  "null"
+                ],
                 "additionalProperties": false,
                 "properties": {
                   "cpu": {
-                    "type": ["string", "null"]
+                    "type": [
+                      "string",
+                      "null"
+                    ]
                   },
                   "memory_mb": {
-                    "type": ["integer", "null"],
+                    "type": [
+                      "integer",
+                      "null"
+                    ],
                     "minimum": 1
                   }
                 }
               },
               "env": {
-                "type": ["object", "null"],
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "additionalProperties": {
+                  "type": "string"
+                }
+              },
+              "command": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "args": {
+                "type": [
+                  "array",
+                  "null"
+                ],
+                "items": {
+                  "type": "string"
+                }
+              },
+              "timeout_seconds": {
+                "type": [
+                  "integer",
+                  "null"
+                ],
+                "minimum": 1
+              },
+              "ttl_seconds_after_finished": {
+                "type": [
+                  "integer",
+                  "null"
+                ],
+                "minimum": 0
+              },
+              "poll_interval_seconds": {
+                "type": [
+                  "integer",
+                  "null"
+                ],
+                "minimum": 1
+              },
+              "secrets": {
+                "type": [
+                  "array",
+                  "null"
+                ],
+                "items": {
+                  "type": "object"
+                }
+              },
+              "workspace_url": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "minLength": 1
+              },
+              "existing_cluster_id": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "minLength": 1
+              },
+              "config_uri": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "minLength": 1
+              },
+              "job_name": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "minLength": 1
+              },
+              "auth": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "additionalProperties": false,
+                "properties": {
+                  "service_principal_oauth_ref": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "minLength": 1
+                  }
+                }
+              },
+              "env_parameters": {
+                "type": [
+                  "object",
+                  "null"
+                ],
                 "additionalProperties": {
                   "type": "string"
                 }
               }
-            }
+            },
+            "allOf": [
+              {
+                "if": {
+                  "properties": {
+                    "type": {
+                      "const": "databricks_job"
+                    }
+                  }
+                },
+                "then": {
+                  "required": [
+                    "workspace_url",
+                    "existing_cluster_id",
+                    "config_uri",
+                    "auth"
+                  ],
+                  "properties": {
+                    "auth": {
+                      "type": "object",
+                      "required": [
+                        "service_principal_oauth_ref"
+                      ],
+                      "properties": {
+                        "service_principal_oauth_ref": {
+                          "type": "string",
+                          "minLength": 1
+                        }
+                      },
+                      "additionalProperties": false
+                    }
+                  }
+                }
+              }
+            ]
           }
         }
       }
@@ -227,7 +411,10 @@
             "minLength": 1
           },
           "domain": {
-            "type": ["string", "null"]
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "group_name": {
             "type": "string",
@@ -250,21 +437,36 @@
             "minLength": 1
           },
           "rejected_sink_uri": {
-            "type": ["string", "null"]
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "tags": {
-            "type": ["object", "null"],
+            "type": [
+              "object",
+              "null"
+            ],
             "additionalProperties": {
               "type": "string"
             }
           },
           "runner": {
-            "type": ["string", "null"]
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "source": {
             "type": "object",
             "additionalProperties": false,
-            "required": ["format", "storage", "uri", "path", "resolved"],
+            "required": [
+              "format",
+              "storage",
+              "uri",
+              "path",
+              "resolved"
+            ],
             "properties": {
               "format": {
                 "type": "string",
@@ -286,31 +488,47 @@
                 "type": "boolean"
               },
               "cast_mode": {
-                "type": ["string", "null"]
+                "type": [
+                  "string",
+                  "null"
+                ]
               },
               "options": {
-                "type": ["object", "null"]
+                "type": [
+                  "object",
+                  "null"
+                ]
               }
             }
           },
           "sinks": {
             "type": "object",
             "additionalProperties": false,
-            "required": ["accepted"],
+            "required": [
+              "accepted"
+            ],
             "properties": {
               "accepted": {
                 "$ref": "#/$defs/sink_target"
               },
               "rejected": {
                 "anyOf": [
-                  { "$ref": "#/$defs/sink_target" },
-                  { "type": "null" }
+                  {
+                    "$ref": "#/$defs/sink_target"
+                  },
+                  {
+                    "type": "null"
+                  }
                 ]
               },
               "archive": {
                 "anyOf": [
-                  { "$ref": "#/$defs/archive_target" },
-                  { "type": "null" }
+                  {
+                    "$ref": "#/$defs/archive_target"
+                  },
+                  {
+                    "type": "null"
+                  }
                 ]
               }
             }
@@ -323,7 +541,13 @@
     "sink_target": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["format", "storage", "uri", "path", "resolved"],
+      "required": [
+        "format",
+        "storage",
+        "uri",
+        "path",
+        "resolved"
+      ],
       "properties": {
         "format": {
           "type": "string",
@@ -349,7 +573,12 @@
     "archive_target": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["storage", "uri", "path", "resolved"],
+      "required": [
+        "storage",
+        "uri",
+        "path",
+        "resolved"
+      ],
       "properties": {
         "storage": {
           "type": "string",


### PR DESCRIPTION
## Summary

Foundational support for the `databricks_job` runner across the Floe stack: profile contract, manifest schema, and connector-side Jobs API client for Airflow and Dagster. Execution stays in the connectors; floe-core only emits the manifest.

## What's in this PR

### `floe-core` (Rust)
- New `databricks_job` runner type in profile schema with required fields: `workspace_url`, `existing_cluster_id`, `config_uri`, `python_file_uri`, `auth.service_principal_oauth_ref`.
- `python_file_uri` is the `spark_python_task.python_file` (Python entry script). `config_uri` is the YAML the floe CLI runs against (`-c`). They are intentionally separate artifacts.
- Profile validator enforces required fields per runner type.
- Manifest builder propagates Databricks fields into `floe.manifest.v1`.

### Schemas
- `orchestrators/schemas/floe.manifest.v1.json` and the dagster-packaged copy gain `python_file_uri` and conditional `required` rules under `databricks_job`.
- `auth.service_principal_oauth_ref` pinned to `^env://[A-Z0-9_]+$` (schema-enforced).

### Connectors (`airflow-floe`, `dagster-floe`)
- `DatabricksJobsClient` abstraction with mockable HTTP: `ensure_domain_job` → `run_now` → `poll_run_to_terminal`.
- Drift detection via a `floe_settings_version` job tag (avoids spurious resets from server-normalized settings).
- `jobs/list` pagination capped at 200 pages.
- Auth precedence: declared `auth.service_principal_oauth_ref=env://VAR` is used when present; `FLOE_DATABRICKS_OAUTH_TOKEN` is the no-ref fallback. Non-`env://` schemes are rejected at runtime.
- Unified `backend_metadata` shape across both connectors (`backend_run_id` int, `error_type`, `life_cycle_state`, `result_state`, `state_message`, `run_page_url`).

### Docs
- `docs/profiles.md`: new `databricks_job` example, auth precedence rules, and the existing-cluster constraint that per-run env vars cannot reach a `spark_python_task` (set them at cluster level).

## Notes / non-goals

- Primary auth is service-principal OAuth bearer token. No PAT path.
- CLI/connector split preserved: manifest generation in floe-core, execution in connectors.
- Per-run env injection is intentionally not delivered via `job_parameters` — Databricks does not surface them to `spark_python_task` on existing clusters.

## Test plan

- [x] Rust: `cargo test -p floe-core --test unit profile::` (34 passing) and `manifest::` (8 passing), incl. `validate_databricks_job_missing_python_file_uri_fails` and `manifest_with_databricks_profile_serializes_runner_fields`.
- [x] Airflow: `pytest tests/test_databricks_client.py tests/test_databricks_runner.py tests/test_manifest_loader.py` — 20 passing (incl. auth precedence, non-env scheme rejection, fallback, payload parity).
- [x] Dagster: `pytest tests/test_databricks_client.py tests/test_databricks_runner.py tests/test_manifest.py` — 22 passing (same coverage).
