### PR TITLE
feat(state): add entity state store foundation for incremental ingestion

### DIFF
--- a/crates/floe-core/src/config/parse.rs
+++ b/crates/floe-core/src/config/parse.rs
@@ -10,12 +10,12 @@ use crate::config::yaml_decode::{
 };
 use crate::config::{
     ArchiveTarget, CatalogDefinition, CatalogsConfig, ColumnConfig, DomainConfig, EntityConfig,
-    EntityMetadata, EnvConfig, IcebergPartitionFieldConfig, IcebergSinkTargetConfig,
-    IncrementalMode, MergeOptionsConfig, MergeScd2OptionsConfig, NormalizeColumnsConfig,
-    PolicyConfig, ProjectMetadata, ReportConfig, RootConfig, SchemaConfig, SchemaEvolutionConfig,
-    SchemaEvolutionIncompatibleAction, SchemaEvolutionMode, SchemaMismatchConfig, SinkConfig,
-    SinkOptions, SinkTarget, SourceConfig, SourceOptions, StorageDefinition, StoragesConfig,
-    WriteMode,
+    EntityMetadata, EntityStateConfig, EnvConfig, IcebergPartitionFieldConfig,
+    IcebergSinkTargetConfig, IncrementalMode, MergeOptionsConfig, MergeScd2OptionsConfig,
+    NormalizeColumnsConfig, PolicyConfig, ProjectMetadata, ReportConfig, RootConfig, SchemaConfig,
+    SchemaEvolutionConfig, SchemaEvolutionIncompatibleAction, SchemaEvolutionMode,
+    SchemaMismatchConfig, SinkConfig, SinkOptions, SinkTarget, SourceConfig, SourceOptions,
+    StorageDefinition, StoragesConfig, WriteMode,
 };
 use crate::{ConfigError, FloeResult};
 
@@ -138,6 +138,7 @@ fn parse_entity(value: &Yaml) -> FloeResult<EntityConfig> {
             "metadata",
             "domain",
             "incremental_mode",
+            "state",
             "source",
             "sink",
             "policy",
@@ -155,6 +156,10 @@ fn parse_entity(value: &Yaml) -> FloeResult<EntityConfig> {
         Some(value) => parse_incremental_mode(&value, "entity.incremental_mode")?,
         None => IncrementalMode::default(),
     };
+    let state = match hash_get(hash, "state") {
+        Some(value) => Some(parse_entity_state(value)?),
+        None => None,
+    };
 
     let source = parse_source(get_value(hash, "source", "entity")?)?;
     let sink = parse_sink(get_value(hash, "sink", "entity")?)?;
@@ -166,6 +171,7 @@ fn parse_entity(value: &Yaml) -> FloeResult<EntityConfig> {
         metadata,
         domain,
         incremental_mode,
+        state,
         source,
         sink,
         policy,
@@ -197,6 +203,14 @@ fn parse_entity_metadata(value: &Yaml) -> FloeResult<EntityMetadata> {
         owner: opt_string(hash, "owner", "entity.metadata")?,
         description: opt_string(hash, "description", "entity.metadata")?,
         tags: opt_vec_string(hash, "tags", "entity.metadata")?,
+    })
+}
+
+fn parse_entity_state(value: &Yaml) -> FloeResult<EntityStateConfig> {
+    let hash = yaml_hash(value, "entity.state")?;
+    validate_known_keys(hash, "entity.state", &["path"])?;
+    Ok(EntityStateConfig {
+        path: opt_string(hash, "path", "entity.state")?,
     })
 }
 

--- a/crates/floe-core/src/config/types.rs
+++ b/crates/floe-core/src/config/types.rs
@@ -47,6 +47,7 @@ pub struct EntityConfig {
     pub metadata: Option<EntityMetadata>,
     pub domain: Option<String>,
     pub incremental_mode: IncrementalMode,
+    pub state: Option<EntityStateConfig>,
     pub source: SourceConfig,
     pub sink: SinkConfig,
     pub policy: PolicyConfig,
@@ -80,6 +81,11 @@ pub struct EntityMetadata {
     pub owner: Option<String>,
     pub description: Option<String>,
     pub tags: Option<Vec<String>>,
+}
+
+#[derive(Debug, Clone)]
+pub struct EntityStateConfig {
+    pub path: Option<String>,
 }
 
 #[derive(Debug)]

--- a/crates/floe-core/src/config/validate.rs
+++ b/crates/floe-core/src/config/validate.rs
@@ -116,9 +116,28 @@ fn validate_entity(
     catalogs: &CatalogRegistry,
 ) -> FloeResult<()> {
     validate_source(entity, storages)?;
+    validate_state(entity)?;
     validate_policy(entity)?;
     validate_sink(entity, storages, catalogs)?;
     validate_schema(entity, config_version)?;
+    Ok(())
+}
+
+fn validate_state(entity: &EntityConfig) -> FloeResult<()> {
+    if let Some(path) = entity
+        .state
+        .as_ref()
+        .and_then(|state| state.path.as_deref())
+        .map(str::trim)
+    {
+        if path.is_empty() {
+            return Err(Box::new(ConfigError(format!(
+                "entity.name={} entity.state.path must not be empty",
+                entity.name
+            ))));
+        }
+    }
+
     Ok(())
 }
 

--- a/crates/floe-core/src/lib.rs
+++ b/crates/floe-core/src/lib.rs
@@ -11,6 +11,7 @@ pub mod report;
 pub mod run;
 pub mod runner;
 pub mod runtime;
+pub mod state;
 pub mod vars;
 pub mod warnings;
 

--- a/crates/floe-core/src/state/mod.rs
+++ b/crates/floe-core/src/state/mod.rs
@@ -1,0 +1,151 @@
+use std::collections::BTreeMap;
+use std::fs;
+use std::path::Path;
+
+use serde::{Deserialize, Serialize};
+use tempfile::NamedTempFile;
+
+use crate::config::{EntityConfig, ResolvedPath, StorageResolver};
+use crate::io::storage::extensions;
+use crate::{ConfigError, FloeResult};
+
+pub const ENTITY_STATE_SCHEMA_V1: &str = "floe.state.file-ingest.v1";
+pub const ENTITY_STATE_FILENAME: &str = "state.json";
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct EntityState {
+    pub schema: String,
+    pub entity: String,
+    pub updated_at: Option<String>,
+    #[serde(default)]
+    pub files: BTreeMap<String, EntityFileState>,
+}
+
+impl EntityState {
+    pub fn new(entity: impl Into<String>) -> Self {
+        Self {
+            schema: ENTITY_STATE_SCHEMA_V1.to_string(),
+            entity: entity.into(),
+            updated_at: None,
+            files: BTreeMap::new(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct EntityFileState {
+    pub processed_at: String,
+    pub size: Option<u64>,
+    pub mtime: Option<String>,
+}
+
+pub fn resolve_entity_state_path(
+    resolver: &StorageResolver,
+    entity: &EntityConfig,
+) -> FloeResult<ResolvedPath> {
+    if let Some(state) = &entity.state {
+        if let Some(path) = state.path.as_deref() {
+            return resolver.resolve_path(
+                &entity.name,
+                "entity.state.path",
+                entity.source.storage.as_deref(),
+                path,
+            );
+        }
+    }
+
+    let source_root = derive_source_root(&entity.source.path, &entity.source.format);
+    let default_path = join_state_path(&source_root, &entity.name);
+    resolver.resolve_path(
+        &entity.name,
+        "entity.state.path",
+        entity.source.storage.as_deref(),
+        &default_path,
+    )
+}
+
+pub fn read_entity_state(path: &Path) -> FloeResult<Option<EntityState>> {
+    if !path.exists() {
+        return Ok(None);
+    }
+    let payload = fs::read_to_string(path)?;
+    let state: EntityState = serde_json::from_str(&payload)?;
+    Ok(Some(state))
+}
+
+pub fn write_entity_state_atomic(path: &Path, state: &EntityState) -> FloeResult<()> {
+    let parent = path.parent().ok_or_else(|| {
+        Box::new(ConfigError(format!(
+            "state path has no parent directory: {}",
+            path.display()
+        ))) as Box<dyn std::error::Error + Send + Sync>
+    })?;
+    fs::create_dir_all(parent)?;
+
+    let mut temp = NamedTempFile::new_in(parent)?;
+    serde_json::to_writer_pretty(temp.as_file_mut(), state)?;
+    temp.as_file_mut().sync_all()?;
+    temp.persist(path).map_err(|err| err.error)?;
+    Ok(())
+}
+
+fn join_state_path(source_root: &str, entity_name: &str) -> String {
+    if source_root.is_empty() || source_root == "." {
+        format!(".floe/state/{entity_name}/{ENTITY_STATE_FILENAME}")
+    } else {
+        format!(
+            "{}/.floe/state/{entity_name}/{ENTITY_STATE_FILENAME}",
+            source_root.trim_end_matches('/')
+        )
+    }
+}
+
+fn derive_source_root(raw_path: &str, source_format: &str) -> String {
+    let trimmed = raw_path.trim_end_matches('/');
+    if trimmed.is_empty() {
+        return String::new();
+    }
+
+    if let Some(prefix) = prefix_before_first_glob(trimmed) {
+        if prefix.is_empty() {
+            return String::new();
+        }
+        if prefix.ends_with('/') {
+            return prefix.trim_end_matches('/').to_string();
+        }
+        return parent_like(prefix)
+            .unwrap_or(prefix)
+            .trim_end_matches('/')
+            .to_string();
+    }
+
+    if matches_source_file_suffix(trimmed, source_format) {
+        return parent_like(trimmed)
+            .unwrap_or(trimmed)
+            .trim_end_matches('/')
+            .to_string();
+    }
+
+    trimmed.to_string()
+}
+
+fn prefix_before_first_glob(value: &str) -> Option<&str> {
+    let index = value.find(['*', '?', '['])?;
+    Some(&value[..index])
+}
+
+fn matches_source_file_suffix(value: &str, source_format: &str) -> bool {
+    let Some(segment) = value.rsplit('/').next() else {
+        return false;
+    };
+
+    extensions::suffixes_for_format(source_format)
+        .map(|suffixes| suffixes.iter().any(|suffix| segment.ends_with(suffix)))
+        .unwrap_or(false)
+}
+
+fn parent_like(value: &str) -> Option<&str> {
+    value
+        .rfind('/')
+        .map(|index| if index == 0 { "/" } else { &value[..index] })
+}

--- a/crates/floe-core/src/state/mod.rs
+++ b/crates/floe-core/src/state/mod.rs
@@ -133,9 +133,19 @@ fn derive_source_root(
             .to_string();
     }
 
-    if resolved_local_path.is_some_and(|path| path.is_file())
-        || matches_source_file_suffix(trimmed, source_format)
-    {
+    if let Some(path) = resolved_local_path.filter(|path| path.exists()) {
+        if path.is_dir() {
+            return trimmed.to_string();
+        }
+        if path.is_file() {
+            return parent_like(trimmed)
+                .unwrap_or(trimmed)
+                .trim_end_matches('/')
+                .to_string();
+        }
+    }
+
+    if matches_source_file_suffix(trimmed, source_format) {
         return parent_like(trimmed)
             .unwrap_or(trimmed)
             .trim_end_matches('/')

--- a/crates/floe-core/src/state/mod.rs
+++ b/crates/floe-core/src/state/mod.rs
@@ -54,7 +54,17 @@ pub fn resolve_entity_state_path(
         }
     }
 
-    let source_root = derive_source_root(&entity.source.path, &entity.source.format);
+    let resolved_source = resolver.resolve_path(
+        &entity.name,
+        "entity.source.path",
+        entity.source.storage.as_deref(),
+        &entity.source.path,
+    )?;
+    let source_root = derive_source_root(
+        &entity.source.path,
+        &entity.source.format,
+        resolved_source.local_path.as_deref(),
+    );
     let default_path = join_state_path(&source_root, &entity.name);
     resolver.resolve_path(
         &entity.name,
@@ -100,7 +110,11 @@ fn join_state_path(source_root: &str, entity_name: &str) -> String {
     }
 }
 
-fn derive_source_root(raw_path: &str, source_format: &str) -> String {
+fn derive_source_root(
+    raw_path: &str,
+    source_format: &str,
+    resolved_local_path: Option<&Path>,
+) -> String {
     let trimmed = raw_path.trim_end_matches('/');
     if trimmed.is_empty() {
         return String::new();
@@ -119,7 +133,9 @@ fn derive_source_root(raw_path: &str, source_format: &str) -> String {
             .to_string();
     }
 
-    if matches_source_file_suffix(trimmed, source_format) {
+    if resolved_local_path.is_some_and(|path| path.is_file())
+        || matches_source_file_suffix(trimmed, source_format)
+    {
         return parent_like(trimmed)
             .unwrap_or(trimmed)
             .trim_end_matches('/')

--- a/crates/floe-core/src/state/mod.rs
+++ b/crates/floe-core/src/state/mod.rs
@@ -105,7 +105,7 @@ fn join_state_path(source_root: &str, entity_name: &str) -> String {
     } else {
         format!(
             "{}/.floe/state/{entity_name}/{ENTITY_STATE_FILENAME}",
-            source_root.trim_end_matches('/')
+            source_root.trim_end_matches(is_path_separator)
         )
     }
 }
@@ -115,7 +115,7 @@ fn derive_source_root(
     source_format: &str,
     resolved_local_path: Option<&Path>,
 ) -> String {
-    let trimmed = raw_path.trim_end_matches('/');
+    let trimmed = raw_path.trim_end_matches(is_path_separator);
     if trimmed.is_empty() {
         return String::new();
     }
@@ -124,12 +124,12 @@ fn derive_source_root(
         if prefix.is_empty() {
             return String::new();
         }
-        if prefix.ends_with('/') {
-            return prefix.trim_end_matches('/').to_string();
+        if prefix.ends_with(is_path_separator) {
+            return prefix.trim_end_matches(is_path_separator).to_string();
         }
         return parent_like(prefix)
             .unwrap_or(prefix)
-            .trim_end_matches('/')
+            .trim_end_matches(is_path_separator)
             .to_string();
     }
 
@@ -140,7 +140,7 @@ fn derive_source_root(
         if path.is_file() {
             return parent_like(trimmed)
                 .unwrap_or(trimmed)
-                .trim_end_matches('/')
+                .trim_end_matches(is_path_separator)
                 .to_string();
         }
     }
@@ -148,7 +148,7 @@ fn derive_source_root(
     if matches_source_file_suffix(trimmed, source_format) {
         return parent_like(trimmed)
             .unwrap_or(trimmed)
-            .trim_end_matches('/')
+            .trim_end_matches(is_path_separator)
             .to_string();
     }
 
@@ -161,17 +161,30 @@ fn prefix_before_first_glob(value: &str) -> Option<&str> {
 }
 
 fn matches_source_file_suffix(value: &str, source_format: &str) -> bool {
-    let Some(segment) = value.rsplit('/').next() else {
+    let Some(segment) = value.rsplit(is_path_separator).next() else {
         return false;
     };
+    let segment = segment.to_ascii_lowercase();
 
     extensions::suffixes_for_format(source_format)
-        .map(|suffixes| suffixes.iter().any(|suffix| segment.ends_with(suffix)))
+        .map(|suffixes| {
+            suffixes
+                .iter()
+                .any(|suffix| segment.ends_with(&suffix.to_ascii_lowercase()))
+        })
         .unwrap_or(false)
 }
 
 fn parent_like(value: &str) -> Option<&str> {
-    value
-        .rfind('/')
-        .map(|index| if index == 0 { "/" } else { &value[..index] })
+    value.rfind(is_path_separator).map(|index| {
+        if index == 0 {
+            &value[..1]
+        } else {
+            &value[..index]
+        }
+    })
+}
+
+fn is_path_separator(ch: char) -> bool {
+    ch == '/' || ch == '\\'
 }

--- a/crates/floe-core/tests/unit/config/adls_validation.rs
+++ b/crates/floe-core/tests/unit/config/adls_validation.rs
@@ -6,6 +6,7 @@ fn base_entity() -> config::EntityConfig {
         metadata: None,
         domain: None,
         incremental_mode: config::IncrementalMode::None,
+        state: None,
         source: config::SourceConfig {
             format: "csv".to_string(),
             path: "in.csv".to_string(),

--- a/crates/floe-core/tests/unit/config/catalogs.rs
+++ b/crates/floe-core/tests/unit/config/catalogs.rs
@@ -51,6 +51,7 @@ fn entity() -> config::EntityConfig {
         metadata: None,
         domain: Some("Sales Ops".to_string()),
         incremental_mode: config::IncrementalMode::None,
+        state: None,
         source: config::SourceConfig {
             format: "csv".to_string(),
             path: "in".to_string(),

--- a/crates/floe-core/tests/unit/config/config_validation.rs
+++ b/crates/floe-core/tests/unit/config/config_validation.rs
@@ -206,6 +206,39 @@ fn invalid_source_format_errors() {
 }
 
 #[test]
+fn empty_entity_state_path_errors() {
+    let entity = r#"  - name: "customer"
+    state:
+      path: ""
+    source:
+      format: "csv"
+      path: "/tmp/input"
+    sink:
+      accepted:
+        format: "parquet"
+        path: "/tmp/out"
+      rejected:
+        format: "csv"
+        path: "/tmp/rejected"
+    policy:
+      severity: "warn"
+    schema:
+      columns:
+        - name: "customer_id"
+          type: "string"
+"#;
+    let yaml = base_config(entity);
+    assert_validation_error(
+        &yaml,
+        &[
+            "entity.name=customer",
+            "entity.state.path",
+            "must not be empty",
+        ],
+    );
+}
+
+#[test]
 fn unsupported_incremental_mode_errors() {
     let entity = r#"  - name: "customer"
     incremental_mode: "batch"

--- a/crates/floe-core/tests/unit/config/parse.rs
+++ b/crates/floe-core/tests/unit/config/parse.rs
@@ -248,6 +248,41 @@ entities:
 }
 
 #[test]
+fn parse_config_supports_entity_state_path_override() {
+    let yaml = r#"
+version: "0.1"
+entities:
+  - name: "customer"
+    incremental_mode: "file"
+    state:
+      path: "custom/state/customer.json"
+    source:
+      format: "csv"
+      path: "/tmp/input"
+    sink:
+      accepted:
+        format: "parquet"
+        path: "/tmp/out"
+    policy:
+      severity: "warn"
+    schema:
+      columns:
+        - name: "customer_id"
+          type: "string"
+"#;
+    let path = write_temp_config(yaml);
+    let config = load_config(&path).expect("parse config");
+
+    assert_eq!(
+        config.entities[0]
+            .state
+            .as_ref()
+            .and_then(|state| state.path.as_deref()),
+        Some("custom/state/customer.json")
+    );
+}
+
+#[test]
 fn parse_config_supports_sink_level_merge_scd1_write_mode() {
     let yaml = r#"
 version: "0.1"

--- a/crates/floe-core/tests/unit/config/parse.rs
+++ b/crates/floe-core/tests/unit/config/parse.rs
@@ -6,7 +6,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use floe_core::config::{
     IncrementalMode, SchemaEvolutionIncompatibleAction, SchemaEvolutionMode, WriteMode,
 };
-use floe_core::load_config;
+use floe_core::{load_config, validate_config_for_tests};
 
 static TEMP_CONFIG_SEQ: AtomicU64 = AtomicU64::new(0);
 
@@ -280,6 +280,39 @@ entities:
             .and_then(|state| state.path.as_deref()),
         Some("custom/state/customer.json")
     );
+}
+
+#[test]
+fn parse_config_rejects_empty_entity_state_path_during_validation() {
+    let yaml = r#"
+version: "0.1"
+entities:
+  - name: "customer"
+    incremental_mode: "file"
+    state:
+      path: ""
+    source:
+      format: "csv"
+      path: "/tmp/input"
+    sink:
+      accepted:
+        format: "parquet"
+        path: "/tmp/out"
+    policy:
+      severity: "warn"
+    schema:
+      columns:
+        - name: "customer_id"
+          type: "string"
+"#;
+    let path = write_temp_config(yaml);
+    let config = load_config(&path).expect("parse config");
+    let err =
+        validate_config_for_tests(&config).expect_err("empty state.path should fail validation");
+
+    assert!(err
+        .to_string()
+        .contains("entity.state.path must not be empty"));
 }
 
 #[test]

--- a/crates/floe-core/tests/unit/io/storage/inputs.rs
+++ b/crates/floe-core/tests/unit/io/storage/inputs.rs
@@ -206,6 +206,7 @@ fn mock_entity(name: &str) -> config::EntityConfig {
         metadata: None,
         domain: None,
         incremental_mode: config::IncrementalMode::None,
+        state: None,
         source: config::SourceConfig {
             format: "csv".to_string(),
             path: "unused".to_string(),

--- a/crates/floe-core/tests/unit/io/write/delta_write.rs
+++ b/crates/floe-core/tests/unit/io/write/delta_write.rs
@@ -639,6 +639,7 @@ fn build_entity(
         metadata: None,
         domain: None,
         incremental_mode: config::IncrementalMode::None,
+        state: None,
         source: config::SourceConfig {
             format: "csv".to_string(),
             path: "in".to_string(),

--- a/crates/floe-core/tests/unit/io/write/iceberg_write.rs
+++ b/crates/floe-core/tests/unit/io/write/iceberg_write.rs
@@ -442,6 +442,7 @@ fn build_entity(
         metadata: None,
         domain: None,
         incremental_mode: config::IncrementalMode::None,
+        state: None,
         source: config::SourceConfig {
             format: "csv".to_string(),
             path: "in".to_string(),

--- a/crates/floe-core/tests/unit/io/write/object_store.rs
+++ b/crates/floe-core/tests/unit/io/write/object_store.rs
@@ -42,6 +42,7 @@ fn delta_store_config_builds_s3_url_and_options() -> FloeResult<()> {
         metadata: None,
         domain: None,
         incremental_mode: config::IncrementalMode::None,
+        state: None,
         source: config::SourceConfig {
             format: "csv".to_string(),
             path: "in".to_string(),
@@ -103,6 +104,7 @@ fn iceberg_store_config_builds_s3_warehouse_and_region_props() -> FloeResult<()>
         metadata: None,
         domain: None,
         incremental_mode: config::IncrementalMode::None,
+        state: None,
         source: config::SourceConfig {
             format: "csv".to_string(),
             path: "in".to_string(),
@@ -176,6 +178,7 @@ fn delta_store_config_builds_local_url() -> FloeResult<()> {
         metadata: None,
         domain: None,
         incremental_mode: config::IncrementalMode::None,
+        state: None,
         source: config::SourceConfig {
             format: "csv".to_string(),
             path: "in".to_string(),
@@ -238,6 +241,7 @@ fn iceberg_store_config_builds_local_warehouse_without_props() -> FloeResult<()>
         metadata: None,
         domain: None,
         incremental_mode: config::IncrementalMode::None,
+        state: None,
         source: config::SourceConfig {
             format: "csv".to_string(),
             path: "in".to_string(),
@@ -312,6 +316,7 @@ fn delta_store_config_builds_adls_url_and_options() -> FloeResult<()> {
         metadata: None,
         domain: None,
         incremental_mode: config::IncrementalMode::None,
+        state: None,
         source: config::SourceConfig {
             format: "csv".to_string(),
             path: "in".to_string(),
@@ -402,6 +407,7 @@ fn iceberg_store_config_builds_gcs_warehouse_without_props() -> FloeResult<()> {
         metadata: None,
         domain: None,
         incremental_mode: config::IncrementalMode::None,
+        state: None,
         source: config::SourceConfig {
             format: "csv".to_string(),
             path: "in".to_string(),
@@ -479,6 +485,7 @@ fn iceberg_store_config_rejects_adls_target() -> FloeResult<()> {
         metadata: None,
         domain: None,
         incremental_mode: config::IncrementalMode::None,
+        state: None,
         source: config::SourceConfig {
             format: "csv".to_string(),
             path: "in".to_string(),
@@ -552,6 +559,7 @@ fn delta_store_config_builds_gcs_url() -> FloeResult<()> {
         metadata: None,
         domain: None,
         incremental_mode: config::IncrementalMode::None,
+        state: None,
         source: config::SourceConfig {
             format: "csv".to_string(),
             path: "in".to_string(),

--- a/crates/floe-core/tests/unit/io/write/rejected_csv.rs
+++ b/crates/floe-core/tests/unit/io/write/rejected_csv.rs
@@ -12,6 +12,7 @@ fn sample_entity() -> config::EntityConfig {
         metadata: None,
         domain: None,
         incremental_mode: config::IncrementalMode::None,
+        state: None,
         source: config::SourceConfig {
             format: "csv".to_string(),
             path: "in".to_string(),

--- a/crates/floe-core/tests/unit/mod.rs
+++ b/crates/floe-core/tests/unit/mod.rs
@@ -5,4 +5,5 @@ pub mod profile;
 pub mod report;
 pub mod run;
 pub mod runner;
+pub mod state;
 pub mod vars;

--- a/crates/floe-core/tests/unit/state/mod.rs
+++ b/crates/floe-core/tests/unit/state/mod.rs
@@ -18,6 +18,17 @@ fn load_config_from_yaml(
     load_config(&path).expect("load config")
 }
 
+fn build_local_resolver(
+    temp_dir: &tempfile::TempDir,
+    yaml: &str,
+) -> (floe_core::config::RootConfig, StorageResolver) {
+    let config = load_config_from_yaml(temp_dir, yaml);
+    let config_path = temp_dir.path().join("floe.yml");
+    let resolver =
+        StorageResolver::new(&config, ConfigBase::local_from_path(&config_path)).expect("resolver");
+    (config, resolver)
+}
+
 #[test]
 fn resolves_default_entity_state_path_from_local_source_directory() {
     let temp_dir = tempfile::TempDir::new().expect("temp dir");
@@ -105,6 +116,7 @@ entities:
 fn resolves_default_entity_state_path_from_dotted_source_directory() {
     let temp_dir = tempfile::TempDir::new().expect("temp dir");
     let source_dir = temp_dir.path().join("incoming/v1.2");
+    fs::create_dir_all(&source_dir).expect("create dotted dir");
     let yaml = format!(
         r#"version: "0.1"
 entities:
@@ -127,16 +139,99 @@ entities:
         source_dir.display(),
         temp_dir.path().join("out").display()
     );
-    let config = load_config_from_yaml(&temp_dir, &yaml);
-    let config_path = temp_dir.path().join("floe.yml");
-    let resolver =
-        StorageResolver::new(&config, ConfigBase::local_from_path(&config_path)).expect("resolver");
+    let (config, resolver) = build_local_resolver(&temp_dir, &yaml);
 
     let resolved = resolve_entity_state_path(&resolver, &config.entities[0]).expect("state path");
 
     assert_eq!(
         resolved.local_path.as_deref(),
         Some(source_dir.join(".floe/state/sales/state.json").as_path())
+    );
+}
+
+#[test]
+fn resolves_default_entity_state_path_from_local_file_with_uppercase_extension() {
+    let temp_dir = tempfile::TempDir::new().expect("temp dir");
+    let source_file = temp_dir.path().join("incoming/INPUT.CSV");
+    fs::create_dir_all(source_file.parent().expect("parent")).expect("create parent");
+    fs::write(&source_file, "id\n1\n").expect("write source file");
+    let yaml = format!(
+        r#"version: "0.1"
+entities:
+  - name: "sales"
+    incremental_mode: "file"
+    source:
+      format: "csv"
+      path: "{}"
+    sink:
+      accepted:
+        format: "parquet"
+        path: "{}"
+    policy:
+      severity: "warn"
+    schema:
+      columns:
+        - name: "id"
+          type: "string"
+"#,
+        source_file.display(),
+        temp_dir.path().join("out").display()
+    );
+    let (config, resolver) = build_local_resolver(&temp_dir, &yaml);
+
+    let resolved = resolve_entity_state_path(&resolver, &config.entities[0]).expect("state path");
+
+    assert_eq!(
+        resolved.local_path.as_deref(),
+        Some(
+            temp_dir
+                .path()
+                .join("incoming/.floe/state/sales/state.json")
+                .as_path()
+        )
+    );
+}
+
+#[test]
+fn resolves_default_entity_state_path_from_local_extensionless_file() {
+    let temp_dir = tempfile::TempDir::new().expect("temp dir");
+    let source_file = temp_dir.path().join("incoming/manifest");
+    fs::create_dir_all(source_file.parent().expect("parent")).expect("create parent");
+    fs::write(&source_file, "id\n1\n").expect("write source file");
+    let yaml = format!(
+        r#"version: "0.1"
+entities:
+  - name: "sales"
+    incremental_mode: "file"
+    source:
+      format: "csv"
+      path: "{}"
+    sink:
+      accepted:
+        format: "parquet"
+        path: "{}"
+    policy:
+      severity: "warn"
+    schema:
+      columns:
+        - name: "id"
+          type: "string"
+"#,
+        source_file.display(),
+        temp_dir.path().join("out").display()
+    );
+    let (config, resolver) = build_local_resolver(&temp_dir, &yaml);
+
+    let resolved = resolve_entity_state_path(&resolver, &config.entities[0]).expect("state path");
+
+    assert_eq!(
+        resolved.local_path.as_deref(),
+        Some(
+            temp_dir
+                .path()
+                .join("incoming/.floe/state/sales/state.json")
+                .as_path()
+        )
     );
 }
 

--- a/crates/floe-core/tests/unit/state/mod.rs
+++ b/crates/floe-core/tests/unit/state/mod.rs
@@ -236,6 +236,43 @@ entities:
 }
 
 #[test]
+fn resolves_default_entity_state_path_from_local_directory_with_file_like_suffix() {
+    let temp_dir = tempfile::TempDir::new().expect("temp dir");
+    let source_dir = temp_dir.path().join("landing/archive.csv");
+    fs::create_dir_all(&source_dir).expect("create source dir");
+    let yaml = format!(
+        r#"version: "0.1"
+entities:
+  - name: "sales"
+    incremental_mode: "file"
+    source:
+      format: "csv"
+      path: "{}/"
+    sink:
+      accepted:
+        format: "parquet"
+        path: "{}"
+    policy:
+      severity: "warn"
+    schema:
+      columns:
+        - name: "id"
+          type: "string"
+"#,
+        source_dir.display(),
+        temp_dir.path().join("out").display()
+    );
+    let (config, resolver) = build_local_resolver(&temp_dir, &yaml);
+
+    let resolved = resolve_entity_state_path(&resolver, &config.entities[0]).expect("state path");
+
+    assert_eq!(
+        resolved.local_path.as_deref(),
+        Some(source_dir.join(".floe/state/sales/state.json").as_path())
+    );
+}
+
+#[test]
 fn resolves_default_entity_state_path_from_hidden_source_directory() {
     let temp_dir = tempfile::TempDir::new().expect("temp dir");
     let source_dir = temp_dir.path().join("data/.snapshot");

--- a/crates/floe-core/tests/unit/state/mod.rs
+++ b/crates/floe-core/tests/unit/state/mod.rs
@@ -1,0 +1,349 @@
+use std::collections::BTreeMap;
+use std::fs;
+use std::path::Path;
+
+use floe_core::config::{ConfigBase, StorageResolver};
+use floe_core::load_config;
+use floe_core::state::{
+    read_entity_state, resolve_entity_state_path, write_entity_state_atomic, EntityFileState,
+    EntityState, ENTITY_STATE_SCHEMA_V1,
+};
+
+fn load_config_from_yaml(
+    temp_dir: &tempfile::TempDir,
+    yaml: &str,
+) -> floe_core::config::RootConfig {
+    let path = temp_dir.path().join("floe.yml");
+    fs::write(&path, yaml).expect("write config");
+    load_config(&path).expect("load config")
+}
+
+#[test]
+fn resolves_default_entity_state_path_from_local_source_directory() {
+    let temp_dir = tempfile::TempDir::new().expect("temp dir");
+    let source_dir = temp_dir.path().join("incoming");
+    let yaml = format!(
+        r#"version: "0.1"
+entities:
+  - name: "sales"
+    incremental_mode: "file"
+    source:
+      format: "csv"
+      path: "{}"
+    sink:
+      accepted:
+        format: "parquet"
+        path: "{}"
+    policy:
+      severity: "warn"
+    schema:
+      columns:
+        - name: "id"
+          type: "string"
+"#,
+        source_dir.display(),
+        temp_dir.path().join("out").display()
+    );
+    let config = load_config_from_yaml(&temp_dir, &yaml);
+    let resolver = StorageResolver::new(
+        &config,
+        ConfigBase::local_from_path(&temp_dir.path().join("floe.yml")),
+    )
+    .expect("resolver");
+
+    let resolved = resolve_entity_state_path(&resolver, &config.entities[0]).expect("state path");
+
+    assert_eq!(
+        resolved.local_path.as_deref(),
+        Some(source_dir.join(".floe/state/sales/state.json").as_path())
+    );
+}
+
+#[test]
+fn resolves_default_entity_state_path_from_glob_source_prefix() {
+    let temp_dir = tempfile::TempDir::new().expect("temp dir");
+    let yaml = format!(
+        r#"version: "0.1"
+entities:
+  - name: "sales"
+    incremental_mode: "file"
+    source:
+      format: "csv"
+      path: "incoming/*.csv"
+    sink:
+      accepted:
+        format: "parquet"
+        path: "{}"
+    policy:
+      severity: "warn"
+    schema:
+      columns:
+        - name: "id"
+          type: "string"
+"#,
+        temp_dir.path().join("out").display()
+    );
+    let config = load_config_from_yaml(&temp_dir, &yaml);
+    let config_path = temp_dir.path().join("floe.yml");
+    let resolver =
+        StorageResolver::new(&config, ConfigBase::local_from_path(&config_path)).expect("resolver");
+
+    let resolved = resolve_entity_state_path(&resolver, &config.entities[0]).expect("state path");
+
+    assert_eq!(
+        resolved.local_path.as_deref(),
+        Some(
+            temp_dir
+                .path()
+                .join("incoming/.floe/state/sales/state.json")
+                .as_path()
+        )
+    );
+}
+
+#[test]
+fn resolves_default_entity_state_path_from_dotted_source_directory() {
+    let temp_dir = tempfile::TempDir::new().expect("temp dir");
+    let source_dir = temp_dir.path().join("incoming/v1.2");
+    let yaml = format!(
+        r#"version: "0.1"
+entities:
+  - name: "sales"
+    incremental_mode: "file"
+    source:
+      format: "csv"
+      path: "{}"
+    sink:
+      accepted:
+        format: "parquet"
+        path: "{}"
+    policy:
+      severity: "warn"
+    schema:
+      columns:
+        - name: "id"
+          type: "string"
+"#,
+        source_dir.display(),
+        temp_dir.path().join("out").display()
+    );
+    let config = load_config_from_yaml(&temp_dir, &yaml);
+    let config_path = temp_dir.path().join("floe.yml");
+    let resolver =
+        StorageResolver::new(&config, ConfigBase::local_from_path(&config_path)).expect("resolver");
+
+    let resolved = resolve_entity_state_path(&resolver, &config.entities[0]).expect("state path");
+
+    assert_eq!(
+        resolved.local_path.as_deref(),
+        Some(source_dir.join(".floe/state/sales/state.json").as_path())
+    );
+}
+
+#[test]
+fn resolves_default_entity_state_path_from_hidden_source_directory() {
+    let temp_dir = tempfile::TempDir::new().expect("temp dir");
+    let source_dir = temp_dir.path().join("data/.snapshot");
+    let yaml = format!(
+        r#"version: "0.1"
+entities:
+  - name: "sales"
+    incremental_mode: "file"
+    source:
+      format: "csv"
+      path: "{}"
+    sink:
+      accepted:
+        format: "parquet"
+        path: "{}"
+    policy:
+      severity: "warn"
+    schema:
+      columns:
+        - name: "id"
+          type: "string"
+"#,
+        source_dir.display(),
+        temp_dir.path().join("out").display()
+    );
+    let config = load_config_from_yaml(&temp_dir, &yaml);
+    let config_path = temp_dir.path().join("floe.yml");
+    let resolver =
+        StorageResolver::new(&config, ConfigBase::local_from_path(&config_path)).expect("resolver");
+
+    let resolved = resolve_entity_state_path(&resolver, &config.entities[0]).expect("state path");
+
+    assert_eq!(
+        resolved.local_path.as_deref(),
+        Some(source_dir.join(".floe/state/sales/state.json").as_path())
+    );
+}
+
+#[test]
+fn resolves_default_entity_state_path_from_explicit_source_file() {
+    let temp_dir = tempfile::TempDir::new().expect("temp dir");
+    let source_file = temp_dir.path().join("incoming/v1.2.csv");
+    let yaml = format!(
+        r#"version: "0.1"
+entities:
+  - name: "sales"
+    incremental_mode: "file"
+    source:
+      format: "csv"
+      path: "{}"
+    sink:
+      accepted:
+        format: "parquet"
+        path: "{}"
+    policy:
+      severity: "warn"
+    schema:
+      columns:
+        - name: "id"
+          type: "string"
+"#,
+        source_file.display(),
+        temp_dir.path().join("out").display()
+    );
+    let config = load_config_from_yaml(&temp_dir, &yaml);
+    let config_path = temp_dir.path().join("floe.yml");
+    let resolver =
+        StorageResolver::new(&config, ConfigBase::local_from_path(&config_path)).expect("resolver");
+
+    let resolved = resolve_entity_state_path(&resolver, &config.entities[0]).expect("state path");
+
+    assert_eq!(
+        resolved.local_path.as_deref(),
+        Some(
+            temp_dir
+                .path()
+                .join("incoming/.floe/state/sales/state.json")
+                .as_path()
+        )
+    );
+}
+
+#[test]
+fn resolves_default_entity_state_path_from_remote_source_context() {
+    let temp_dir = tempfile::TempDir::new().expect("temp dir");
+    let yaml = r#"version: "0.1"
+storages:
+  default: "lake"
+  definitions:
+    - name: "lake"
+      type: "s3"
+      bucket: "raw-bucket"
+      prefix: "landing"
+entities:
+  - name: "sales"
+    incremental_mode: "file"
+    source:
+      format: "csv"
+      path: "incoming/sales"
+    sink:
+      accepted:
+        format: "parquet"
+        path: "curated/sales"
+    policy:
+      severity: "warn"
+    schema:
+      columns:
+        - name: "id"
+          type: "string"
+"#;
+    let config = load_config_from_yaml(&temp_dir, yaml);
+    let config_path = temp_dir.path().join("floe.yml");
+    let resolver =
+        StorageResolver::new(&config, ConfigBase::local_from_path(&config_path)).expect("resolver");
+
+    let resolved = resolve_entity_state_path(&resolver, &config.entities[0]).expect("state path");
+
+    assert_eq!(
+        resolved.uri,
+        "s3://raw-bucket/landing/incoming/sales/.floe/state/sales/state.json"
+    );
+}
+
+#[test]
+fn resolves_entity_state_path_override() {
+    let temp_dir = tempfile::TempDir::new().expect("temp dir");
+    let yaml = format!(
+        r#"version: "0.1"
+entities:
+  - name: "sales"
+    incremental_mode: "file"
+    state:
+      path: "custom/state/sales.json"
+    source:
+      format: "csv"
+      path: "incoming"
+    sink:
+      accepted:
+        format: "parquet"
+        path: "{}"
+    policy:
+      severity: "warn"
+    schema:
+      columns:
+        - name: "id"
+          type: "string"
+"#,
+        temp_dir.path().join("out").display()
+    );
+    let config = load_config_from_yaml(&temp_dir, &yaml);
+    let config_path = temp_dir.path().join("floe.yml");
+    let resolver =
+        StorageResolver::new(&config, ConfigBase::local_from_path(&config_path)).expect("resolver");
+
+    let resolved = resolve_entity_state_path(&resolver, &config.entities[0]).expect("state path");
+
+    assert_eq!(
+        resolved.local_path.as_deref(),
+        Some(temp_dir.path().join("custom/state/sales.json").as_path())
+    );
+}
+
+#[test]
+fn writes_and_reads_entity_state_atomically() {
+    let temp_dir = tempfile::TempDir::new().expect("temp dir");
+    let state_path = temp_dir
+        .path()
+        .join("incoming/.floe/state/sales/state.json");
+    let mut files = BTreeMap::new();
+    files.insert(
+        "local:///tmp/sales.csv".to_string(),
+        EntityFileState {
+            processed_at: "2026-04-20T12:59:14Z".to_string(),
+            size: Some(182731),
+            mtime: Some("2026-04-20T11:30:00Z".to_string()),
+        },
+    );
+    let state = EntityState {
+        schema: ENTITY_STATE_SCHEMA_V1.to_string(),
+        entity: "sales".to_string(),
+        updated_at: Some("2026-04-20T13:00:00Z".to_string()),
+        files,
+    };
+
+    write_entity_state_atomic(&state_path, &state).expect("write state");
+    let loaded = read_entity_state(&state_path)
+        .expect("read state")
+        .expect("state exists");
+
+    assert_eq!(loaded, state);
+    assert!(Path::new(&state_path).exists());
+    assert_eq!(
+        fs::read_dir(state_path.parent().expect("parent"))
+            .expect("read dir")
+            .filter_map(Result::ok)
+            .count(),
+        1
+    );
+}
+
+#[test]
+fn read_entity_state_returns_none_when_missing() {
+    let temp_dir = tempfile::TempDir::new().expect("temp dir");
+    let missing = temp_dir.path().join("missing/state.json");
+    assert!(read_entity_state(&missing).expect("read missing").is_none());
+}

--- a/crates/floe-core/tests/unit/state/mod.rs
+++ b/crates/floe-core/tests/unit/state/mod.rs
@@ -356,6 +356,92 @@ entities:
 }
 
 #[test]
+fn resolves_default_entity_state_path_from_windows_style_source_file() {
+    let temp_dir = tempfile::TempDir::new().expect("temp dir");
+    let yaml = format!(
+        r#"version: "0.1"
+entities:
+  - name: "sales"
+    incremental_mode: "file"
+    source:
+      format: "csv"
+      path: 'C:\data\INPUT.CSV'
+    sink:
+      accepted:
+        format: "parquet"
+        path: "{}"
+    policy:
+      severity: "warn"
+    schema:
+      columns:
+        - name: "id"
+          type: "string"
+"#,
+        temp_dir.path().join("out").display()
+    );
+    let config = load_config_from_yaml(&temp_dir, &yaml);
+    let config_path = temp_dir.path().join("floe.yml");
+    let resolver =
+        StorageResolver::new(&config, ConfigBase::local_from_path(&config_path)).expect("resolver");
+
+    let resolved = resolve_entity_state_path(&resolver, &config.entities[0]).expect("state path");
+
+    assert_eq!(
+        resolved.local_path.as_deref(),
+        Some(
+            temp_dir
+                .path()
+                .join(r"C:\data")
+                .join(".floe/state/sales/state.json")
+                .as_path()
+        )
+    );
+}
+
+#[test]
+fn resolves_default_entity_state_path_from_windows_style_glob_prefix() {
+    let temp_dir = tempfile::TempDir::new().expect("temp dir");
+    let yaml = format!(
+        r#"version: "0.1"
+entities:
+  - name: "sales"
+    incremental_mode: "file"
+    source:
+      format: "csv"
+      path: 'C:\data\*.csv'
+    sink:
+      accepted:
+        format: "parquet"
+        path: "{}"
+    policy:
+      severity: "warn"
+    schema:
+      columns:
+        - name: "id"
+          type: "string"
+"#,
+        temp_dir.path().join("out").display()
+    );
+    let config = load_config_from_yaml(&temp_dir, &yaml);
+    let config_path = temp_dir.path().join("floe.yml");
+    let resolver =
+        StorageResolver::new(&config, ConfigBase::local_from_path(&config_path)).expect("resolver");
+
+    let resolved = resolve_entity_state_path(&resolver, &config.entities[0]).expect("state path");
+
+    assert_eq!(
+        resolved.local_path.as_deref(),
+        Some(
+            temp_dir
+                .path()
+                .join(r"C:\data")
+                .join(".floe/state/sales/state.json")
+                .as_path()
+        )
+    );
+}
+
+#[test]
 fn resolves_default_entity_state_path_from_remote_source_context() {
     let temp_dir = tempfile::TempDir::new().expect("temp dir");
     let yaml = r#"version: "0.1"


### PR DESCRIPTION
## Summary
- add a dedicated entity state module with versioned JSON models
- derive source-local default state paths and support optional entity.state.path overrides
- add atomic local read/write helpers and focused unit coverage

## Notes
- this branch includes the incremental mode config contract commit from PR1 as its base

## Testing
- cargo test -p floe-core unit::state:: -- --nocapture
- cargo test -p floe-core parse_config_supports_entity_state_path_override -- --nocapture