### PR TITLE
release: v0.3.4 core + connector package bumps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to Floe are documented in this file.
 
+## v0.3.4
+
+- Databricks runner foundation for orchestrator connectors:
+  - added `databricks_job` runner contract support in Floe profile/manifest flow
+  - added connector-side Databricks job client flow for Airflow and Dagster
+  - standardized Databricks run status/result mapping with backend metadata and failure reason handling
+  - added mocked integration coverage for success, failure, timeout, canceled, and infra failure paths
+- Packaging/version updates:
+  - bumped `floe-core` and `floe-cli` to `0.3.4`
+  - bumped `airflow-floe` and `dagster-floe` Python packages to `0.1.4`
+
 ## v0.3.3
 
 - Runner contract and architecture cleanup:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3376,7 +3376,7 @@ dependencies = [
 
 [[package]]
 name = "floe-cli"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "assert_cmd",
  "clap",
@@ -3389,7 +3389,7 @@ dependencies = [
 
 [[package]]
 name = "floe-core"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "apache-avro 0.16.0",
  "arrow",

--- a/crates/floe-cli/Cargo.toml
+++ b/crates/floe-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "floe-cli"
-version = "0.3.3"
+version = "0.3.4"
 edition = "2021"
 description = "CLI for Floe, a YAML-driven technical ingestion tool."
 license = "MIT"
@@ -17,7 +17,7 @@ path = "src/main.rs"
 
 [dependencies]
 clap = { version = "4", features = ["derive"] }
-floe-core = { path = "../floe-core", version = "0.3.3" }
+floe-core = { path = "../floe-core", version = "0.3.4" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 

--- a/crates/floe-core/Cargo.toml
+++ b/crates/floe-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "floe-core"
-version = "0.3.3"
+version = "0.3.4"
 edition = "2021"
 description = "Core library for Floe, a YAML-driven technical ingestion tool."
 license = "MIT"

--- a/orchestrators/airflow-floe/pyproject.toml
+++ b/orchestrators/airflow-floe/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "airflow-floe"
-version = "0.1.3"
+version = "0.1.4"
 description = "Airflow connector for Floe CLI (manifest-first orchestration)"
 requires-python = ">=3.10"
 readme = "README.md"

--- a/orchestrators/dagster-floe/pyproject.toml
+++ b/orchestrators/dagster-floe/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "dagster-floe"
-version = "0.1.3"
+version = "0.1.4"
 description = "Dagster connector for Floe CLI (config-driven ingestion)"
 requires-python = ">=3.10"
 readme = "README.md"


### PR DESCRIPTION
## Summary
- bump Rust crates for core release:
  - floe-core -> 0.3.4
  - floe-cli -> 0.3.4
- bump connector Python package versions:
  - airflow-floe -> 0.1.4
  - dagster-floe -> 0.1.4
- update CHANGELOG.md with v0.3.4 release notes for Databricks runner foundation

## Validation
- cargo test -p floe-core --test unit profile:: -- --nocapture
- cargo test -p floe-core --test unit manifest:: -- --nocapture
- cargo test -p floe-cli --test manifest_output -- --nocapture

## Tag plan after merge
- core: v0.3.4
- connectors:
  - airflow-floe-v0.1.4
  - dagster-floe-v0.1.4
