### PR TITLE
feat(incremental): add state inspection and reset tooling

### DIFF
--- a/crates/floe-cli/src/main.rs
+++ b/crates/floe-cli/src/main.rs
@@ -1,8 +1,9 @@
 use clap::{Parser, Subcommand, ValueEnum};
 use floe_core::{
-    add_entity_to_config, build_common_manifest_json, load_config, parse_profile,
-    resolve_config_location, run_with_base, validate_profile, validate_with_base, AddEntityOptions,
-    FloeResult, RunOptions, ValidateOptions,
+    add_entity_to_config, build_common_manifest_json, inspect_entity_state_with_base, load_config,
+    parse_profile, reset_entity_state_with_base, resolve_config_location, run_with_base,
+    validate_profile, validate_with_base, AddEntityOptions, FloeResult, RunOptions,
+    ValidateOptions,
 };
 use std::io::Write;
 
@@ -82,6 +83,14 @@ const ADD_ENTITY_LONG_ABOUT: &str = concat!(
     "\n",
     "Example:\n",
     "  floe add-entity -c config.yml --input ./in/customers.csv\n",
+);
+
+const STATE_LONG_ABOUT: &str = concat!(
+    "Inspect or intentionally reset per-entity incremental state.\n",
+    "\n",
+    "Examples:\n",
+    "  floe state inspect -c example/config.yml --entity customers\n",
+    "  floe state reset -c example/config.yml --entity customers --yes\n",
 );
 
 mod logging;
@@ -177,6 +186,31 @@ enum Command {
         output: Option<String>,
         #[arg(long, help = "Print the updated YAML without writing the file")]
         dry_run: bool,
+    },
+    #[command(about = "Inspect or reset entity incremental state", long_about = STATE_LONG_ABOUT)]
+    State {
+        #[command(subcommand)]
+        command: StateCommand,
+    },
+}
+
+#[derive(Subcommand, Debug)]
+enum StateCommand {
+    #[command(about = "Inspect entity state")]
+    Inspect {
+        #[arg(short, long, help = "Path or URI to the Floe config file")]
+        config: String,
+        #[arg(long, help = "Entity name")]
+        entity: String,
+    },
+    #[command(about = "Reset entity state")]
+    Reset {
+        #[arg(short, long, help = "Path or URI to the Floe config file")]
+        config: String,
+        #[arg(long, help = "Entity name")]
+        entity: String,
+        #[arg(long, help = "Required confirmation to delete the state file")]
+        yes: bool,
     },
 }
 
@@ -470,5 +504,102 @@ fn main() -> FloeResult<()> {
             let _ = out.flush();
             Ok(())
         }
+        Command::State { command } => match command {
+            StateCommand::Inspect { config, entity } => {
+                let config_location = resolve_or_exit(&config);
+                let inspection = match inspect_entity_state_with_base(
+                    &config_location.path,
+                    config_location.base.clone(),
+                    &entity,
+                ) {
+                    Ok(inspection) => inspection,
+                    Err(err) => exit_with_error(err),
+                };
+
+                let mut out = std::io::stdout().lock();
+                let _ = writeln!(out, "Entity: {}", inspection.entity_name);
+                let _ = writeln!(
+                    out,
+                    "Incremental mode: {}",
+                    inspection.incremental_mode.as_str()
+                );
+                let _ = writeln!(out, "State path: {}", inspection.path.uri);
+                match inspection.state {
+                    Some(state) => {
+                        let _ = writeln!(out, "State exists: yes");
+                        let _ = writeln!(out, "Tracked files: {}", state.files.len());
+                        let _ = writeln!(
+                            out,
+                            "Updated at: {}",
+                            state.updated_at.as_deref().unwrap_or("(unknown)")
+                        );
+                        let _ = writeln!(out);
+                        let _ = serde_json::to_writer_pretty(&mut out, &state);
+                        let _ = writeln!(out);
+                    }
+                    None => {
+                        let _ = writeln!(out, "State exists: no");
+                        let _ = writeln!(out, "Tracked files: 0");
+                    }
+                }
+                let _ = out.flush();
+                Ok(())
+            }
+            StateCommand::Reset {
+                config,
+                entity,
+                yes,
+            } => {
+                if !yes {
+                    exit_with_error(Box::new(std::io::Error::new(
+                        std::io::ErrorKind::InvalidInput,
+                        "state reset is destructive, rerun with --yes to confirm",
+                    )));
+                }
+
+                let config_location = resolve_or_exit(&config);
+                let inspection = match inspect_entity_state_with_base(
+                    &config_location.path,
+                    config_location.base.clone(),
+                    &entity,
+                ) {
+                    Ok(inspection) => inspection,
+                    Err(err) => exit_with_error(err),
+                };
+                let removed = match reset_entity_state_with_base(
+                    &config_location.path,
+                    config_location.base.clone(),
+                    &entity,
+                ) {
+                    Ok(removed) => removed,
+                    Err(err) => exit_with_error(err),
+                };
+
+                let mut out = std::io::stdout().lock();
+                let _ = writeln!(out, "Entity: {}", inspection.entity_name);
+                let _ = writeln!(out, "State path: {}", inspection.path.uri);
+                if removed {
+                    let _ = writeln!(out, "State reset: removed state file");
+                } else {
+                    let _ = writeln!(out, "State reset: no state file found");
+                }
+                let _ = out.flush();
+                Ok(())
+            }
+        },
     }
+}
+
+fn resolve_or_exit(config: &str) -> floe_core::ConfigLocation {
+    match resolve_config_location(config) {
+        Ok(location) => location,
+        Err(err) => exit_with_error(err),
+    }
+}
+
+fn exit_with_error(err: Box<dyn std::error::Error + Send + Sync>) -> ! {
+    let mut err_out = std::io::stderr().lock();
+    let _ = writeln!(err_out, "Error: {err}");
+    let _ = err_out.flush();
+    std::process::exit(1);
 }

--- a/crates/floe-cli/src/main.rs
+++ b/crates/floe-cli/src/main.rs
@@ -558,20 +558,20 @@ fn main() -> FloeResult<()> {
                 }
 
                 let config_location = resolve_or_exit(&config);
-                let inspection = match inspect_entity_state_with_base(
-                    &config_location.path,
-                    config_location.base.clone(),
-                    &entity,
-                ) {
-                    Ok(inspection) => inspection,
-                    Err(err) => exit_with_error(err),
-                };
                 let removed = match reset_entity_state_with_base(
                     &config_location.path,
                     config_location.base.clone(),
                     &entity,
                 ) {
                     Ok(removed) => removed,
+                    Err(err) => exit_with_error(err),
+                };
+                let inspection = match inspect_entity_state_with_base(
+                    &config_location.path,
+                    config_location.base.clone(),
+                    &entity,
+                ) {
+                    Ok(inspection) => inspection,
                     Err(err) => exit_with_error(err),
                 };
 

--- a/crates/floe-cli/tests/state.rs
+++ b/crates/floe-cli/tests/state.rs
@@ -86,6 +86,19 @@ fn state_reset_requires_explicit_yes_flag() {
         .stderr(predicate::str::contains("rerun with --yes to confirm"));
 }
 
+fn assert_state_reset(config_path: &std::path::Path, state_path: &std::path::Path) {
+    let mut cmd = Command::new(assert_cmd::cargo::cargo_bin!("floe"));
+    cmd.args(["state", "reset", "-c"])
+        .arg(config_path)
+        .args(["--entity", "sales", "--yes"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Entity: sales"))
+        .stdout(predicate::str::contains("State reset: removed state file"));
+
+    assert!(!state_path.exists());
+}
+
 #[test]
 fn state_reset_removes_existing_file() {
     let dir = tempdir().expect("tempdir");
@@ -98,13 +111,31 @@ fn state_reset_removes_existing_file() {
     )
     .expect("write state");
 
-    let mut cmd = Command::new(assert_cmd::cargo::cargo_bin!("floe"));
-    cmd.args(["state", "reset", "-c"])
-        .arg(&config_path)
-        .args(["--entity", "sales", "--yes"])
-        .assert()
-        .success()
-        .stdout(predicate::str::contains("State reset: removed state file"));
+    assert_state_reset(&config_path, &state_path);
+}
 
-    assert!(!state_path.exists());
+#[test]
+fn state_reset_removes_malformed_state_file() {
+    let dir = tempdir().expect("tempdir");
+    let config_path = write_config(&dir);
+    let state_path = dir.path().join("incoming/.floe/state/sales/state.json");
+    fs::create_dir_all(state_path.parent().expect("parent")).expect("mkdir state parent");
+    fs::write(&state_path, "{not valid json").expect("write malformed state");
+
+    assert_state_reset(&config_path, &state_path);
+}
+
+#[test]
+fn state_reset_removes_mismatched_state_file() {
+    let dir = tempdir().expect("tempdir");
+    let config_path = write_config(&dir);
+    let state_path = dir.path().join("incoming/.floe/state/sales/state.json");
+    fs::create_dir_all(state_path.parent().expect("parent")).expect("mkdir state parent");
+    fs::write(
+        &state_path,
+        r#"{"schema":"wrong.schema","entity":"other","updated_at":null,"files":{}}"#,
+    )
+    .expect("write mismatched state");
+
+    assert_state_reset(&config_path, &state_path);
 }

--- a/crates/floe-cli/tests/state.rs
+++ b/crates/floe-cli/tests/state.rs
@@ -1,0 +1,110 @@
+use assert_cmd::Command;
+use predicates::prelude::*;
+use std::fs;
+use tempfile::tempdir;
+
+fn write_config(dir: &tempfile::TempDir) -> std::path::PathBuf {
+    let source_dir = dir.path().join("incoming");
+    fs::create_dir_all(&source_dir).expect("mkdir source");
+    let config_path = dir.path().join("config.yml");
+    fs::write(
+        &config_path,
+        format!(
+            r#"version: "0.1"
+entities:
+  - name: "sales"
+    incremental_mode: "file"
+    source:
+      format: "csv"
+      path: "{}"
+    sink:
+      accepted:
+        format: "parquet"
+        path: "{}"
+    policy:
+      severity: "warn"
+    schema:
+      columns:
+        - name: "id"
+          type: "string"
+"#,
+            source_dir.display(),
+            dir.path().join("out").display()
+        ),
+    )
+    .expect("write config");
+    config_path
+}
+
+#[test]
+fn state_inspect_prints_state_summary_and_json() {
+    let dir = tempdir().expect("tempdir");
+    let config_path = write_config(&dir);
+    let state_path = dir.path().join("incoming/.floe/state/sales/state.json");
+    fs::create_dir_all(state_path.parent().expect("parent")).expect("mkdir state parent");
+    fs::write(
+        &state_path,
+        r#"{
+  "schema": "floe.state.file-ingest.v1",
+  "entity": "sales",
+  "updated_at": "2026-04-22T09:00:00Z",
+  "files": {
+    "local:///tmp/incoming/sales.csv": {
+      "processed_at": "2026-04-22T08:59:00Z",
+      "size": 42,
+      "mtime": "2026-04-22T08:00:00Z"
+    }
+  }
+}"#,
+    )
+    .expect("write state");
+
+    let mut cmd = Command::new(assert_cmd::cargo::cargo_bin!("floe"));
+    cmd.args(["state", "inspect", "-c"])
+        .arg(&config_path)
+        .args(["--entity", "sales"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Entity: sales"))
+        .stdout(predicate::str::contains("Incremental mode: file"))
+        .stdout(predicate::str::contains("State exists: yes"))
+        .stdout(predicate::str::contains("Tracked files: 1"))
+        .stdout(predicate::str::contains("\"entity\": \"sales\""));
+}
+
+#[test]
+fn state_reset_requires_explicit_yes_flag() {
+    let dir = tempdir().expect("tempdir");
+    let config_path = write_config(&dir);
+
+    let mut cmd = Command::new(assert_cmd::cargo::cargo_bin!("floe"));
+    cmd.args(["state", "reset", "-c"])
+        .arg(&config_path)
+        .args(["--entity", "sales"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("rerun with --yes to confirm"));
+}
+
+#[test]
+fn state_reset_removes_existing_file() {
+    let dir = tempdir().expect("tempdir");
+    let config_path = write_config(&dir);
+    let state_path = dir.path().join("incoming/.floe/state/sales/state.json");
+    fs::create_dir_all(state_path.parent().expect("parent")).expect("mkdir state parent");
+    fs::write(
+        &state_path,
+        r#"{"schema":"floe.state.file-ingest.v1","entity":"sales","updated_at":null,"files":{}}"#,
+    )
+    .expect("write state");
+
+    let mut cmd = Command::new(assert_cmd::cargo::cargo_bin!("floe"));
+    cmd.args(["state", "reset", "-c"])
+        .arg(&config_path)
+        .args(["--entity", "sales", "--yes"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("State reset: removed state file"));
+
+    assert!(!state_path.exists());
+}

--- a/crates/floe-core/src/lib.rs
+++ b/crates/floe-core/src/lib.rs
@@ -15,6 +15,7 @@ pub mod state;
 pub mod vars;
 pub mod warnings;
 
+pub use crate::state::{inspect_entity_state_with_base, reset_entity_state_with_base};
 pub use add_entity::{add_entity_to_config, AddEntityOptions, AddEntityOutcome};
 pub use checks as check;
 pub use config::{resolve_config_location, ConfigLocation};

--- a/crates/floe-core/src/run/entity/incremental.rs
+++ b/crates/floe-core/src/run/entity/incremental.rs
@@ -8,8 +8,8 @@ use crate::report::{
 };
 use crate::run::RunContext;
 use crate::state::{
-    read_entity_state, resolve_entity_state_path, write_entity_state_atomic, EntityFileState,
-    EntityState,
+    read_entity_state, resolve_entity_state_path, validate_entity_state, write_entity_state_atomic,
+    EntityFileState, EntityState,
 };
 use crate::{config, report, warnings, FloeResult};
 
@@ -40,7 +40,7 @@ pub(super) fn prepare_incremental_context(
         ))) as Box<dyn std::error::Error + Send + Sync>
     })?;
     let existing = read_entity_state(&state_path)?
-        .map(|state| validate_loaded_state(entity, &state_path, state))
+        .map(|state| validate_entity_state(entity, state))
         .transpose()?
         .unwrap_or_else(|| EntityState::new(&entity.name));
 
@@ -98,34 +98,6 @@ pub(super) fn prepare_incremental_context(
             pending_entries,
         }),
     })
-}
-
-fn validate_loaded_state(
-    entity: &config::EntityConfig,
-    state_path: &std::path::Path,
-    state: EntityState,
-) -> FloeResult<EntityState> {
-    if state.schema != crate::state::ENTITY_STATE_SCHEMA_V1 {
-        return Err(Box::new(crate::ConfigError(format!(
-            "entity.name={} incremental_mode=file state schema mismatch at {}: expected {}, got {}",
-            entity.name,
-            state_path.display(),
-            crate::state::ENTITY_STATE_SCHEMA_V1,
-            state.schema
-        ))));
-    }
-
-    if state.entity != entity.name {
-        return Err(Box::new(crate::ConfigError(format!(
-            "entity.name={} incremental_mode=file state entity mismatch at {}: expected {}, got {}",
-            entity.name,
-            state_path.display(),
-            entity.name,
-            state.entity
-        ))));
-    }
-
-    Ok(state)
 }
 
 fn file_state_matches(recorded: &EntityFileState, input_file: &InputFile) -> bool {

--- a/crates/floe-core/src/state/mod.rs
+++ b/crates/floe-core/src/state/mod.rs
@@ -171,16 +171,7 @@ pub fn inspect_entity_state(
     config_base: ConfigBase,
     entity_name: &str,
 ) -> FloeResult<EntityStateInspection> {
-    let entity = config
-        .entities
-        .iter()
-        .find(|entity| entity.name == entity_name)
-        .ok_or_else(|| {
-            Box::new(ConfigError(format!("entity not found: {entity_name}")))
-                as Box<dyn std::error::Error + Send + Sync>
-        })?;
-    let resolver = StorageResolver::new(config, config_base)?;
-    let path = resolve_entity_state_path(&resolver, entity)?;
+    let (entity, path) = resolve_entity_state_target(config, config_base, entity_name)?;
     let state = match &path.local_path {
         Some(local_path) => read_entity_state(local_path)?
             .map(|state| validate_entity_state(entity, state))
@@ -201,11 +192,12 @@ pub fn reset_entity_state_with_base(
     config_base: ConfigBase,
     entity_name: &str,
 ) -> FloeResult<bool> {
-    let inspection = inspect_entity_state_with_base(config_path, config_base, entity_name)?;
-    let Some(local_path) = inspection.path.local_path.as_ref() else {
+    let config = crate::load_config(config_path)?;
+    let (entity, path) = resolve_entity_state_target(&config, config_base, entity_name)?;
+    let Some(local_path) = path.local_path.as_ref() else {
         return Err(Box::new(ConfigError(format!(
             "entity.name={} state path is not local and cannot be reset: {}",
-            inspection.entity_name, inspection.path.uri
+            entity.name, path.uri
         ))));
     };
 
@@ -215,6 +207,24 @@ pub fn reset_entity_state_with_base(
 
     fs::remove_file(local_path)?;
     Ok(true)
+}
+
+fn resolve_entity_state_target<'a>(
+    config: &'a RootConfig,
+    config_base: ConfigBase,
+    entity_name: &str,
+) -> FloeResult<(&'a EntityConfig, ResolvedPath)> {
+    let entity = config
+        .entities
+        .iter()
+        .find(|entity| entity.name == entity_name)
+        .ok_or_else(|| {
+            Box::new(ConfigError(format!("entity not found: {entity_name}")))
+                as Box<dyn std::error::Error + Send + Sync>
+        })?;
+    let resolver = StorageResolver::new(config, config_base)?;
+    let path = resolve_entity_state_path(&resolver, entity)?;
+    Ok((entity, path))
 }
 
 pub fn write_entity_state_atomic(path: &Path, state: &EntityState) -> FloeResult<()> {

--- a/crates/floe-core/src/state/mod.rs
+++ b/crates/floe-core/src/state/mod.rs
@@ -5,7 +5,9 @@ use std::path::{Path, PathBuf};
 use serde::{Deserialize, Serialize};
 use tempfile::NamedTempFile;
 
-use crate::config::{EntityConfig, ResolvedPath, StorageResolver};
+use crate::config::{
+    ConfigBase, EntityConfig, IncrementalMode, ResolvedPath, RootConfig, StorageResolver,
+};
 use crate::io::storage::extensions;
 use crate::{ConfigError, FloeResult};
 
@@ -37,6 +39,14 @@ pub struct EntityFileState {
     pub processed_at: String,
     pub size: Option<u64>,
     pub mtime: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct EntityStateInspection {
+    pub entity_name: String,
+    pub incremental_mode: IncrementalMode,
+    pub path: ResolvedPath,
+    pub state: Option<EntityState>,
 }
 
 pub fn resolve_entity_state_path(
@@ -147,6 +157,66 @@ pub fn read_entity_state(path: &Path) -> FloeResult<Option<EntityState>> {
     Ok(Some(state))
 }
 
+pub fn inspect_entity_state_with_base(
+    config_path: &Path,
+    config_base: ConfigBase,
+    entity_name: &str,
+) -> FloeResult<EntityStateInspection> {
+    let config = crate::load_config(config_path)?;
+    inspect_entity_state(&config, config_base, entity_name)
+}
+
+pub fn inspect_entity_state(
+    config: &RootConfig,
+    config_base: ConfigBase,
+    entity_name: &str,
+) -> FloeResult<EntityStateInspection> {
+    let entity = config
+        .entities
+        .iter()
+        .find(|entity| entity.name == entity_name)
+        .ok_or_else(|| {
+            Box::new(ConfigError(format!("entity not found: {entity_name}")))
+                as Box<dyn std::error::Error + Send + Sync>
+        })?;
+    let resolver = StorageResolver::new(config, config_base)?;
+    let path = resolve_entity_state_path(&resolver, entity)?;
+    let state = match &path.local_path {
+        Some(local_path) => read_entity_state(local_path)?
+            .map(|state| validate_entity_state(entity, state))
+            .transpose()?,
+        None => None,
+    };
+
+    Ok(EntityStateInspection {
+        entity_name: entity.name.clone(),
+        incremental_mode: entity.incremental_mode,
+        path,
+        state,
+    })
+}
+
+pub fn reset_entity_state_with_base(
+    config_path: &Path,
+    config_base: ConfigBase,
+    entity_name: &str,
+) -> FloeResult<bool> {
+    let inspection = inspect_entity_state_with_base(config_path, config_base, entity_name)?;
+    let Some(local_path) = inspection.path.local_path.as_ref() else {
+        return Err(Box::new(ConfigError(format!(
+            "entity.name={} state path is not local and cannot be reset: {}",
+            inspection.entity_name, inspection.path.uri
+        ))));
+    };
+
+    if !local_path.exists() {
+        return Ok(false);
+    }
+
+    fs::remove_file(local_path)?;
+    Ok(true)
+}
+
 pub fn write_entity_state_atomic(path: &Path, state: &EntityState) -> FloeResult<()> {
     let parent = path.parent().ok_or_else(|| {
         Box::new(ConfigError(format!(
@@ -255,4 +325,22 @@ fn is_path_separator(ch: char) -> bool {
 
 fn is_remote_uri(value: &str) -> bool {
     value.starts_with("s3://") || value.starts_with("gs://") || value.starts_with("abfs://")
+}
+
+pub fn validate_entity_state(entity: &EntityConfig, state: EntityState) -> FloeResult<EntityState> {
+    if state.schema != ENTITY_STATE_SCHEMA_V1 {
+        return Err(Box::new(ConfigError(format!(
+            "entity.name={} state schema mismatch: expected {}, got {}",
+            entity.name, ENTITY_STATE_SCHEMA_V1, state.schema
+        ))));
+    }
+
+    if state.entity != entity.name {
+        return Err(Box::new(ConfigError(format!(
+            "entity.name={} state entity mismatch: expected {}, got {}",
+            entity.name, entity.name, state.entity
+        ))));
+    }
+
+    Ok(state)
 }

--- a/crates/floe-core/tests/unit/state/mod.rs
+++ b/crates/floe-core/tests/unit/state/mod.rs
@@ -5,8 +5,9 @@ use std::path::Path;
 use floe_core::config::{ConfigBase, StorageResolver};
 use floe_core::load_config;
 use floe_core::state::{
-    read_entity_state, resolve_entity_state_path, write_entity_state_atomic, EntityFileState,
-    EntityState, ENTITY_STATE_SCHEMA_V1,
+    inspect_entity_state_with_base, read_entity_state, reset_entity_state_with_base,
+    resolve_entity_state_path, write_entity_state_atomic, EntityFileState, EntityState,
+    ENTITY_STATE_SCHEMA_V1,
 };
 
 fn load_config_from_yaml(
@@ -813,4 +814,128 @@ fn read_entity_state_returns_none_when_missing() {
     let temp_dir = tempfile::TempDir::new().expect("temp dir");
     let missing = temp_dir.path().join("missing/state.json");
     assert!(read_entity_state(&missing).expect("read missing").is_none());
+}
+
+#[test]
+fn inspect_entity_state_reports_current_state() {
+    let temp_dir = tempfile::TempDir::new().expect("temp dir");
+    let source_dir = temp_dir.path().join("incoming");
+    fs::create_dir_all(&source_dir).expect("mkdir source");
+    let config_path = temp_dir.path().join("floe.yml");
+    fs::write(
+        &config_path,
+        format!(
+            r#"version: "0.1"
+entities:
+  - name: "sales"
+    incremental_mode: "file"
+    source:
+      format: "csv"
+      path: "{}"
+    sink:
+      accepted:
+        format: "parquet"
+        path: "{}"
+    policy:
+      severity: "warn"
+    schema:
+      columns:
+        - name: "id"
+          type: "string"
+"#,
+            source_dir.display(),
+            temp_dir.path().join("out").display()
+        ),
+    )
+    .expect("write config");
+
+    let config = load_config(&config_path).expect("load config");
+    let resolver =
+        StorageResolver::new(&config, ConfigBase::local_from_path(&config_path)).expect("resolver");
+    let state_path = resolve_entity_state_path(&resolver, &config.entities[0])
+        .expect("state path")
+        .local_path
+        .expect("local path");
+    let state = EntityState {
+        schema: ENTITY_STATE_SCHEMA_V1.to_string(),
+        entity: "sales".to_string(),
+        updated_at: Some("2026-04-22T09:00:00Z".to_string()),
+        files: BTreeMap::from([(
+            "local:///tmp/incoming/sales.csv".to_string(),
+            EntityFileState {
+                processed_at: "2026-04-22T08:59:00Z".to_string(),
+                size: Some(42),
+                mtime: Some("2026-04-22T08:00:00Z".to_string()),
+            },
+        )]),
+    };
+    write_entity_state_atomic(&state_path, &state).expect("write state");
+
+    let inspection = inspect_entity_state_with_base(
+        &config_path,
+        ConfigBase::local_from_path(&config_path),
+        "sales",
+    )
+    .expect("inspect state");
+
+    assert_eq!(inspection.entity_name, "sales");
+    assert_eq!(inspection.incremental_mode.as_str(), "file");
+    assert_eq!(
+        inspection.path.local_path.as_deref(),
+        Some(state_path.as_path())
+    );
+    assert_eq!(inspection.state, Some(state));
+}
+
+#[test]
+fn reset_entity_state_removes_existing_state_file() {
+    let temp_dir = tempfile::TempDir::new().expect("temp dir");
+    let source_dir = temp_dir.path().join("incoming");
+    fs::create_dir_all(&source_dir).expect("mkdir source");
+    let config_path = temp_dir.path().join("floe.yml");
+    fs::write(
+        &config_path,
+        format!(
+            r#"version: "0.1"
+entities:
+  - name: "sales"
+    incremental_mode: "file"
+    source:
+      format: "csv"
+      path: "{}"
+    sink:
+      accepted:
+        format: "parquet"
+        path: "{}"
+    policy:
+      severity: "warn"
+    schema:
+      columns:
+        - name: "id"
+          type: "string"
+"#,
+            source_dir.display(),
+            temp_dir.path().join("out").display()
+        ),
+    )
+    .expect("write config");
+
+    let config = load_config(&config_path).expect("load config");
+    let resolver =
+        StorageResolver::new(&config, ConfigBase::local_from_path(&config_path)).expect("resolver");
+    let state_path = resolve_entity_state_path(&resolver, &config.entities[0])
+        .expect("state path")
+        .local_path
+        .expect("local path");
+    write_entity_state_atomic(&state_path, &EntityState::new("sales")).expect("write state");
+
+    let removed = reset_entity_state_with_base(
+        &config_path,
+        ConfigBase::local_from_path(&config_path),
+        "sales",
+    )
+    .expect("reset state");
+
+    assert!(removed);
+    assert!(!state_path.exists());
 }

--- a/crates/floe-core/tests/unit/state/mod.rs
+++ b/crates/floe-core/tests/unit/state/mod.rs
@@ -887,8 +887,7 @@ entities:
     assert_eq!(inspection.state, Some(state));
 }
 
-#[test]
-fn reset_entity_state_removes_existing_state_file() {
+fn write_reset_test_config() -> (tempfile::TempDir, std::path::PathBuf, std::path::PathBuf) {
     let temp_dir = tempfile::TempDir::new().expect("temp dir");
     let source_dir = temp_dir.path().join("incoming");
     fs::create_dir_all(&source_dir).expect("mkdir source");
@@ -927,6 +926,13 @@ entities:
         .expect("state path")
         .local_path
         .expect("local path");
+
+    (temp_dir, config_path, state_path)
+}
+
+#[test]
+fn reset_entity_state_removes_existing_state_file() {
+    let (_temp_dir, config_path, state_path) = write_reset_test_config();
     write_entity_state_atomic(&state_path, &EntityState::new("sales")).expect("write state");
 
     let removed = reset_entity_state_with_base(
@@ -935,6 +941,44 @@ entities:
         "sales",
     )
     .expect("reset state");
+
+    assert!(removed);
+    assert!(!state_path.exists());
+}
+
+#[test]
+fn reset_entity_state_removes_malformed_state_file() {
+    let (_temp_dir, config_path, state_path) = write_reset_test_config();
+    fs::create_dir_all(state_path.parent().expect("parent")).expect("mkdir state parent");
+    fs::write(&state_path, "{not valid json").expect("write malformed state");
+
+    let removed = reset_entity_state_with_base(
+        &config_path,
+        ConfigBase::local_from_path(&config_path),
+        "sales",
+    )
+    .expect("reset malformed state");
+
+    assert!(removed);
+    assert!(!state_path.exists());
+}
+
+#[test]
+fn reset_entity_state_removes_mismatched_state_file() {
+    let (_temp_dir, config_path, state_path) = write_reset_test_config();
+    fs::create_dir_all(state_path.parent().expect("parent")).expect("mkdir state parent");
+    fs::write(
+        &state_path,
+        r#"{"schema":"wrong.schema","entity":"other","updated_at":null,"files":{}}"#,
+    )
+    .expect("write mismatched state");
+
+    let removed = reset_entity_state_with_base(
+        &config_path,
+        ConfigBase::local_from_path(&config_path),
+        "sales",
+    )
+    .expect("reset mismatched state");
 
     assert!(removed);
     assert!(!state_path.exists());


### PR DESCRIPTION
## Summary
- add `floe state inspect` and `floe state reset` for per-entity incremental state operations
- expose focused core helpers to resolve, validate, inspect, and delete entity state files
- cover the new inspection and reset flows with unit and CLI integration tests

## Testing
- `CARGO_TARGET_DIR=/srv/agent/cargo-target cargo fmt --all`
- `CARGO_TARGET_DIR=/srv/agent/cargo-target cargo test -p floe-core --test unit unit::state -- --nocapture`
- `CARGO_TARGET_DIR=/srv/agent/cargo-target cargo test -p floe-cli --test state -- --nocapture`
