### PR TITLE
feat(incremental): implement file-based incremental ingestion

### DIFF
--- a/crates/floe-core/src/config/storage.rs
+++ b/crates/floe-core/src/config/storage.rs
@@ -138,6 +138,10 @@ impl StorageResolver {
         self.config_base.local_dir()
     }
 
+    pub fn config_is_remote(&self) -> bool {
+        self.config_base.remote_base().is_some()
+    }
+
     pub fn resolve_local_path(&self, raw_path: &str) -> FloeResult<ResolvedPath> {
         if is_remote_uri(raw_path) {
             return Err(Box::new(ConfigError(format!(

--- a/crates/floe-core/src/config/storage.rs
+++ b/crates/floe-core/src/config/storage.rs
@@ -134,6 +134,30 @@ pub struct StorageResolver {
 }
 
 impl StorageResolver {
+    pub fn config_local_dir(&self) -> &Path {
+        self.config_base.local_dir()
+    }
+
+    pub fn resolve_local_path(&self, raw_path: &str) -> FloeResult<ResolvedPath> {
+        if is_remote_uri(raw_path) {
+            return Err(Box::new(ConfigError(format!(
+                "entity.state.path must be a local path (got {})",
+                raw_path
+            ))));
+        }
+        if self.config_base.remote_base().is_some() && Path::new(raw_path).is_relative() {
+            return Err(Box::new(ConfigError(
+                "entity.state.path must be absolute when config is remote".to_string(),
+            )));
+        }
+        let resolved = resolve_local_path(self.config_base.local_dir(), raw_path);
+        Ok(ResolvedPath {
+            storage: "local".to_string(),
+            uri: local_uri(&resolved),
+            local_path: Some(resolved),
+        })
+    }
+
     pub fn new(config: &RootConfig, config_base: ConfigBase) -> FloeResult<Self> {
         if let Some(storages) = &config.storages {
             let mut definitions = HashMap::new();

--- a/crates/floe-core/src/io/format.rs
+++ b/crates/floe-core/src/io/format.rs
@@ -13,6 +13,8 @@ pub struct InputFile {
     pub source_local_path: PathBuf,
     pub source_name: String,
     pub source_stem: String,
+    pub source_size: Option<u64>,
+    pub source_mtime: Option<String>,
 }
 
 #[derive(Debug, Clone)]

--- a/crates/floe-core/src/io/storage/ops/inputs.rs
+++ b/crates/floe-core/src/io/storage/ops/inputs.rs
@@ -1,4 +1,5 @@
 use std::path::{Path, PathBuf};
+use std::time::SystemTime;
 
 use glob::{MatchOptions, Pattern};
 
@@ -209,6 +210,8 @@ fn build_cloud_inputs(
             source_local_path: local_path,
             source_name,
             source_stem,
+            source_size: object.size,
+            source_mtime: object.last_modified.clone(),
         });
     }
     Ok(inputs)
@@ -223,6 +226,7 @@ fn build_local_inputs(
         .iter()
         .map(|path| {
             let normalized_path = crate::io::storage::paths::normalize_local_path(path);
+            let metadata = std::fs::metadata(&normalized_path).ok();
             let source_name = path
                 .file_name()
                 .and_then(|name| name.to_str())
@@ -245,9 +249,20 @@ fn build_local_inputs(
                 source_local_path: normalized_path,
                 source_name,
                 source_stem,
+                source_size: metadata.as_ref().map(|metadata| metadata.len()),
+                source_mtime: metadata
+                    .as_ref()
+                    .and_then(|metadata| metadata.modified().ok())
+                    .and_then(system_time_to_rfc3339),
             }
         })
         .collect()
+}
+
+fn system_time_to_rfc3339(value: SystemTime) -> Option<String> {
+    time::OffsetDateTime::from(value)
+        .format(&time::format_description::well_known::Rfc3339)
+        .ok()
 }
 
 fn build_local_listing(

--- a/crates/floe-core/src/run/entity/accepted_write.rs
+++ b/crates/floe-core/src/run/entity/accepted_write.rs
@@ -110,6 +110,7 @@ pub(super) struct AcceptedWritePhaseContext<'a> {
     pub(super) write_mode: config::WriteMode,
     pub(super) perf_enabled: bool,
     pub(super) phase_timings: &'a mut EntityPhaseTimings,
+    pub(super) pending_input_count: usize,
     pub(super) accepted_accum: Vec<DataFrame>,
 }
 
@@ -126,10 +127,15 @@ pub(super) fn run_accepted_write_phase(
         write_mode,
         perf_enabled,
         phase_timings,
+        pending_input_count,
         accepted_accum,
     } = context;
 
     let mut accepted_write_report = AcceptedWriteReportState::for_entity(entity, write_mode);
+    if pending_input_count == 0 {
+        accepted_write_report.files_written = Some(0);
+        return Ok(accepted_write_report);
+    }
     if accepted_accum.is_empty() && write_mode != config::WriteMode::Overwrite {
         accepted_write_report.files_written = Some(0);
         return Ok(accepted_write_report);

--- a/crates/floe-core/src/run/entity/incremental.rs
+++ b/crates/floe-core/src/run/entity/incremental.rs
@@ -39,8 +39,10 @@ pub(super) fn prepare_incremental_context(
             entity.name
         ))) as Box<dyn std::error::Error + Send + Sync>
     })?;
-    let existing =
-        read_entity_state(&state_path)?.unwrap_or_else(|| EntityState::new(&entity.name));
+    let existing = read_entity_state(&state_path)?
+        .map(|state| validate_loaded_state(entity, &state_path, state))
+        .transpose()?
+        .unwrap_or_else(|| EntityState::new(&entity.name));
 
     let mut pending_inputs = Vec::new();
     let mut skipped_reports = Vec::new();
@@ -96,6 +98,34 @@ pub(super) fn prepare_incremental_context(
             pending_entries,
         }),
     })
+}
+
+fn validate_loaded_state(
+    entity: &config::EntityConfig,
+    state_path: &std::path::Path,
+    state: EntityState,
+) -> FloeResult<EntityState> {
+    if state.schema != crate::state::ENTITY_STATE_SCHEMA_V1 {
+        return Err(Box::new(crate::ConfigError(format!(
+            "entity.name={} incremental_mode=file state schema mismatch at {}: expected {}, got {}",
+            entity.name,
+            state_path.display(),
+            crate::state::ENTITY_STATE_SCHEMA_V1,
+            state.schema
+        ))));
+    }
+
+    if state.entity != entity.name {
+        return Err(Box::new(crate::ConfigError(format!(
+            "entity.name={} incremental_mode=file state entity mismatch at {}: expected {}, got {}",
+            entity.name,
+            state_path.display(),
+            entity.name,
+            state.entity
+        ))));
+    }
+
+    Ok(state)
 }
 
 fn file_state_matches(recorded: &EntityFileState, input_file: &InputFile) -> bool {

--- a/crates/floe-core/src/run/entity/incremental.rs
+++ b/crates/floe-core/src/run/entity/incremental.rs
@@ -1,0 +1,175 @@
+use std::collections::BTreeMap;
+use std::path::PathBuf;
+
+use crate::config::IncrementalMode;
+use crate::io::format::InputFile;
+use crate::report::{
+    FileMismatch, FileOutput, FileReport, FileStatus, FileValidation, MismatchAction,
+};
+use crate::run::RunContext;
+use crate::state::{
+    read_entity_state, resolve_entity_state_path, write_entity_state_atomic, EntityFileState,
+    EntityState,
+};
+use crate::{config, report, warnings, FloeResult};
+
+pub(super) struct IncrementalContext {
+    pub(super) pending_inputs: Vec<InputFile>,
+    pub(super) skipped_reports: Vec<FileReport>,
+    pub(super) pending_state: Option<PendingEntityState>,
+}
+
+pub(super) fn prepare_incremental_context(
+    context: &RunContext,
+    entity: &config::EntityConfig,
+    input_files: Vec<InputFile>,
+) -> FloeResult<IncrementalContext> {
+    if entity.incremental_mode != IncrementalMode::File {
+        return Ok(IncrementalContext {
+            pending_inputs: input_files,
+            skipped_reports: Vec::new(),
+            pending_state: None,
+        });
+    }
+
+    let resolved_state = resolve_entity_state_path(&context.storage_resolver, entity)?;
+    let state_path = resolved_state.local_path.ok_or_else(|| {
+        Box::new(crate::ConfigError(format!(
+            "entity.name={} incremental_mode=file requires a local state path",
+            entity.name
+        ))) as Box<dyn std::error::Error + Send + Sync>
+    })?;
+    let existing =
+        read_entity_state(&state_path)?.unwrap_or_else(|| EntityState::new(&entity.name));
+
+    let mut pending_inputs = Vec::new();
+    let mut skipped_reports = Vec::new();
+    let mut pending_entries = BTreeMap::new();
+
+    for input_file in input_files {
+        match existing.files.get(&input_file.source_uri) {
+            Some(recorded) if file_state_matches(recorded, &input_file) => {
+                skipped_reports.push(build_skipped_report(input_file.source_uri.clone(), None));
+            }
+            Some(recorded) => {
+                let message = format!(
+                    "entity.name={} incremental_mode=file skipping previously ingested file with changed metadata: {} (recorded size={:?}, mtime={:?}; current size={:?}, mtime={:?})",
+                    entity.name,
+                    input_file.source_uri,
+                    recorded.size,
+                    recorded.mtime,
+                    input_file.source_size,
+                    input_file.source_mtime,
+                );
+                warnings::emit(
+                    &context.run_id,
+                    Some(&entity.name),
+                    Some(&input_file.source_uri),
+                    Some("incremental_file_changed"),
+                    &message,
+                );
+                skipped_reports.push(build_skipped_report(
+                    input_file.source_uri.clone(),
+                    Some(message),
+                ));
+            }
+            None => {
+                pending_entries.insert(
+                    input_file.source_uri.clone(),
+                    PendingFileState {
+                        size: input_file.source_size,
+                        mtime: input_file.source_mtime.clone(),
+                    },
+                );
+                pending_inputs.push(input_file);
+            }
+        }
+    }
+
+    Ok(IncrementalContext {
+        pending_inputs,
+        skipped_reports,
+        pending_state: Some(PendingEntityState {
+            path: state_path,
+            entity_name: entity.name.clone(),
+            base_state: existing,
+            pending_entries,
+        }),
+    })
+}
+
+fn file_state_matches(recorded: &EntityFileState, input_file: &InputFile) -> bool {
+    recorded.size == input_file.source_size && recorded.mtime == input_file.source_mtime
+}
+
+fn build_skipped_report(input_file: String, warning: Option<String>) -> FileReport {
+    let warnings = u64::from(warning.is_some());
+    FileReport {
+        input_file,
+        status: FileStatus::Success,
+        row_count: 0,
+        accepted_count: 0,
+        rejected_count: 0,
+        mismatch: FileMismatch {
+            declared_columns_count: 0,
+            input_columns_count: 0,
+            missing_columns: Vec::new(),
+            extra_columns: Vec::new(),
+            mismatch_action: MismatchAction::None,
+            error: None,
+            warning,
+        },
+        output: FileOutput {
+            accepted_path: None,
+            rejected_path: None,
+            errors_path: None,
+            archived_path: None,
+        },
+        validation: FileValidation {
+            errors: 0,
+            warnings,
+            rules: Vec::new(),
+        },
+    }
+}
+
+struct PendingFileState {
+    size: Option<u64>,
+    mtime: Option<String>,
+}
+
+pub(super) struct PendingEntityState {
+    path: PathBuf,
+    entity_name: String,
+    base_state: EntityState,
+    pending_entries: BTreeMap<String, PendingFileState>,
+}
+
+impl PendingEntityState {
+    pub(super) fn commit(&self) -> FloeResult<()> {
+        if self.pending_entries.is_empty() {
+            return Ok(());
+        }
+
+        let processed_at = report::now_rfc3339();
+        let mut state = self.base_state.clone();
+        if state.schema.is_empty() {
+            state.schema = crate::state::ENTITY_STATE_SCHEMA_V1.to_string();
+        }
+        if state.entity.is_empty() {
+            state.entity = self.entity_name.clone();
+        }
+        state.updated_at = Some(processed_at.clone());
+        for (source_uri, pending) in &self.pending_entries {
+            state.files.insert(
+                source_uri.clone(),
+                EntityFileState {
+                    processed_at: processed_at.clone(),
+                    size: pending.size,
+                    mtime: pending.mtime.clone(),
+                },
+            );
+        }
+        write_entity_state_atomic(&self.path, &state)
+    }
+}

--- a/crates/floe-core/src/run/entity/mod.rs
+++ b/crates/floe-core/src/run/entity/mod.rs
@@ -12,6 +12,7 @@ use crate::checks::normalize::{
 use io::storage::Target;
 
 mod accepted_write;
+mod incremental;
 mod precheck;
 mod process;
 mod resolve;
@@ -114,6 +115,8 @@ pub(super) fn run_entity(
         listed: resolved_files,
         mode: resolved_mode,
     } = plan.resolved_inputs;
+    let incremental = incremental::prepare_incremental_context(context, entity, input_files)?;
+    let input_files = incremental.pending_inputs;
 
     let severity = match entity.policy.severity.as_str() {
         "warn" => report::Severity::Warn,
@@ -133,7 +136,8 @@ pub(super) fn run_entity(
         .cloned()
         .collect::<Vec<_>>();
 
-    let mut file_reports = Vec::with_capacity(input_files.len());
+    let mut file_reports =
+        Vec::with_capacity(input_files.len() + incremental.skipped_reports.len());
     let mut totals = report::ResultsTotals {
         files_total: 0,
         rows_total: 0,
@@ -160,7 +164,14 @@ pub(super) fn run_entity(
             Target::from_resolved(&resolved)
         })
         .transpose()?;
-    let mut file_timings_ms = Vec::with_capacity(input_files.len());
+    let mut file_timings_ms =
+        Vec::with_capacity(input_files.len() + incremental.skipped_reports.len());
+    for skipped in incremental.skipped_reports {
+        totals.files_total += 1;
+        totals.warnings_total += skipped.validation.warnings;
+        file_reports.push(skipped);
+        file_timings_ms.push(Some(0));
+    }
     let sink_options_warning = sink_options_warning(entity);
     // Phase A: per-file precheck (schema mismatch / early rejection).
     let precheck_start = perf_enabled.then(Instant::now);
@@ -314,6 +325,22 @@ pub(super) fn run_entity(
         )?;
         if let Some(start) = report_write_start {
             phase_timings.report_write_ms += start.elapsed().as_millis() as u64;
+        }
+    }
+
+    if let Some(pending_state) = incremental.pending_state.as_ref() {
+        let (status, _) = report::compute_run_outcome(
+            &run_report
+                .files
+                .iter()
+                .map(|file| file.status)
+                .collect::<Vec<_>>(),
+        );
+        if matches!(
+            status,
+            report::RunStatus::Success | report::RunStatus::SuccessWithWarnings
+        ) {
+            pending_state.commit()?;
         }
     }
 

--- a/crates/floe-core/src/run/entity/mod.rs
+++ b/crates/floe-core/src/run/entity/mod.rs
@@ -117,6 +117,7 @@ pub(super) fn run_entity(
     } = plan.resolved_inputs;
     let incremental = incremental::prepare_incremental_context(context, entity, input_files)?;
     let input_files = incremental.pending_inputs;
+    let pending_input_count = input_files.len();
 
     let severity = match entity.policy.severity.as_str() {
         "warn" => report::Severity::Warn,
@@ -260,6 +261,7 @@ pub(super) fn run_entity(
         write_mode,
         perf_enabled,
         phase_timings: &mut phase_timings,
+        pending_input_count,
         accepted_accum,
     })?;
     accepted_write_report

--- a/crates/floe-core/src/state/mod.rs
+++ b/crates/floe-core/src/state/mod.rs
@@ -86,17 +86,56 @@ fn with_local_state_fallback(
     mut resolved: ResolvedPath,
 ) -> ResolvedPath {
     if resolved.local_path.is_none() {
-        resolved.local_path = Some(default_local_state_cache_path(resolver, entity));
+        resolved.local_path = Some(default_local_state_cache_path(
+            resolver,
+            entity,
+            &resolved.uri,
+        ));
     }
     resolved
 }
 
-fn default_local_state_cache_path(resolver: &StorageResolver, entity: &EntityConfig) -> PathBuf {
-    resolver
-        .config_local_dir()
+fn default_local_state_cache_path(
+    resolver: &StorageResolver,
+    entity: &EntityConfig,
+    resolved_uri: &str,
+) -> PathBuf {
+    if resolver.config_is_remote() {
+        remote_config_state_cache_root()
+            .join(short_stable_hash_hex(resolved_uri))
+            .join(&entity.name)
+            .join(ENTITY_STATE_FILENAME)
+    } else {
+        resolver
+            .config_local_dir()
+            .join(".floe/state")
+            .join(&entity.name)
+            .join(ENTITY_STATE_FILENAME)
+    }
+}
+
+fn remote_config_state_cache_root() -> PathBuf {
+    if let Some(path) = std::env::var_os("XDG_CACHE_HOME") {
+        let path = PathBuf::from(path);
+        if path.is_absolute() {
+            return path.join("floe/state");
+        }
+    }
+    if let Some(home) = std::env::var_os("HOME") {
+        return PathBuf::from(home).join(".cache/floe/state");
+    }
+    std::env::current_dir()
+        .unwrap_or_else(|_| PathBuf::from("."))
         .join(".floe/state")
-        .join(&entity.name)
-        .join(ENTITY_STATE_FILENAME)
+}
+
+fn short_stable_hash_hex(value: &str) -> String {
+    let mut hash: u64 = 0xcbf29ce484222325;
+    for byte in value.as_bytes() {
+        hash ^= u64::from(*byte);
+        hash = hash.wrapping_mul(0x100000001b3);
+    }
+    format!("{:016x}", hash)
 }
 
 pub fn read_entity_state(path: &Path) -> FloeResult<Option<EntityState>> {

--- a/crates/floe-core/src/state/mod.rs
+++ b/crates/floe-core/src/state/mod.rs
@@ -1,6 +1,6 @@
 use std::collections::BTreeMap;
 use std::fs;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use serde::{Deserialize, Serialize};
 use tempfile::NamedTempFile;
@@ -45,12 +45,17 @@ pub fn resolve_entity_state_path(
 ) -> FloeResult<ResolvedPath> {
     if let Some(state) = &entity.state {
         if let Some(path) = state.path.as_deref() {
-            return resolver.resolve_path(
-                &entity.name,
-                "entity.state.path",
-                entity.source.storage.as_deref(),
-                path,
-            );
+            let resolved = if is_remote_uri(path) {
+                resolver.resolve_path(
+                    &entity.name,
+                    "entity.state.path",
+                    entity.source.storage.as_deref(),
+                    path,
+                )?
+            } else {
+                resolver.resolve_local_path(path)?
+            };
+            return Ok(with_local_state_fallback(resolver, entity, resolved));
         }
     }
 
@@ -66,12 +71,32 @@ pub fn resolve_entity_state_path(
         resolved_source.local_path.as_deref(),
     );
     let default_path = join_state_path(&source_root, &entity.name);
-    resolver.resolve_path(
+    let resolved = resolver.resolve_path(
         &entity.name,
         "entity.state.path",
         entity.source.storage.as_deref(),
         &default_path,
-    )
+    )?;
+    Ok(with_local_state_fallback(resolver, entity, resolved))
+}
+
+fn with_local_state_fallback(
+    resolver: &StorageResolver,
+    entity: &EntityConfig,
+    mut resolved: ResolvedPath,
+) -> ResolvedPath {
+    if resolved.local_path.is_none() {
+        resolved.local_path = Some(default_local_state_cache_path(resolver, entity));
+    }
+    resolved
+}
+
+fn default_local_state_cache_path(resolver: &StorageResolver, entity: &EntityConfig) -> PathBuf {
+    resolver
+        .config_local_dir()
+        .join(".floe/state")
+        .join(&entity.name)
+        .join(ENTITY_STATE_FILENAME)
 }
 
 pub fn read_entity_state(path: &Path) -> FloeResult<Option<EntityState>> {
@@ -187,4 +212,8 @@ fn parent_like(value: &str) -> Option<&str> {
 
 fn is_path_separator(ch: char) -> bool {
     ch == '/' || ch == '\\'
+}
+
+fn is_remote_uri(value: &str) -> bool {
+    value.starts_with("s3://") || value.starts_with("gs://") || value.starts_with("abfs://")
 }

--- a/crates/floe-core/tests/unit/run/entity/incremental.rs
+++ b/crates/floe-core/tests/unit/run/entity/incremental.rs
@@ -1,0 +1,269 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex, OnceLock};
+use std::thread::sleep;
+use std::time::Duration;
+
+use floe_core::report::{FileStatus, RunStatus};
+use floe_core::state::read_entity_state;
+use floe_core::{run, set_observer, RunEvent, RunObserver, RunOptions};
+
+#[derive(Default)]
+struct TestObserver {
+    events: Mutex<Vec<RunEvent>>,
+}
+
+impl TestObserver {
+    fn reset(&self) {
+        self.events.lock().expect("observer lock").clear();
+    }
+
+    fn events_for_run(&self, run_id: &str) -> Vec<RunEvent> {
+        self.events
+            .lock()
+            .expect("observer lock")
+            .iter()
+            .filter(|event| match event {
+                RunEvent::Log {
+                    run_id: event_run_id,
+                    ..
+                }
+                | RunEvent::RunStarted {
+                    run_id: event_run_id,
+                    ..
+                }
+                | RunEvent::EntityStarted {
+                    run_id: event_run_id,
+                    ..
+                }
+                | RunEvent::FileStarted {
+                    run_id: event_run_id,
+                    ..
+                }
+                | RunEvent::FileFinished {
+                    run_id: event_run_id,
+                    ..
+                }
+                | RunEvent::SchemaEvolutionApplied {
+                    run_id: event_run_id,
+                    ..
+                }
+                | RunEvent::EntityFinished {
+                    run_id: event_run_id,
+                    ..
+                }
+                | RunEvent::RunFinished {
+                    run_id: event_run_id,
+                    ..
+                } => event_run_id == run_id,
+            })
+            .cloned()
+            .collect()
+    }
+}
+
+impl RunObserver for TestObserver {
+    fn on_event(&self, event: RunEvent) {
+        self.events.lock().expect("observer lock").push(event);
+    }
+}
+
+fn test_observer() -> &'static TestObserver {
+    static OBSERVER: OnceLock<Arc<TestObserver>> = OnceLock::new();
+    let observer = OBSERVER.get_or_init(|| {
+        let observer = Arc::new(TestObserver::default());
+        let _ = set_observer(observer.clone());
+        observer
+    });
+    observer.as_ref()
+}
+
+fn write_csv(dir: &Path, name: &str, contents: &str) -> PathBuf {
+    let path = dir.join(name);
+    fs::write(&path, contents).expect("write csv");
+    path
+}
+
+fn write_config(dir: &Path, contents: &str) -> PathBuf {
+    let path = dir.join("config.yml");
+    fs::write(&path, contents).expect("write config");
+    path
+}
+
+fn config_yaml(
+    input_dir: &Path,
+    accepted_dir: &Path,
+    rejected_dir: Option<&Path>,
+    report_dir: &Path,
+    severity: &str,
+    mismatch_block: &str,
+) -> String {
+    let rejected_block = rejected_dir
+        .map(|path| {
+            format!(
+                "      rejected:\n        format: \"csv\"\n        path: \"{}\"\n",
+                path.display()
+            )
+        })
+        .unwrap_or_default();
+    format!(
+        r#"version: "0.1"
+report:
+  path: "{report_dir}"
+entities:
+  - name: "customer"
+    incremental_mode: "file"
+    source:
+      format: "csv"
+      path: "{input_dir}"
+    sink:
+      accepted:
+        format: "parquet"
+        path: "{accepted_dir}"
+{rejected_block}    policy:
+      severity: "{severity}"
+    schema:
+{mismatch_block}      columns:
+        - name: "id"
+          type: "string"
+        - name: "name"
+          type: "string"
+"#,
+        report_dir = report_dir.display(),
+        input_dir = input_dir.display(),
+        accepted_dir = accepted_dir.display(),
+        rejected_block = rejected_block,
+        severity = severity,
+        mismatch_block = mismatch_block,
+    )
+}
+
+fn run_config(path: &Path, run_id: &str) -> floe_core::RunOutcome {
+    run(
+        path,
+        RunOptions {
+            run_id: Some(run_id.to_string()),
+            entities: Vec::new(),
+            dry_run: false,
+        },
+    )
+    .expect("run config")
+}
+
+fn state_path(input_dir: &Path) -> PathBuf {
+    input_dir.join(".floe/state/customer/state.json")
+}
+
+#[test]
+fn incremental_file_mode_skips_seen_files_and_commits_once() {
+    let observer = test_observer();
+    observer.reset();
+
+    let root = tempfile::TempDir::new().expect("temp dir");
+    let input_dir = root.path().join("in");
+    let accepted_dir = root.path().join("out/accepted");
+    let report_dir = root.path().join("report");
+    fs::create_dir_all(&input_dir).expect("create input dir");
+    write_csv(&input_dir, "customers.csv", "id;name\n1;alice\n");
+    let config_path = write_config(
+        root.path(),
+        &config_yaml(&input_dir, &accepted_dir, None, &report_dir, "warn", ""),
+    );
+
+    let first = run_config(&config_path, "incremental-first");
+    assert_eq!(first.summary.run.status, RunStatus::Success);
+    let state_file = state_path(&input_dir);
+    let state = read_entity_state(&state_file)
+        .expect("read state")
+        .expect("state exists");
+    assert_eq!(state.files.len(), 1);
+    let recorded = state.files.values().next().expect("recorded file");
+    assert_eq!(recorded.size, Some(16));
+    assert!(recorded.processed_at.contains('T'));
+
+    let second = run_config(&config_path, "incremental-second");
+    assert_eq!(second.summary.run.status, RunStatus::Success);
+    let report = &second.entity_outcomes[0].report;
+    assert_eq!(report.results.files_total, 1);
+    assert_eq!(report.results.rows_total, 0);
+    assert_eq!(report.files[0].status, FileStatus::Success);
+    assert_eq!(report.files[0].validation.warnings, 0);
+    let second_state = read_entity_state(&state_file)
+        .expect("read state again")
+        .expect("state exists again");
+    assert_eq!(second_state.files, state.files);
+}
+
+#[test]
+fn incremental_file_mode_warns_and_skips_changed_files() {
+    let observer = test_observer();
+    observer.reset();
+
+    let root = tempfile::TempDir::new().expect("temp dir");
+    let input_dir = root.path().join("in");
+    let accepted_dir = root.path().join("out/accepted");
+    let report_dir = root.path().join("report");
+    fs::create_dir_all(&input_dir).expect("create input dir");
+    let source = write_csv(&input_dir, "customers.csv", "id;name\n1;alice\n");
+    let config_path = write_config(
+        root.path(),
+        &config_yaml(&input_dir, &accepted_dir, None, &report_dir, "warn", ""),
+    );
+
+    let _ = run_config(&config_path, "incremental-changed-first");
+    sleep(Duration::from_secs(1));
+    fs::write(&source, "id;name\n1;alice\n2;bob\n").expect("rewrite csv");
+
+    let outcome = run_config(&config_path, "incremental-changed-second");
+    assert_eq!(outcome.summary.run.status, RunStatus::SuccessWithWarnings);
+    let report = &outcome.entity_outcomes[0].report;
+    assert_eq!(report.results.files_total, 1);
+    assert_eq!(report.results.rows_total, 0);
+    assert_eq!(report.results.warnings_total, 1);
+    assert_eq!(report.files[0].validation.warnings, 1);
+    let warning = report.files[0]
+        .mismatch
+        .warning
+        .as_deref()
+        .expect("warning text");
+    assert!(warning.contains("changed metadata"));
+
+    let events = observer.events_for_run("incremental-changed-second");
+    assert!(events.iter().any(|event| matches!(
+        event,
+        RunEvent::Log {
+            code: Some(code),
+            message,
+            ..
+        } if code == "incremental_file_changed" && message.contains("changed metadata")
+    )));
+}
+
+#[test]
+fn incremental_file_mode_does_not_commit_state_after_unsuccessful_entity() {
+    let root = tempfile::TempDir::new().expect("temp dir");
+    let input_dir = root.path().join("in");
+    let accepted_dir = root.path().join("out/accepted");
+    let rejected_dir = root.path().join("out/rejected");
+    let report_dir = root.path().join("report");
+    fs::create_dir_all(&input_dir).expect("create input dir");
+    write_csv(&input_dir, "customers.csv", "id\n1\n");
+    let mismatch_block = "      mismatch:\n        missing_columns: \"reject_file\"\n";
+    let config_path = write_config(
+        root.path(),
+        &config_yaml(
+            &input_dir,
+            &accepted_dir,
+            Some(&rejected_dir),
+            &report_dir,
+            "reject",
+            mismatch_block,
+        ),
+    );
+
+    let outcome = run_config(&config_path, "incremental-rejected");
+    assert_eq!(outcome.summary.run.status, RunStatus::Rejected);
+    assert!(read_entity_state(&state_path(&input_dir))
+        .expect("read state")
+        .is_none());
+}

--- a/crates/floe-core/tests/unit/run/entity/incremental.rs
+++ b/crates/floe-core/tests/unit/run/entity/incremental.rs
@@ -97,6 +97,7 @@ fn config_yaml(
     report_dir: &Path,
     severity: &str,
     mismatch_block: &str,
+    write_mode: Option<&str>,
 ) -> String {
     let rejected_block = rejected_dir
         .map(|path| {
@@ -105,6 +106,9 @@ fn config_yaml(
                 path.display()
             )
         })
+        .unwrap_or_default();
+    let write_mode_block = write_mode
+        .map(|mode| format!("      write_mode: \"{mode}\"\n"))
         .unwrap_or_default();
     format!(
         r#"version: "0.1"
@@ -120,7 +124,7 @@ entities:
       accepted:
         format: "parquet"
         path: "{accepted_dir}"
-{rejected_block}    policy:
+{write_mode_block}{rejected_block}    policy:
       severity: "{severity}"
     schema:
 {mismatch_block}      columns:
@@ -132,10 +136,21 @@ entities:
         report_dir = report_dir.display(),
         input_dir = input_dir.display(),
         accepted_dir = accepted_dir.display(),
+        write_mode_block = write_mode_block,
         rejected_block = rejected_block,
         severity = severity,
         mismatch_block = mismatch_block,
     )
+}
+
+fn list_files(dir: &Path) -> Vec<PathBuf> {
+    let mut files = fs::read_dir(dir)
+        .expect("read dir")
+        .filter_map(Result::ok)
+        .map(|entry| entry.path())
+        .collect::<Vec<_>>();
+    files.sort();
+    files
 }
 
 fn run_config(path: &Path, run_id: &str) -> floe_core::RunOutcome {
@@ -167,7 +182,15 @@ fn incremental_file_mode_skips_seen_files_and_commits_once() {
     write_csv(&input_dir, "customers.csv", "id;name\n1;alice\n");
     let config_path = write_config(
         root.path(),
-        &config_yaml(&input_dir, &accepted_dir, None, &report_dir, "warn", ""),
+        &config_yaml(
+            &input_dir,
+            &accepted_dir,
+            None,
+            &report_dir,
+            "warn",
+            "",
+            None,
+        ),
     );
 
     let first = run_config(&config_path, "incremental-first");
@@ -207,7 +230,15 @@ fn incremental_file_mode_warns_and_skips_changed_files() {
     let source = write_csv(&input_dir, "customers.csv", "id;name\n1;alice\n");
     let config_path = write_config(
         root.path(),
-        &config_yaml(&input_dir, &accepted_dir, None, &report_dir, "warn", ""),
+        &config_yaml(
+            &input_dir,
+            &accepted_dir,
+            None,
+            &report_dir,
+            "warn",
+            "",
+            None,
+        ),
     );
 
     let _ = run_config(&config_path, "incremental-changed-first");
@@ -240,6 +271,51 @@ fn incremental_file_mode_warns_and_skips_changed_files() {
 }
 
 #[test]
+fn incremental_file_mode_overwrite_noop_preserves_accepted_output() {
+    let root = tempfile::TempDir::new().expect("temp dir");
+    let input_dir = root.path().join("in");
+    let accepted_dir = root.path().join("out/accepted");
+    let report_dir = root.path().join("report");
+    fs::create_dir_all(&input_dir).expect("create input dir");
+    write_csv(&input_dir, "customers.csv", "id;name\n1;alice\n");
+    let config_path = write_config(
+        root.path(),
+        &config_yaml(
+            &input_dir,
+            &accepted_dir,
+            None,
+            &report_dir,
+            "warn",
+            "",
+            Some("overwrite"),
+        ),
+    );
+
+    let first = run_config(&config_path, "incremental-overwrite-first");
+    assert_eq!(first.summary.run.status, RunStatus::Success);
+    let first_outputs = list_files(&accepted_dir);
+    assert!(!first_outputs.is_empty());
+    let first_sizes = first_outputs
+        .iter()
+        .map(|path| fs::metadata(path).expect("metadata").len())
+        .collect::<Vec<_>>();
+
+    let second = run_config(&config_path, "incremental-overwrite-second");
+    assert_eq!(second.summary.run.status, RunStatus::Success);
+    let report = &second.entity_outcomes[0].report;
+    assert_eq!(report.results.rows_total, 0);
+    assert_eq!(report.results.accepted_total, 0);
+
+    let second_outputs = list_files(&accepted_dir);
+    assert_eq!(second_outputs, first_outputs);
+    let second_sizes = second_outputs
+        .iter()
+        .map(|path| fs::metadata(path).expect("metadata").len())
+        .collect::<Vec<_>>();
+    assert_eq!(second_sizes, first_sizes);
+}
+
+#[test]
 fn incremental_file_mode_does_not_commit_state_after_unsuccessful_entity() {
     let root = tempfile::TempDir::new().expect("temp dir");
     let input_dir = root.path().join("in");
@@ -258,6 +334,7 @@ fn incremental_file_mode_does_not_commit_state_after_unsuccessful_entity() {
             &report_dir,
             "reject",
             mismatch_block,
+            None,
         ),
     );
 

--- a/crates/floe-core/tests/unit/run/entity/incremental.rs
+++ b/crates/floe-core/tests/unit/run/entity/incremental.rs
@@ -5,7 +5,9 @@ use std::thread::sleep;
 use std::time::Duration;
 
 use floe_core::report::{FileStatus, RunStatus};
-use floe_core::state::read_entity_state;
+use floe_core::state::{
+    read_entity_state, write_entity_state_atomic, EntityState, ENTITY_STATE_SCHEMA_V1,
+};
 use floe_core::{run, set_observer, RunEvent, RunObserver, RunOptions};
 
 #[derive(Default)]
@@ -268,6 +270,118 @@ fn incremental_file_mode_warns_and_skips_changed_files() {
             ..
         } if code == "incremental_file_changed" && message.contains("changed metadata")
     )));
+}
+
+#[test]
+fn incremental_file_mode_accepts_matching_state_file() {
+    let root = tempfile::TempDir::new().expect("temp dir");
+    let input_dir = root.path().join("in");
+    let accepted_dir = root.path().join("out/accepted");
+    let report_dir = root.path().join("report");
+    fs::create_dir_all(&input_dir).expect("create input dir");
+    write_csv(&input_dir, "customers.csv", "id;name\n1;alice\n");
+    let state_file = state_path(&input_dir);
+    write_entity_state_atomic(&state_file, &EntityState::new("customer")).expect("write state");
+    let config_path = write_config(
+        root.path(),
+        &config_yaml(
+            &input_dir,
+            &accepted_dir,
+            None,
+            &report_dir,
+            "warn",
+            "",
+            None,
+        ),
+    );
+
+    let outcome = run_config(&config_path, "incremental-matching-state");
+    assert_eq!(outcome.summary.run.status, RunStatus::Success);
+    assert_eq!(outcome.entity_outcomes[0].report.results.rows_total, 1);
+}
+
+#[test]
+fn incremental_file_mode_fails_on_mismatched_state_entity() {
+    let root = tempfile::TempDir::new().expect("temp dir");
+    let input_dir = root.path().join("in");
+    let accepted_dir = root.path().join("out/accepted");
+    let report_dir = root.path().join("report");
+    fs::create_dir_all(&input_dir).expect("create input dir");
+    write_csv(&input_dir, "customers.csv", "id;name\n1;alice\n");
+    let state_file = state_path(&input_dir);
+    write_entity_state_atomic(&state_file, &EntityState::new("orders")).expect("write state");
+    let config_path = write_config(
+        root.path(),
+        &config_yaml(
+            &input_dir,
+            &accepted_dir,
+            None,
+            &report_dir,
+            "warn",
+            "",
+            None,
+        ),
+    );
+
+    let err = run(
+        &config_path,
+        RunOptions {
+            run_id: Some("incremental-entity-mismatch".to_string()),
+            entities: Vec::new(),
+            dry_run: false,
+        },
+    )
+    .expect_err("mismatched entity state should fail");
+    let msg = err.to_string();
+    assert!(msg.contains("state entity mismatch"));
+    assert!(msg.contains("expected customer, got orders"));
+}
+
+#[test]
+fn incremental_file_mode_fails_on_mismatched_state_schema() {
+    let root = tempfile::TempDir::new().expect("temp dir");
+    let input_dir = root.path().join("in");
+    let accepted_dir = root.path().join("out/accepted");
+    let report_dir = root.path().join("report");
+    fs::create_dir_all(&input_dir).expect("create input dir");
+    write_csv(&input_dir, "customers.csv", "id;name\n1;alice\n");
+    let state_file = state_path(&input_dir);
+    write_entity_state_atomic(
+        &state_file,
+        &EntityState {
+            schema: "floe.state.file-ingest.v0".to_string(),
+            entity: "customer".to_string(),
+            updated_at: None,
+            files: Default::default(),
+        },
+    )
+    .expect("write state");
+    let config_path = write_config(
+        root.path(),
+        &config_yaml(
+            &input_dir,
+            &accepted_dir,
+            None,
+            &report_dir,
+            "warn",
+            "",
+            None,
+        ),
+    );
+
+    let err = run(
+        &config_path,
+        RunOptions {
+            run_id: Some("incremental-schema-mismatch".to_string()),
+            entities: Vec::new(),
+            dry_run: false,
+        },
+    )
+    .expect_err("mismatched schema state should fail");
+    let msg = err.to_string();
+    assert!(msg.contains("state schema mismatch"));
+    assert!(msg.contains(ENTITY_STATE_SCHEMA_V1));
+    assert!(msg.contains("floe.state.file-ingest.v0"));
 }
 
 #[test]

--- a/crates/floe-core/tests/unit/run/entity/mod.rs
+++ b/crates/floe-core/tests/unit/run/entity/mod.rs
@@ -1,1 +1,2 @@
 pub mod accepted_output;
+pub mod incremental;

--- a/crates/floe-core/tests/unit/state/mod.rs
+++ b/crates/floe-core/tests/unit/state/mod.rs
@@ -480,6 +480,15 @@ entities:
         resolved.uri,
         "s3://raw-bucket/landing/incoming/sales/.floe/state/sales/state.json"
     );
+    assert_eq!(
+        resolved.local_path.as_deref(),
+        Some(
+            temp_dir
+                .path()
+                .join(".floe/state/sales/state.json")
+                .as_path()
+        )
+    );
 }
 
 #[test]
@@ -519,6 +528,47 @@ entities:
         resolved.local_path.as_deref(),
         Some(temp_dir.path().join("custom/state/sales.json").as_path())
     );
+}
+
+#[test]
+fn resolves_remote_entity_state_override_to_local_path() {
+    let temp_dir = tempfile::TempDir::new().expect("temp dir");
+    let yaml = r#"version: "0.1"
+storages:
+  default: "lake"
+  definitions:
+    - name: "lake"
+      type: "s3"
+      bucket: "raw-bucket"
+      prefix: "landing"
+entities:
+  - name: "sales"
+    incremental_mode: "file"
+    state:
+      path: "custom/state/sales.json"
+    source:
+      format: "csv"
+      path: "incoming/sales"
+    sink:
+      accepted:
+        format: "parquet"
+        path: "curated/sales"
+    policy:
+      severity: "warn"
+    schema:
+      columns:
+        - name: "id"
+          type: "string"
+"#;
+    let (config, resolver) = build_local_resolver(&temp_dir, yaml);
+
+    let resolved = resolve_entity_state_path(&resolver, &config.entities[0]).expect("state path");
+
+    assert_eq!(
+        resolved.local_path.as_deref(),
+        Some(temp_dir.path().join("custom/state/sales.json").as_path())
+    );
+    assert!(resolved.uri.starts_with("local://"));
 }
 
 #[test]

--- a/crates/floe-core/tests/unit/state/mod.rs
+++ b/crates/floe-core/tests/unit/state/mod.rs
@@ -29,6 +29,26 @@ fn build_local_resolver(
     (config, resolver)
 }
 
+fn short_stable_hash_hex(value: &str) -> String {
+    let mut hash: u64 = 0xcbf29ce484222325;
+    for byte in value.as_bytes() {
+        hash ^= u64::from(*byte);
+        hash = hash.wrapping_mul(0x100000001b3);
+    }
+    format!("{:016x}", hash)
+}
+
+fn with_cache_home<T>(cache_home: &Path, test: impl FnOnce() -> T) -> T {
+    let previous = std::env::var_os("XDG_CACHE_HOME");
+    std::env::set_var("XDG_CACHE_HOME", cache_home);
+    let output = test();
+    match previous {
+        Some(value) => std::env::set_var("XDG_CACHE_HOME", value),
+        None => std::env::remove_var("XDG_CACHE_HOME"),
+    }
+    output
+}
+
 #[test]
 fn resolves_default_entity_state_path_from_local_source_directory() {
     let temp_dir = tempfile::TempDir::new().expect("temp dir");
@@ -489,6 +509,185 @@ entities:
                 .as_path()
         )
     );
+}
+
+#[test]
+fn resolves_default_entity_state_path_from_remote_config_into_persistent_cache() {
+    let temp_dir = tempfile::TempDir::new().expect("temp dir");
+    let cache_home = temp_dir.path().join("cache-home");
+    fs::create_dir_all(&cache_home).expect("cache dir");
+    let yaml = r#"version: "0.1"
+storages:
+  default: "lake"
+  definitions:
+    - name: "lake"
+      type: "s3"
+      bucket: "raw-bucket"
+      prefix: "landing"
+entities:
+  - name: "sales"
+    incremental_mode: "file"
+    source:
+      format: "csv"
+      path: "incoming/sales"
+    sink:
+      accepted:
+        format: "parquet"
+        path: "curated/sales"
+    policy:
+      severity: "warn"
+    schema:
+      columns:
+        - name: "id"
+          type: "string"
+"#;
+    let config = load_config_from_yaml(&temp_dir, yaml);
+    let remote_base = ConfigBase::remote_from_uri(
+        temp_dir.path().join("ephemeral-config-download"),
+        "s3://raw-bucket/configs/floe.yml",
+    )
+    .expect("remote base");
+    let resolver = StorageResolver::new(&config, remote_base).expect("resolver");
+
+    let resolved = with_cache_home(&cache_home, || {
+        resolve_entity_state_path(&resolver, &config.entities[0]).expect("state path")
+    });
+    let expected_uri = "s3://raw-bucket/landing/incoming/sales/.floe/state/sales/state.json";
+
+    assert_eq!(resolved.uri, expected_uri);
+    assert_eq!(
+        resolved.local_path.as_deref(),
+        Some(
+            cache_home
+                .join("floe/state")
+                .join(short_stable_hash_hex(expected_uri))
+                .join("sales/state.json")
+                .as_path()
+        )
+    );
+}
+
+#[test]
+fn resolves_remote_config_state_cache_for_all_remote_storage_backends() {
+    let temp_dir = tempfile::TempDir::new().expect("temp dir");
+    let cache_home = temp_dir.path().join("cache-home");
+    fs::create_dir_all(&cache_home).expect("cache dir");
+
+    let cases = [
+        (
+            r#"version: "0.1"
+storages:
+  default: "lake"
+  definitions:
+    - name: "lake"
+      type: "s3"
+      bucket: "raw-bucket"
+      prefix: "landing"
+entities:
+  - name: "sales"
+    incremental_mode: "file"
+    source:
+      format: "csv"
+      path: "incoming/sales"
+    sink:
+      accepted:
+        format: "parquet"
+        path: "curated/sales"
+    policy:
+      severity: "warn"
+    schema:
+      columns:
+        - name: "id"
+          type: "string"
+"#,
+            "s3://raw-bucket/configs/floe.yml",
+            "s3://raw-bucket/landing/incoming/sales/.floe/state/sales/state.json",
+        ),
+        (
+            r#"version: "0.1"
+storages:
+  default: "lake"
+  definitions:
+    - name: "lake"
+      type: "gcs"
+      bucket: "raw-bucket"
+      prefix: "landing"
+entities:
+  - name: "sales"
+    incremental_mode: "file"
+    source:
+      format: "csv"
+      path: "incoming/sales"
+    sink:
+      accepted:
+        format: "parquet"
+        path: "curated/sales"
+    policy:
+      severity: "warn"
+    schema:
+      columns:
+        - name: "id"
+          type: "string"
+"#,
+            "gs://raw-bucket/configs/floe.yml",
+            "gs://raw-bucket/landing/incoming/sales/.floe/state/sales/state.json",
+        ),
+        (
+            r#"version: "0.1"
+storages:
+  default: "lake"
+  definitions:
+    - name: "lake"
+      type: "adls"
+      account: "acct"
+      container: "cont"
+      prefix: "landing"
+entities:
+  - name: "sales"
+    incremental_mode: "file"
+    source:
+      format: "csv"
+      path: "incoming/sales"
+    sink:
+      accepted:
+        format: "parquet"
+        path: "curated/sales"
+    policy:
+      severity: "warn"
+    schema:
+      columns:
+        - name: "id"
+          type: "string"
+"#,
+            "abfs://cont@acct.dfs.core.windows.net/configs/floe.yml",
+            "abfs://cont@acct.dfs.core.windows.net/landing/incoming/sales/.floe/state/sales/state.json",
+        ),
+    ];
+
+    with_cache_home(&cache_home, || {
+        for (yaml, config_uri, expected_uri) in cases {
+            let config = load_config_from_yaml(&temp_dir, yaml);
+            let base = ConfigBase::remote_from_uri(
+                temp_dir.path().join("ephemeral-config-download"),
+                config_uri,
+            )
+            .expect("remote base");
+            let resolver = StorageResolver::new(&config, base).expect("resolver");
+            let resolved =
+                resolve_entity_state_path(&resolver, &config.entities[0]).expect("state path");
+
+            assert_eq!(resolved.uri, expected_uri);
+            assert_eq!(
+                resolved.local_path,
+                Some(
+                    cache_home
+                        .join("floe/state")
+                        .join(short_stable_hash_hex(expected_uri))
+                        .join("sales/state.json")
+                )
+            );
+        }
+    });
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- implement `incremental_mode=file` runtime filtering and deferred state commits on top of the new entity state store
- skip previously ingested files, emit warnings for changed-after-ingest files, and preserve non-file incremental behavior
- add unit coverage for unseen, seen, changed, and unsuccessful-entity state commit semantics

## Testing
- cargo test -p floe-core --test unit unit::run::entity::incremental -- --nocapture
