### PR TITLE
release: finalize incremental ingestion for v0.3.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to Floe are documented in this file.
 
+## v0.3.5
+
+- Incremental ingestion release finalization:
+  - documented `incremental_mode: file`, entity `state.path`, and the `floe state inspect/reset` CLI flow
+  - refreshed the repository example config to show file-based incremental ingestion state explicitly
+  - clarified incremental planning and state-commit behavior in the docs summary/reference set
+- Packaging/version updates:
+  - bumped `floe-core` and `floe-cli` to `0.3.5`
+
 ## v0.3.4
 
 - Databricks runner foundation for orchestrator connectors:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3376,7 +3376,7 @@ dependencies = [
 
 [[package]]
 name = "floe-cli"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "assert_cmd",
  "clap",
@@ -3389,7 +3389,7 @@ dependencies = [
 
 [[package]]
 name = "floe-core"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "apache-avro 0.16.0",
  "arrow",

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Start here: [docs/summary.md](docs/summary.md)
 - Schema enforcement and type casting (`strict` vs `coerce`)
 - Nullability checks (`not_null`)
 - Uniqueness checks (`unique`)
+- Incremental ingestion with per-entity file state tracking (`incremental_mode: file`)
 - Policy behavior: `warn` / `reject` / `abort`
 - Accepted vs rejected outputs for clean separation
 - JSON run reports for observability and audit
@@ -148,6 +149,27 @@ Report details: [docs/report.md](docs/report.md)
 - `abort`: reject the entire file on first violation
 
 Checks and policy details: [docs/checks.md](docs/checks.md)
+
+## Incremental ingestion
+
+For file-based incremental ingestion, set `incremental_mode: "file"` on an entity.
+Floe records processed file metadata in a per-entity state file and skips files it
+has already ingested unchanged on later runs.
+
+By default the state file lives under the source root:
+
+- local source dir `./in/customer` → `./in/customer/.floe/state/customer/state.json`
+- local source file `./in/customer.csv` → `./in/.floe/state/customer/state.json`
+
+You can override the location with `state.path` when you want the state file in a
+separate local directory.
+
+Inspect or intentionally reset that state with:
+
+```bash
+floe state inspect -c example/config.yml --entity customer
+floe state reset -c example/config.yml --entity customer --yes
+```
 
 ## Supported formats
 

--- a/crates/floe-cli/Cargo.toml
+++ b/crates/floe-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "floe-cli"
-version = "0.3.4"
+version = "0.3.5"
 edition = "2021"
 description = "CLI for Floe, a YAML-driven technical ingestion tool."
 license = "MIT"
@@ -17,7 +17,7 @@ path = "src/main.rs"
 
 [dependencies]
 clap = { version = "4", features = ["derive"] }
-floe-core = { path = "../floe-core", version = "0.3.4" }
+floe-core = { path = "../floe-core", version = "0.3.5" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 

--- a/crates/floe-core/Cargo.toml
+++ b/crates/floe-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "floe-core"
-version = "0.3.4"
+version = "0.3.5"
 edition = "2021"
 description = "Core library for Floe, a YAML-driven technical ingestion tool."
 license = "MIT"

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -28,6 +28,14 @@
   - `--dry-run` prints the updated YAML without writing.
   - `--output <new.yml>` writes the updated config to a new file instead of overwriting `-c`.
 
+- `floe state inspect -c <config> --entity <name>`
+  - Print the resolved incremental state path for an entity and the current state JSON when present.
+  - Helpful for confirming what Floe has already seen in `incremental_mode: file`.
+
+- `floe state reset -c <config> --entity <name> --yes`
+  - Remove the local state file for an entity.
+  - Requires `--yes` because the next incremental run may reprocess previously tracked files.
+
 ### Dry-run behavior
 
 - Dry-run resolves input files/objects using the same planning path as real runs.
@@ -54,6 +62,10 @@
   - `floe add-entity -c example/config.yml --input ./in/customers.csv --format csv --name customers`
 - Bootstrap a new config file and infer name/format:
   - `floe add-entity -c new-config.yml --input ./in/orders.csv`
+- Inspect incremental state:
+  - `floe state inspect -c example/config.yml --entity customer`
+- Reset incremental state:
+  - `floe state reset -c example/config.yml --entity customer --yes`
 - Report output:
   - `example/report/run_<run_id>/run.summary.json`
   - `example/report/run_<run_id>/customer/run.json`

--- a/docs/config.md
+++ b/docs/config.md
@@ -22,6 +22,9 @@ entities:
   - name: "customer"
     domain: "sales"
     metadata: { ... }
+    incremental_mode: "file"
+    state:
+      path: "./state/customer.json"
     source:
       format: "csv"
       path: "{{domain.incoming_dir}}/customer"
@@ -118,6 +121,30 @@ Free-form entity metadata. Supported keys: `data_product`, `domain`, `owner`,
 ### `domain` (optional)
 Reference to a domain defined in `domains`. When set, `{{domain.incoming_dir}}`
 is available for templating within that entity.
+
+### `incremental_mode` (optional)
+
+- Controls incremental ingestion behavior for the entity.
+- Supported values:
+  - `none` (default)
+  - `archive`
+  - `file`
+  - `row` (reserved contract value, not runtime-enabled in this release)
+- `incremental_mode: archive` requires `sink.archive`.
+- `incremental_mode: file` enables per-file state tracking and skip logic.
+- For backward compatibility, `sink.archive` without `incremental_mode` is still
+  treated as archive mode, but new configs should set `incremental_mode: archive`
+  explicitly.
+
+### `state` (optional)
+
+- Entity-local state settings used by incremental ingestion.
+- `state.path` (optional)
+  - Overrides the local file used to store entity state.
+  - Must be a local path, not `s3://`, `gs://`, or `abfs://`.
+  - When the config itself is remote, the override must be an absolute local path.
+  - If omitted and `incremental_mode: file` is used, Floe derives the path under the
+    source root as `.floe/state/<entity>/state.json`.
 
 ### `source` (required)
 

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -11,8 +11,11 @@ entity. The order is deterministic and is reflected in reports.
    - In normal runs, resolved cloud objects are then downloaded to temp files.
    - In dry-run, resolution is list-only for cloud inputs (no downloads, no writes).
 2. Resolve storage targets for accepted/rejected/report outputs.
-3. If `incremental_mode: file` is enabled, load the entity state file and filter out
-   files already processed with matching metadata.
+3. If `incremental_mode: file` is enabled, load the entity state file and skip any
+   file URI already recorded as previously ingested.
+   - If the current size/mtime still matches the recorded state, Floe skips the file silently.
+   - If the size/mtime changed, Floe still skips the file and emits an
+     `incremental_file_changed` warning instead of reprocessing it.
 4. Prepare output directories if needed.
 
 ### B) File-level prechecks (per file)
@@ -61,8 +64,14 @@ via `sink.accepted.options.max_size_per_file`).
 ### F) Incremental state commit
 
 When `incremental_mode: file` is enabled and the entity finishes successfully,
-Floe updates the entity state file with the processed file URIs plus observed
-size/mtime metadata. Later runs reuse that state to skip unchanged inputs.
+Floe updates the entity state file with the newly processed file URIs plus
+observed size/mtime metadata. Later runs reuse that state to skip any file URI
+already present in the state file.
+
+The recorded metadata is used only to detect that a previously ingested file has
+changed since the earlier run. In that case Floe emits an
+`incremental_file_changed` warning, but it still does not reprocess the file
+automatically.
 
 ## Severity behavior
 

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -11,7 +11,9 @@ entity. The order is deterministic and is reflected in reports.
    - In normal runs, resolved cloud objects are then downloaded to temp files.
    - In dry-run, resolution is list-only for cloud inputs (no downloads, no writes).
 2. Resolve storage targets for accepted/rejected/report outputs.
-3. Prepare output directories if needed.
+3. If `incremental_mode: file` is enabled, load the entity state file and filter out
+   files already processed with matching metadata.
+4. Prepare output directories if needed.
 
 ### B) File-level prechecks (per file)
 
@@ -55,6 +57,12 @@ Accepted rows from all input files are concatenated in file order and written
 once to the accepted sink. For parquet sinks, Floe writes a dataset directory
 containing `part-00000.parquet` (and additional parts when chunking is enabled
 via `sink.accepted.options.max_size_per_file`).
+
+### F) Incremental state commit
+
+When `incremental_mode: file` is enabled and the entity finishes successfully,
+Floe updates the entity state file with the processed file URIs plus observed
+size/mtime metadata. Later runs reuse that state to skip unchanged inputs.
 
 ## Severity behavior
 

--- a/docs/summary.md
+++ b/docs/summary.md
@@ -43,8 +43,9 @@ important references so you can quickly find the right guide.
 
 ## Bootstrap & CLI productivity
 
-- CLI usage (`validate`, `run`, `manifest generate`, `add-entity`): [docs/cli.md](cli.md)
+- CLI usage (`validate`, `run`, `manifest generate`, `add-entity`, `state inspect`, `state reset`): [docs/cli.md](cli.md)
 - `floe add-entity` can bootstrap a missing config file and infer entity name/format from input path extensions (CSV/JSON/Parquet).
+- `floe state inspect` / `floe state reset` help manage per-entity incremental state for `incremental_mode: file`.
 
 ## Benchmarking & development
 
@@ -53,6 +54,7 @@ important references so you can quickly find the right guide.
 ## Current boundaries
 
 - Floe supports partitioned Delta (`partition_by`) and partitioned Iceberg (`partition_spec`) writes.
+- File-based incremental ingestion is implemented. Row-based incremental mode remains a contract-level value for future work.
 - Floe reports write-time metrics/metadata for accepted outputs (format-dependent), including Delta/Iceberg table versioning metadata and file sizing metrics where available.
 - Floe does not perform table optimization/maintenance (for example Delta optimize/vacuum or Iceberg compaction/maintenance); run those as separate jobs.
 - Iceberg schema evolution and merge/upsert workflows are out of scope in current releases.

--- a/example/config.yml
+++ b/example/config.yml
@@ -11,6 +11,9 @@ report:
 
 entities:
   - name: "customer"
+    incremental_mode: "file"
+    state:
+      path: "./state/customer.json"
 
     metadata:
       data_product: "customer_master"
@@ -27,6 +30,7 @@ entities:
         separator: ","
         encoding: "utf-8"
         null_values: ["", "NULL", "null"]
+        glob: "*.csv"
       cast_mode: "strict"   # strict | coerce
 
     sink:


### PR DESCRIPTION
## Summary
- finalize incremental ingestion release docs and example polish for the shipped feature set
- bump `floe-core` and `floe-cli` to `0.3.5` and refresh `Cargo.lock`
- add a `v0.3.5` changelog entry scoped to the release-finalization work in this PR

## Testing
- `CARGO_TARGET_DIR=/srv/agent/cargo-target cargo test -p floe-cli state -- --nocapture`
- `CARGO_TARGET_DIR=/srv/agent/cargo-target cargo test -p floe-core parse_config_supports_entity_state_path_override -- --nocapture`
- `CARGO_TARGET_DIR=/srv/agent/cargo-target cargo test -p floe-core parse_config_rejects_empty_entity_state_path_during_validation -- --nocapture`
- `CARGO_TARGET_DIR=/srv/agent/cargo-target cargo run -p floe-cli -- validate -c example/config.yml`
- `CARGO_TARGET_DIR=/srv/agent/cargo-target cargo run -p floe-cli -- state inspect -c example/config.yml --entity customer`
