### PR TITLE
feat(config): add incremental_mode contract for stateful ingestion

### DIFF
--- a/crates/floe-core/src/config/parse.rs
+++ b/crates/floe-core/src/config/parse.rs
@@ -11,8 +11,8 @@ use crate::config::yaml_decode::{
 use crate::config::{
     ArchiveTarget, CatalogDefinition, CatalogsConfig, ColumnConfig, DomainConfig, EntityConfig,
     EntityMetadata, EnvConfig, IcebergPartitionFieldConfig, IcebergSinkTargetConfig,
-    MergeOptionsConfig, MergeScd2OptionsConfig, NormalizeColumnsConfig, PolicyConfig,
-    ProjectMetadata, ReportConfig, RootConfig, SchemaConfig, SchemaEvolutionConfig,
+    IncrementalMode, MergeOptionsConfig, MergeScd2OptionsConfig, NormalizeColumnsConfig,
+    PolicyConfig, ProjectMetadata, ReportConfig, RootConfig, SchemaConfig, SchemaEvolutionConfig,
     SchemaEvolutionIncompatibleAction, SchemaEvolutionMode, SchemaMismatchConfig, SinkConfig,
     SinkOptions, SinkTarget, SourceConfig, SourceOptions, StorageDefinition, StoragesConfig,
     WriteMode,
@@ -134,7 +134,14 @@ fn parse_entity(value: &Yaml) -> FloeResult<EntityConfig> {
         hash,
         "entity",
         &[
-            "name", "metadata", "domain", "source", "sink", "policy", "schema",
+            "name",
+            "metadata",
+            "domain",
+            "incremental_mode",
+            "source",
+            "sink",
+            "policy",
+            "schema",
         ],
     )?;
     let name = get_string(hash, "name", "entity")?;
@@ -144,6 +151,10 @@ fn parse_entity(value: &Yaml) -> FloeResult<EntityConfig> {
         None => None,
     };
     let domain = opt_string(hash, "domain", "entity")?;
+    let incremental_mode = match opt_string(hash, "incremental_mode", "entity")? {
+        Some(value) => parse_incremental_mode(&value, "entity.incremental_mode")?,
+        None => IncrementalMode::default(),
+    };
 
     let source = parse_source(get_value(hash, "source", "entity")?)?;
     let sink = parse_sink(get_value(hash, "sink", "entity")?)?;
@@ -154,6 +165,7 @@ fn parse_entity(value: &Yaml) -> FloeResult<EntityConfig> {
         name,
         metadata,
         domain,
+        incremental_mode,
         source,
         sink,
         policy,
@@ -225,6 +237,18 @@ fn parse_string_map(value: &Yaml, context: &str) -> FloeResult<HashMap<String, S
         map.insert(key_str, value_str);
     }
     Ok(map)
+}
+
+fn parse_incremental_mode(value: &str, ctx: &str) -> FloeResult<IncrementalMode> {
+    match value.trim().to_ascii_lowercase().as_str() {
+        "none" => Ok(IncrementalMode::None),
+        "archive" => Ok(IncrementalMode::Archive),
+        "file" => Ok(IncrementalMode::File),
+        "row" => Ok(IncrementalMode::Row),
+        _ => Err(Box::new(ConfigError(format!(
+            "unsupported value at {ctx}: {value} (allowed: none, archive, file, row)"
+        )))),
+    }
 }
 
 fn parse_source(value: &Yaml) -> FloeResult<SourceConfig> {

--- a/crates/floe-core/src/config/types.rs
+++ b/crates/floe-core/src/config/types.rs
@@ -46,10 +46,31 @@ pub struct EntityConfig {
     pub name: String,
     pub metadata: Option<EntityMetadata>,
     pub domain: Option<String>,
+    pub incremental_mode: IncrementalMode,
     pub source: SourceConfig,
     pub sink: SinkConfig,
     pub policy: PolicyConfig,
     pub schema: SchemaConfig,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum IncrementalMode {
+    #[default]
+    None,
+    Archive,
+    File,
+    Row,
+}
+
+impl IncrementalMode {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::None => "none",
+            Self::Archive => "archive",
+            Self::File => "file",
+            Self::Row => "row",
+        }
+    }
 }
 
 #[derive(Debug)]

--- a/crates/floe-core/tests/unit/config/adls_validation.rs
+++ b/crates/floe-core/tests/unit/config/adls_validation.rs
@@ -5,6 +5,7 @@ fn base_entity() -> config::EntityConfig {
         name: "customer".to_string(),
         metadata: None,
         domain: None,
+        incremental_mode: config::IncrementalMode::None,
         source: config::SourceConfig {
             format: "csv".to_string(),
             path: "in.csv".to_string(),

--- a/crates/floe-core/tests/unit/config/catalogs.rs
+++ b/crates/floe-core/tests/unit/config/catalogs.rs
@@ -50,6 +50,7 @@ fn entity() -> config::EntityConfig {
         name: "Customer Orders".to_string(),
         metadata: None,
         domain: Some("Sales Ops".to_string()),
+        incremental_mode: config::IncrementalMode::None,
         source: config::SourceConfig {
             format: "csv".to_string(),
             path: "in".to_string(),

--- a/crates/floe-core/tests/unit/config/config_validation.rs
+++ b/crates/floe-core/tests/unit/config/config_validation.rs
@@ -206,6 +206,35 @@ fn invalid_source_format_errors() {
 }
 
 #[test]
+fn unsupported_incremental_mode_errors() {
+    let entity = r#"  - name: "customer"
+    incremental_mode: "batch"
+    source:
+      format: "csv"
+      path: "/tmp/input"
+    sink:
+      accepted:
+        format: "parquet"
+        path: "/tmp/out"
+    policy:
+      severity: "warn"
+    schema:
+      columns:
+        - name: "customer_id"
+          type: "string"
+"#;
+    let yaml = base_config(entity);
+    assert_validation_error(
+        &yaml,
+        &[
+            "entity.incremental_mode",
+            "batch",
+            "allowed: none, archive, file, row",
+        ],
+    );
+}
+
+#[test]
 fn xml_source_requires_row_tag() {
     let entity = r#"  - name: "customer"
     source:

--- a/crates/floe-core/tests/unit/config/parse.rs
+++ b/crates/floe-core/tests/unit/config/parse.rs
@@ -3,7 +3,9 @@ use std::path::PathBuf;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{SystemTime, UNIX_EPOCH};
 
-use floe_core::config::{SchemaEvolutionIncompatibleAction, SchemaEvolutionMode, WriteMode};
+use floe_core::config::{
+    IncrementalMode, SchemaEvolutionIncompatibleAction, SchemaEvolutionMode, WriteMode,
+};
 use floe_core::load_config;
 
 static TEMP_CONFIG_SEQ: AtomicU64 = AtomicU64::new(0);
@@ -181,6 +183,68 @@ entities:
         WriteMode::Append
     );
     assert_eq!(entity.sink.resolved_write_mode(), WriteMode::Append);
+}
+
+#[test]
+fn parse_config_defaults_incremental_mode_to_none() {
+    let yaml = r#"
+version: "0.1"
+entities:
+  - name: "customer"
+    source:
+      format: "csv"
+      path: "/tmp/input"
+    sink:
+      accepted:
+        format: "parquet"
+        path: "/tmp/out"
+    policy:
+      severity: "warn"
+    schema:
+      columns:
+        - name: "customer_id"
+          type: "string"
+"#;
+    let path = write_temp_config(yaml);
+    let config = load_config(&path).expect("parse config");
+
+    assert_eq!(config.entities[0].incremental_mode, IncrementalMode::None);
+}
+
+#[test]
+fn parse_config_supports_incremental_modes() {
+    for (raw, expected) in [
+        ("none", IncrementalMode::None),
+        ("archive", IncrementalMode::Archive),
+        ("file", IncrementalMode::File),
+        ("row", IncrementalMode::Row),
+    ] {
+        let yaml = format!(
+            r#"
+version: "0.1"
+entities:
+  - name: "customer"
+    incremental_mode: "{raw}"
+    source:
+      format: "csv"
+      path: "/tmp/input"
+    sink:
+      accepted:
+        format: "parquet"
+        path: "/tmp/out"
+    policy:
+      severity: "warn"
+    schema:
+      columns:
+        - name: "customer_id"
+          type: "string"
+"#
+        );
+        let path = write_temp_config(&yaml);
+        let config = load_config(&path).expect("parse config");
+
+        assert_eq!(config.entities[0].incremental_mode, expected, "mode {raw}");
+    }
 }
 
 #[test]

--- a/crates/floe-core/tests/unit/io/storage/inputs.rs
+++ b/crates/floe-core/tests/unit/io/storage/inputs.rs
@@ -205,6 +205,7 @@ fn mock_entity(name: &str) -> config::EntityConfig {
         name: name.to_string(),
         metadata: None,
         domain: None,
+        incremental_mode: config::IncrementalMode::None,
         source: config::SourceConfig {
             format: "csv".to_string(),
             path: "unused".to_string(),

--- a/crates/floe-core/tests/unit/io/write/delta_write.rs
+++ b/crates/floe-core/tests/unit/io/write/delta_write.rs
@@ -638,6 +638,7 @@ fn build_entity(
         name: "orders".to_string(),
         metadata: None,
         domain: None,
+        incremental_mode: config::IncrementalMode::None,
         source: config::SourceConfig {
             format: "csv".to_string(),
             path: "in".to_string(),

--- a/crates/floe-core/tests/unit/io/write/iceberg_write.rs
+++ b/crates/floe-core/tests/unit/io/write/iceberg_write.rs
@@ -441,6 +441,7 @@ fn build_entity(
         name: "orders".to_string(),
         metadata: None,
         domain: None,
+        incremental_mode: config::IncrementalMode::None,
         source: config::SourceConfig {
             format: "csv".to_string(),
             path: "in".to_string(),

--- a/crates/floe-core/tests/unit/io/write/object_store.rs
+++ b/crates/floe-core/tests/unit/io/write/object_store.rs
@@ -41,6 +41,7 @@ fn delta_store_config_builds_s3_url_and_options() -> FloeResult<()> {
         name: "orders".to_string(),
         metadata: None,
         domain: None,
+        incremental_mode: config::IncrementalMode::None,
         source: config::SourceConfig {
             format: "csv".to_string(),
             path: "in".to_string(),
@@ -101,6 +102,7 @@ fn iceberg_store_config_builds_s3_warehouse_and_region_props() -> FloeResult<()>
         name: "orders".to_string(),
         metadata: None,
         domain: None,
+        incremental_mode: config::IncrementalMode::None,
         source: config::SourceConfig {
             format: "csv".to_string(),
             path: "in".to_string(),
@@ -173,6 +175,7 @@ fn delta_store_config_builds_local_url() -> FloeResult<()> {
         name: "orders".to_string(),
         metadata: None,
         domain: None,
+        incremental_mode: config::IncrementalMode::None,
         source: config::SourceConfig {
             format: "csv".to_string(),
             path: "in".to_string(),
@@ -234,6 +237,7 @@ fn iceberg_store_config_builds_local_warehouse_without_props() -> FloeResult<()>
         name: "orders".to_string(),
         metadata: None,
         domain: None,
+        incremental_mode: config::IncrementalMode::None,
         source: config::SourceConfig {
             format: "csv".to_string(),
             path: "in".to_string(),
@@ -307,6 +311,7 @@ fn delta_store_config_builds_adls_url_and_options() -> FloeResult<()> {
         name: "orders".to_string(),
         metadata: None,
         domain: None,
+        incremental_mode: config::IncrementalMode::None,
         source: config::SourceConfig {
             format: "csv".to_string(),
             path: "in".to_string(),
@@ -396,6 +401,7 @@ fn iceberg_store_config_builds_gcs_warehouse_without_props() -> FloeResult<()> {
         name: "orders".to_string(),
         metadata: None,
         domain: None,
+        incremental_mode: config::IncrementalMode::None,
         source: config::SourceConfig {
             format: "csv".to_string(),
             path: "in".to_string(),
@@ -472,6 +478,7 @@ fn iceberg_store_config_rejects_adls_target() -> FloeResult<()> {
         name: "orders".to_string(),
         metadata: None,
         domain: None,
+        incremental_mode: config::IncrementalMode::None,
         source: config::SourceConfig {
             format: "csv".to_string(),
             path: "in".to_string(),
@@ -544,6 +551,7 @@ fn delta_store_config_builds_gcs_url() -> FloeResult<()> {
         name: "orders".to_string(),
         metadata: None,
         domain: None,
+        incremental_mode: config::IncrementalMode::None,
         source: config::SourceConfig {
             format: "csv".to_string(),
             path: "in".to_string(),

--- a/crates/floe-core/tests/unit/io/write/rejected_csv.rs
+++ b/crates/floe-core/tests/unit/io/write/rejected_csv.rs
@@ -11,6 +11,7 @@ fn sample_entity() -> config::EntityConfig {
         name: "orders".to_string(),
         metadata: None,
         domain: None,
+        incremental_mode: config::IncrementalMode::None,
         source: config::SourceConfig {
             format: "csv".to_string(),
             path: "in".to_string(),


### PR DESCRIPTION
## Summary
- add an incremental_mode entity config enum with none, archive, file, and reserved row values
- parse and validate the new config surface while defaulting to none when omitted
- cover valid modes and unsupported values with unit tests

## Testing
- cargo test -p floe-core incremental_mode -- --nocapture
- cargo test -p floe-core unit::config -- --nocapture