### PR TITLE
refactor(incremental): align archive behavior under incremental_mode

### DIFF
--- a/config.schema.yaml
+++ b/config.schema.yaml
@@ -66,6 +66,11 @@ $defs:
         $ref: "#/$defs/entity_metadata"
       domain:
         type: string
+      incremental_mode:
+        type: string
+        enum: [none, archive, file, row]
+      state:
+        $ref: "#/$defs/entity_state"
       source:
         $ref: "#/$defs/source"
       sink:
@@ -113,6 +118,13 @@ $defs:
         type: array
         items:
           type: string
+
+  entity_state:
+    type: object
+    additionalProperties: false
+    properties:
+      path:
+        type: string
 
   env:
     type: object

--- a/crates/floe-core/src/config/types.rs
+++ b/crates/floe-core/src/config/types.rs
@@ -54,6 +54,20 @@ pub struct EntityConfig {
     pub schema: SchemaConfig,
 }
 
+impl EntityConfig {
+    pub fn resolved_incremental_mode(&self) -> IncrementalMode {
+        if self.incremental_mode == IncrementalMode::None && self.sink.archive.is_some() {
+            IncrementalMode::Archive
+        } else {
+            self.incremental_mode
+        }
+    }
+
+    pub fn archive_enabled(&self) -> bool {
+        self.resolved_incremental_mode() == IncrementalMode::Archive && self.sink.archive.is_some()
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum IncrementalMode {
     #[default]

--- a/crates/floe-core/src/config/validate.rs
+++ b/crates/floe-core/src/config/validate.rs
@@ -1,7 +1,7 @@
 use std::collections::HashSet;
 
 use crate::config::{
-    CatalogDefinition, EntityConfig, RootConfig, SourceOptions, StorageDefinition,
+    CatalogDefinition, EntityConfig, IncrementalMode, RootConfig, SourceOptions, StorageDefinition,
 };
 use crate::io::format;
 use crate::io::read::json_selector::parse_selector;
@@ -135,6 +135,36 @@ fn validate_state(entity: &EntityConfig) -> FloeResult<()> {
                 "entity.name={} entity.state.path must not be empty",
                 entity.name
             ))));
+        }
+    }
+
+    if entity.incremental_mode == IncrementalMode::Archive && entity.sink.archive.is_none() {
+        return Err(Box::new(ConfigError(format!(
+            "entity.name={} incremental_mode=archive requires sink.archive",
+            entity.name
+        ))));
+    }
+
+    if entity.sink.archive.is_some() {
+        match entity.incremental_mode {
+            IncrementalMode::None => warnings::emit(
+                "validate",
+                Some(&entity.name),
+                None,
+                Some("incremental_archive_legacy"),
+                &format!(
+                    "entity.name={} sink.archive without incremental_mode is deprecated; treating it as incremental_mode=archive for backward compatibility",
+                    entity.name
+                ),
+            ),
+            IncrementalMode::File | IncrementalMode::Row => {
+                return Err(Box::new(ConfigError(format!(
+                    "entity.name={} sink.archive conflicts with incremental_mode={}; use incremental_mode=archive or remove sink.archive",
+                    entity.name,
+                    entity.incremental_mode.as_str()
+                ))));
+            }
+            IncrementalMode::Archive => {}
         }
     }
 

--- a/crates/floe-core/src/report/entity.rs
+++ b/crates/floe-core/src/report/entity.rs
@@ -80,7 +80,7 @@ pub(crate) fn build_run_report(ctx: RunReportContext<'_>) -> report::RunReport {
                         .unwrap_or_else(|| rejected.path.clone()),
                 }),
             archive: report::SinkArchiveEcho {
-                enabled: ctx.entity.sink.archive.is_some(),
+                enabled: ctx.entity.archive_enabled(),
                 path: ctx
                     .entity
                     .sink

--- a/crates/floe-core/src/run/entity/mod.rs
+++ b/crates/floe-core/src/run/entity/mod.rs
@@ -147,24 +147,28 @@ pub(super) fn run_entity(
         warnings_total: 0,
         errors_total: 0,
     };
-    let archive_target = entity
-        .sink
-        .archive
-        .as_ref()
-        .map(|archive| {
-            let storage_name = archive
-                .storage
-                .as_deref()
-                .or(entity.source.storage.as_deref());
-            let resolved = context.storage_resolver.resolve_path(
-                &entity.name,
-                "sink.archive.storage",
-                storage_name,
-                &archive.path,
-            )?;
-            Target::from_resolved(&resolved)
-        })
-        .transpose()?;
+    let archive_target = if entity.archive_enabled() {
+        entity
+            .sink
+            .archive
+            .as_ref()
+            .map(|archive| {
+                let storage_name = archive
+                    .storage
+                    .as_deref()
+                    .or(entity.source.storage.as_deref());
+                let resolved = context.storage_resolver.resolve_path(
+                    &entity.name,
+                    "sink.archive.storage",
+                    storage_name,
+                    &archive.path,
+                )?;
+                Target::from_resolved(&resolved)
+            })
+            .transpose()?
+    } else {
+        None
+    };
     let mut file_timings_ms =
         Vec::with_capacity(input_files.len() + incremental.skipped_reports.len());
     for skipped in incremental.skipped_reports {

--- a/crates/floe-core/tests/integration/archive_run.rs
+++ b/crates/floe-core/tests/integration/archive_run.rs
@@ -227,7 +227,7 @@ fn legacy_archive_config_still_archives_inputs() {
     )
     .expect("run config");
 
-    assert_eq!(outcome.entity_outcomes[0].report.sink.archive.enabled, true);
+    assert!(outcome.entity_outcomes[0].report.sink.archive.enabled);
     assert!(!processed.exists(), "processed file should be archived");
     assert_eq!(
         list_files(&archive_entity_dir(&archive_dir, "customer")).len(),

--- a/crates/floe-core/tests/integration/archive_run.rs
+++ b/crates/floe-core/tests/integration/archive_run.rs
@@ -34,28 +34,25 @@ fn list_files(dir: &Path) -> Vec<PathBuf> {
     files
 }
 
-#[test]
-fn archive_moves_only_processed_input_not_local_siblings() {
-    let temp_dir = tempfile::TempDir::new().expect("temp dir");
-    let root = temp_dir.path();
-    let input_dir = root.join("in");
-    let accepted_dir = root.join("out/accepted/customer");
-    let archive_dir = root.join("archive");
-    let report_dir = root.join("report");
-
-    fs::create_dir_all(&input_dir).expect("create input dir");
-    let processed = write_csv(&input_dir, "data.csv", "id,name\n1,alice\n");
-    let sibling = write_csv(&input_dir, "sibling.csv", "id,name\n99,keep\n");
-
-    let yaml = format!(
+fn archive_config(
+    report_dir: &Path,
+    source_path: &Path,
+    accepted_dir: &Path,
+    archive_dir: &Path,
+    incremental_mode: Option<&str>,
+) -> String {
+    let incremental_block = incremental_mode
+        .map(|mode| format!("    incremental_mode: \"{mode}\"\n"))
+        .unwrap_or_default();
+    format!(
         r#"version: "0.1"
 report:
   path: "{report_dir}"
 entities:
   - name: "customer"
-    source:
+{incremental_block}    source:
       format: "csv"
-      path: "{processed}"
+      path: "{source_path}"
     sink:
       accepted:
         format: "parquet"
@@ -72,9 +69,32 @@ entities:
           type: "string"
 "#,
         report_dir = report_dir.display(),
-        processed = processed.display(),
+        incremental_block = incremental_block,
+        source_path = source_path.display(),
         accepted_dir = accepted_dir.display(),
         archive_dir = archive_dir.display(),
+    )
+}
+
+#[test]
+fn archive_moves_only_processed_input_not_local_siblings() {
+    let temp_dir = tempfile::TempDir::new().expect("temp dir");
+    let root = temp_dir.path();
+    let input_dir = root.join("in");
+    let accepted_dir = root.join("out/accepted/customer");
+    let archive_dir = root.join("archive");
+    let report_dir = root.join("report");
+
+    fs::create_dir_all(&input_dir).expect("create input dir");
+    let processed = write_csv(&input_dir, "data.csv", "id,name\n1,alice\n");
+    let sibling = write_csv(&input_dir, "sibling.csv", "id,name\n99,keep\n");
+
+    let yaml = archive_config(
+        &report_dir,
+        &processed,
+        &accepted_dir,
+        &archive_dir,
+        Some("archive"),
     );
     let config_path = write_config(root, &yaml);
 
@@ -125,34 +145,12 @@ fn archive_repeated_runs_do_not_overwrite_same_source_filename() {
     fs::create_dir_all(&input_dir).expect("create input dir");
     let source_path = input_dir.join("data.csv");
 
-    let yaml = format!(
-        r#"version: "0.1"
-report:
-  path: "{report_dir}"
-entities:
-  - name: "customer"
-    source:
-      format: "csv"
-      path: "{source_path}"
-    sink:
-      accepted:
-        format: "parquet"
-        path: "{accepted_dir}"
-      archive:
-        path: "{archive_dir}"
-    policy:
-      severity: "warn"
-    schema:
-      columns:
-        - name: "id"
-          type: "string"
-        - name: "name"
-          type: "string"
-"#,
-        report_dir = report_dir.display(),
-        source_path = source_path.display(),
-        accepted_dir = accepted_dir.display(),
-        archive_dir = archive_dir.display(),
+    let yaml = archive_config(
+        &report_dir,
+        &source_path,
+        &accepted_dir,
+        &archive_dir,
+        Some("archive"),
     );
     let config_path = write_config(root, &yaml);
 
@@ -203,4 +201,36 @@ entities:
         .collect::<Vec<_>>();
     assert!(contents.iter().any(|content| content.contains("1,first")));
     assert!(contents.iter().any(|content| content.contains("2,second")));
+}
+
+#[test]
+fn legacy_archive_config_still_archives_inputs() {
+    let temp_dir = tempfile::TempDir::new().expect("temp dir");
+    let root = temp_dir.path();
+    let input_dir = root.join("in");
+    let accepted_dir = root.join("out/accepted/customer");
+    let archive_dir = root.join("archive");
+    let report_dir = root.join("report");
+
+    fs::create_dir_all(&input_dir).expect("create input dir");
+    let processed = write_csv(&input_dir, "data.csv", "id,name\n1,alice\n");
+    let yaml = archive_config(&report_dir, &processed, &accepted_dir, &archive_dir, None);
+    let config_path = write_config(root, &yaml);
+
+    let outcome = run(
+        &config_path,
+        RunOptions {
+            run_id: Some("archive-legacy-compat".to_string()),
+            entities: Vec::new(),
+            dry_run: false,
+        },
+    )
+    .expect("run config");
+
+    assert_eq!(outcome.entity_outcomes[0].report.sink.archive.enabled, true);
+    assert!(!processed.exists(), "processed file should be archived");
+    assert_eq!(
+        list_files(&archive_entity_dir(&archive_dir, "customer")).len(),
+        1
+    );
 }

--- a/crates/floe-core/tests/unit/config/config_validation.rs
+++ b/crates/floe-core/tests/unit/config/config_validation.rs
@@ -268,6 +268,64 @@ fn unsupported_incremental_mode_errors() {
 }
 
 #[test]
+fn archive_incremental_mode_requires_archive_sink() {
+    let entity = r#"  - name: "customer"
+    incremental_mode: "archive"
+    source:
+      format: "csv"
+      path: "/tmp/input"
+    sink:
+      accepted:
+        format: "parquet"
+        path: "/tmp/out"
+    policy:
+      severity: "warn"
+    schema:
+      columns:
+        - name: "customer_id"
+          type: "string"
+"#;
+    let yaml = base_config(entity);
+    assert_validation_error(
+        &yaml,
+        &[
+            "entity.name=customer",
+            "incremental_mode=archive requires sink.archive",
+        ],
+    );
+}
+
+#[test]
+fn sink_archive_conflicts_with_file_incremental_mode() {
+    let entity = r#"  - name: "customer"
+    incremental_mode: "file"
+    source:
+      format: "csv"
+      path: "/tmp/input"
+    sink:
+      accepted:
+        format: "parquet"
+        path: "/tmp/out"
+      archive:
+        path: "/tmp/archive"
+    policy:
+      severity: "warn"
+    schema:
+      columns:
+        - name: "customer_id"
+          type: "string"
+"#;
+    let yaml = base_config(entity);
+    assert_validation_error(
+        &yaml,
+        &[
+            "entity.name=customer",
+            "sink.archive conflicts with incremental_mode=file",
+        ],
+    );
+}
+
+#[test]
 fn xml_source_requires_row_tag() {
     let entity = r#"  - name: "customer"
     source:

--- a/crates/floe-core/tests/unit/config/parse.rs
+++ b/crates/floe-core/tests/unit/config/parse.rs
@@ -283,6 +283,39 @@ entities:
 }
 
 #[test]
+fn parse_config_maps_legacy_sink_archive_to_resolved_archive_mode() {
+    let yaml = r#"
+version: "0.1"
+entities:
+  - name: "customer"
+    source:
+      format: "csv"
+      path: "/tmp/input"
+    sink:
+      accepted:
+        format: "parquet"
+        path: "/tmp/out"
+      archive:
+        path: "/tmp/archive"
+    policy:
+      severity: "warn"
+    schema:
+      columns:
+        - name: "customer_id"
+          type: "string"
+"#;
+    let path = write_temp_config(yaml);
+    let config = load_config(&path).expect("parse config");
+
+    assert_eq!(config.entities[0].incremental_mode, IncrementalMode::None);
+    assert_eq!(
+        config.entities[0].resolved_incremental_mode(),
+        IncrementalMode::Archive
+    );
+    assert!(config.entities[0].archive_enabled());
+}
+
+#[test]
 fn parse_config_rejects_empty_entity_state_path_during_validation() {
     let yaml = r#"
 version: "0.1"


### PR DESCRIPTION
## Summary
- align archive runtime and reporting behavior under `incremental_mode=archive`
- keep legacy `sink.archive` configs migration-safe by warning and resolving them as archive mode when `incremental_mode` is omitted
- reject conflicting `sink.archive` plus `incremental_mode=file|row` combinations and add config and runtime coverage

## Testing
- `CARGO_TARGET_DIR=/srv/agent/cargo-target cargo test -p floe-core --tests -- --nocapture`

Closes #244
