### PR TITLE
feat(checks): migrate validation to Polars expression-based checks

### DIFF
--- a/crates/floe-core/src/checks/cast.rs
+++ b/crates/floe-core/src/checks/cast.rs
@@ -183,7 +183,7 @@ fn append_cast_errors(
     Ok(())
 }
 
-fn is_string_type(value: &str) -> bool {
+pub(crate) fn is_string_type(value: &str) -> bool {
     let normalized = value.to_ascii_lowercase().replace(['-', '_'], "");
     matches!(normalized.as_str(), "string" | "str" | "text")
 }

--- a/crates/floe-core/src/checks/cast.rs
+++ b/crates/floe-core/src/checks/cast.rs
@@ -1,4 +1,4 @@
-use polars::prelude::{BooleanChunked, DataFrame, StringChunked};
+use polars::prelude::{col, lit, BooleanChunked, DataFrame, Expr, StringChunked, NULL};
 
 use super::{ColumnIndex, RowError, SparseRowErrors};
 use crate::errors::RunError;
@@ -99,6 +99,17 @@ pub fn cast_mismatch_errors_sparse(
     }
 
     Ok(errors)
+}
+
+pub fn cast_mismatch_expr(typed_col: &str, raw_col: &str) -> (String, Expr) {
+    let err_col = format!("_e_cast_{typed_col}");
+    let error_json =
+        RowError::new("cast_error", typed_col, "invalid value for target type").to_json();
+    let expr = polars::prelude::when(col(raw_col).is_not_null().and(col(typed_col).is_null()))
+        .then(lit(error_json))
+        .otherwise(lit(NULL))
+        .alias(&err_col);
+    (err_col, expr)
 }
 
 pub fn cast_mismatch_counts(

--- a/crates/floe-core/src/checks/mod.rs
+++ b/crates/floe-core/src/checks/mod.rs
@@ -4,17 +4,19 @@ pub mod normalize;
 mod not_null;
 mod unique;
 
-use polars::prelude::{BooleanChunked, DataFrame, NamedFrom, NewChunkedArray, Series};
+use polars::prelude::{BooleanChunked, ChunkFull, DataFrame, NamedFrom, NewChunkedArray, Series};
 use std::collections::{BTreeMap, HashMap};
 
 use crate::{ConfigError, FloeResult};
 
-pub use cast::{cast_mismatch_counts, cast_mismatch_errors, cast_mismatch_errors_sparse};
+pub use cast::{
+    cast_mismatch_counts, cast_mismatch_errors, cast_mismatch_errors_sparse, cast_mismatch_expr,
+};
 pub use mismatch::{
     apply_mismatch_plan, apply_schema_mismatch, plan_schema_mismatch, resolve_mismatch_columns,
     top_level_declared_columns, MismatchOutcome,
 };
-pub use not_null::{not_null_counts, not_null_errors, not_null_errors_sparse};
+pub use not_null::{not_null_counts, not_null_errors, not_null_errors_sparse, not_null_expr};
 pub use unique::{
     resolve_schema_unique_keys, unique_counts, unique_errors, unique_errors_sparse,
     UniqueConstraint, UniqueConstraintResult, UniqueTracker,
@@ -242,6 +244,23 @@ pub fn row_error_formatter(
             "unsupported report.formatter: {other}"
         )))),
     }
+}
+
+pub fn accept_mask_from_error_cols(
+    df: &DataFrame,
+    err_cols: &[&str],
+) -> FloeResult<BooleanChunked> {
+    let mut accept_mask = BooleanChunked::full("floe_accept".into(), true, df.height());
+    for err_col in err_cols {
+        let errors = df.column(err_col).map_err(|err| {
+            Box::new(ConfigError(format!(
+                "error column {err_col} not found: {err}"
+            )))
+        })?;
+        let no_error = errors.is_null();
+        accept_mask = &accept_mask & &no_error;
+    }
+    Ok(accept_mask)
 }
 
 pub fn build_accept_rows(errors_per_row: &[Vec<RowError>]) -> Vec<bool> {

--- a/crates/floe-core/src/checks/mod.rs
+++ b/crates/floe-core/src/checks/mod.rs
@@ -4,7 +4,10 @@ pub mod normalize;
 mod not_null;
 mod unique;
 
-use polars::prelude::{BooleanChunked, ChunkFull, DataFrame, NamedFrom, NewChunkedArray, Series};
+use polars::prelude::{
+    BooleanChunked, ChunkFull, DataFrame, Expr, IntoLazy, IntoSeries, NamedFrom, NewChunkedArray,
+    Series,
+};
 use std::collections::{BTreeMap, HashMap};
 
 use crate::{ConfigError, FloeResult};
@@ -96,6 +99,10 @@ impl SparseRowErrors {
 
     pub fn iter(&self) -> impl Iterator<Item = (&usize, &Vec<RowError>)> {
         self.rows.iter()
+    }
+
+    pub fn get(&self, row_idx: usize) -> Option<&Vec<RowError>> {
+        self.rows.get(&row_idx)
     }
 
     pub fn error_row_count(&self) -> u64 {
@@ -244,6 +251,203 @@ pub fn row_error_formatter(
             "unsupported report.formatter: {other}"
         )))),
     }
+}
+
+/// Result of running expression-based not_null and cast_mismatch checks.
+pub struct ExprCheckResult {
+    /// True for each row that passed all expression checks.
+    pub accept_mask: BooleanChunked,
+    /// Per error column: (column_name, is_null mask).
+    /// `is_null[i] == Some(false)` means row `i` has an error for that check.
+    pub col_masks: Vec<(String, BooleanChunked)>,
+    /// Per error column: (column_name, violation_count). Zero-count entries are omitted.
+    pub col_violation_counts: Vec<(String, u64)>,
+}
+
+impl ExprCheckResult {
+    pub fn all_accepted(height: usize) -> Self {
+        Self {
+            accept_mask: BooleanChunked::full("floe_accept".into(), true, height),
+            col_masks: Vec::new(),
+            col_violation_counts: Vec::new(),
+        }
+    }
+
+    pub fn total_violations(&self) -> u64 {
+        self.col_violation_counts.iter().map(|(_, c)| c).sum()
+    }
+}
+
+/// Runs not_null and cast_mismatch checks using Polars columnar operations.
+///
+/// not_null checks are evaluated via a single lazy expression pass on `df`.
+/// cast_mismatch checks are computed directly from `BooleanChunked` masks derived from
+/// the raw and typed DataFrames, avoiding the need to combine them into one DataFrame.
+///
+/// `track_cast` should only be true when cast errors are known to exist (from a prior
+/// columnar count pass), so the cast path is skipped entirely on the happy path.
+pub fn run_expr_checks(
+    df: &DataFrame,
+    raw_df: &DataFrame,
+    required_cols: &[String],
+    columns: &[crate::config::ColumnConfig],
+    track_cast: bool,
+) -> FloeResult<ExprCheckResult> {
+    let mut err_col_names: Vec<String> = Vec::new();
+
+    // Apply not_null expressions in a single lazy pass.
+    let not_null_exprs: Vec<Expr> = required_cols
+        .iter()
+        .map(|col_name| {
+            let (err_col, expr) = not_null::not_null_expr(col_name);
+            err_col_names.push(err_col);
+            expr
+        })
+        .collect();
+
+    let mut checked = if not_null_exprs.is_empty() {
+        df.clone()
+    } else {
+        df.clone()
+            .lazy()
+            .with_columns(not_null_exprs)
+            .collect()
+            .map_err(|e| {
+                Box::new(crate::errors::RunError(format!(
+                    "run_expr_checks: not_null evaluation failed: {e}"
+                ))) as Box<dyn std::error::Error + Send + Sync>
+            })?
+    };
+
+    // Compute cast error columns directly from BooleanChunked masks, avoiding any
+    // need to join or hstack raw and typed DataFrames.
+    if track_cast {
+        for c in columns {
+            if cast::is_string_type(&c.column_type) {
+                continue;
+            }
+            let raw_not_null = raw_df
+                .column(&c.name)
+                .map_err(|e| {
+                    Box::new(crate::errors::RunError(format!(
+                        "run_expr_checks: raw column '{}' not found: {e}",
+                        c.name
+                    ))) as Box<dyn std::error::Error + Send + Sync>
+                })?
+                .is_not_null();
+
+            let typed_null = df
+                .column(&c.name)
+                .map_err(|e| {
+                    Box::new(crate::errors::RunError(format!(
+                        "run_expr_checks: typed column '{}' not found: {e}",
+                        c.name
+                    ))) as Box<dyn std::error::Error + Send + Sync>
+                })?
+                .is_null();
+
+            let error_mask = &typed_null & &raw_not_null;
+            let err_col_name = format!("_e_cast_{}", c.name);
+            let error_json =
+                RowError::new("cast_error", &c.name, "invalid value for target type").to_json();
+
+            let cast_err_series = bool_mask_to_error_series(&err_col_name, error_mask, &error_json);
+            checked.with_column(cast_err_series).map_err(|e| {
+                Box::new(crate::errors::RunError(format!(
+                    "run_expr_checks: could not attach cast error column '{}': {e}",
+                    err_col_name
+                ))) as Box<dyn std::error::Error + Send + Sync>
+            })?;
+            err_col_names.push(err_col_name);
+        }
+    }
+
+    if err_col_names.is_empty() {
+        return Ok(ExprCheckResult::all_accepted(df.height()));
+    }
+
+    let mut accept_mask = BooleanChunked::full("floe_accept".into(), true, checked.height());
+    let mut col_masks: Vec<(String, BooleanChunked)> = Vec::with_capacity(err_col_names.len());
+    let mut col_violation_counts: Vec<(String, u64)> = Vec::with_capacity(err_col_names.len());
+
+    for err_col in &err_col_names {
+        let col = checked.column(err_col).map_err(|e| {
+            Box::new(crate::errors::RunError(format!(
+                "run_expr_checks: error column '{err_col}' missing after eval: {e}"
+            ))) as Box<dyn std::error::Error + Send + Sync>
+        })?;
+        let null_mask = col.is_null();
+        accept_mask = &accept_mask & &null_mask;
+        let violations = (col.len() - col.null_count()) as u64;
+        col_violation_counts.push((err_col.clone(), violations));
+        col_masks.push((err_col.clone(), null_mask));
+    }
+
+    Ok(ExprCheckResult {
+        accept_mask,
+        col_masks,
+        col_violation_counts,
+    })
+}
+
+/// Converts a boolean error mask into a nullable string Series.
+/// Rows where `error_mask` is true get `error_json`; others are null.
+fn bool_mask_to_error_series(
+    col_name: &str,
+    error_mask: BooleanChunked,
+    error_json: &str,
+) -> Series {
+    use polars::prelude::StringChunked;
+    let ca: StringChunked = error_mask
+        .into_iter()
+        .map(|opt_b| {
+            if opt_b == Some(true) {
+                Some(error_json)
+            } else {
+                None
+            }
+        })
+        .collect();
+    ca.with_name(col_name.into()).into_series()
+}
+
+/// Builds the per-row formatted error string for all rejected rows, combining
+/// expression-based check errors with unique-check errors.
+/// Iterates only rejected rows (the minority), so the happy path is O(1).
+pub fn build_errors_formatted_expr(
+    height: usize,
+    accept_mask: &BooleanChunked,
+    col_masks: &[(String, BooleanChunked)],
+    unique_errors: &SparseRowErrors,
+    formatter: &dyn RowErrorFormatter,
+) -> Vec<Option<String>> {
+    let mut out = vec![None; height];
+    for (row_idx, slot) in out.iter_mut().enumerate() {
+        if accept_mask.get(row_idx) == Some(true) {
+            continue;
+        }
+        let mut row_errors: Vec<RowError> = Vec::new();
+        for (err_col_name, null_mask) in col_masks {
+            if null_mask.get(row_idx) == Some(false) {
+                if let Some(col) = err_col_name.strip_prefix("_e_nn_") {
+                    row_errors.push(RowError::new("not_null", col, "required value missing"));
+                } else if let Some(col) = err_col_name.strip_prefix("_e_cast_") {
+                    row_errors.push(RowError::new(
+                        "cast_error",
+                        col,
+                        "invalid value for target type",
+                    ));
+                }
+            }
+        }
+        if let Some(unique_row_errors) = unique_errors.get(row_idx) {
+            row_errors.extend(unique_row_errors.iter().cloned());
+        }
+        if !row_errors.is_empty() {
+            *slot = Some(formatter.format(&row_errors));
+        }
+    }
+    out
 }
 
 pub fn accept_mask_from_error_cols(

--- a/crates/floe-core/src/checks/not_null.rs
+++ b/crates/floe-core/src/checks/not_null.rs
@@ -1,4 +1,4 @@
-use polars::prelude::{AnyValue, DataFrame};
+use polars::prelude::{col, lit, AnyValue, DataFrame, Expr, NULL};
 
 use super::{ColumnIndex, RowError, SparseRowErrors};
 use crate::errors::RunError;
@@ -83,6 +83,16 @@ pub fn not_null_errors_sparse(
     }
 
     Ok(errors)
+}
+
+pub fn not_null_expr(col_name: &str) -> (String, Expr) {
+    let err_col = format!("_e_nn_{col_name}");
+    let error_json = RowError::new("not_null", col_name, "required value missing").to_json();
+    let expr = polars::prelude::when(col(col_name).is_null())
+        .then(lit(error_json))
+        .otherwise(lit(NULL))
+        .alias(&err_col);
+    (err_col, expr)
 }
 
 pub fn not_null_counts(df: &DataFrame, required_cols: &[String]) -> FloeResult<Vec<(String, u64)>> {

--- a/crates/floe-core/src/report/build.rs
+++ b/crates/floe-core/src/report/build.rs
@@ -7,6 +7,103 @@ use crate::{check, config, report};
 const RULE_COUNT: usize = 4;
 const CAST_ERROR_INDEX: usize = 1;
 
+/// Builds rule summaries from expression-check violation counts plus unique errors.
+///
+/// `col_violation_counts` comes from `ExprCheckResult::col_violation_counts`; entries use
+/// the naming convention `_e_nn_<col>` (not_null) and `_e_cast_<col>` (cast_error).
+pub fn summarize_validation_exprs(
+    col_violation_counts: &[(String, u64)],
+    unique_errors: &check::SparseRowErrors,
+    columns: &[config::ColumnConfig],
+    severity: report::Severity,
+    source_map: Option<&HashMap<String, String>>,
+) -> Vec<report::RuleSummary> {
+    let has_expr = col_violation_counts.iter().any(|(_, c)| *c > 0);
+    if !has_expr && unique_errors.is_empty() {
+        return Vec::new();
+    }
+
+    let mut column_types = HashMap::new();
+    for column in columns {
+        column_types.insert(column.name.clone(), column.column_type.clone());
+    }
+
+    let mut accumulators = vec![RuleAccumulator::default(); RULE_COUNT];
+
+    for (err_col_name, count) in col_violation_counts {
+        if *count == 0 {
+            continue;
+        }
+        let (rule_idx, col_name) = if let Some(n) = err_col_name.strip_prefix("_e_nn_") {
+            (0usize, n)
+        } else if let Some(n) = err_col_name.strip_prefix("_e_cast_") {
+            (CAST_ERROR_INDEX, n)
+        } else {
+            continue;
+        };
+        let accumulator = &mut accumulators[rule_idx];
+        accumulator.violations += count;
+        let target_type = if rule_idx == CAST_ERROR_INDEX {
+            column_types.get(col_name).cloned()
+        } else {
+            None
+        };
+        let entry = accumulator
+            .columns
+            .entry(col_name.to_string())
+            .or_insert_with(|| ColumnAccumulator {
+                violations: 0,
+                target_type,
+            });
+        entry.violations += count;
+    }
+
+    for (_, row_errors) in unique_errors.iter() {
+        for error in row_errors {
+            let idx = rule_index(&error.rule);
+            let accumulator = &mut accumulators[idx];
+            accumulator.violations += 1;
+            let target_type = if idx == CAST_ERROR_INDEX {
+                column_types.get(&error.column).cloned()
+            } else {
+                None
+            };
+            let entry = accumulator
+                .columns
+                .entry(error.column.clone())
+                .or_insert_with(|| ColumnAccumulator {
+                    violations: 0,
+                    target_type,
+                });
+            entry.violations += 1;
+        }
+    }
+
+    let mut rules = Vec::new();
+    for (idx, accumulator) in accumulators.iter().enumerate() {
+        if accumulator.violations == 0 {
+            continue;
+        }
+        let mut cols = Vec::with_capacity(accumulator.columns.len());
+        for (name, column_acc) in &accumulator.columns {
+            cols.push(report::ColumnSummary {
+                column: name.clone(),
+                violations: column_acc.violations,
+                target_type: column_acc.target_type.clone(),
+                source: source_map.and_then(|map| map.get(name).cloned()),
+            });
+        }
+        rules.push(report::RuleSummary {
+            rule: rule_from_index(idx),
+            severity,
+            violations: accumulator.violations,
+            columns: cols,
+        });
+    }
+
+    rules
+}
+
 pub fn summarize_validation(
     errors_per_row: &[Vec<check::RowError>],
     columns: &[config::ColumnConfig],

--- a/crates/floe-core/src/run/entity/validate_split.rs
+++ b/crates/floe-core/src/run/entity/validate_split.rs
@@ -2,11 +2,11 @@ use std::collections::{HashMap, HashSet};
 use std::path::Path;
 use std::time::Instant;
 
-use polars::prelude::DataFrame;
+use polars::prelude::{BooleanChunked, DataFrame};
 
 use crate::checks::normalize::rename_output_columns;
 use crate::errors::RunError;
-use crate::report::build::summarize_validation_sparse;
+use crate::report::build::summarize_validation_exprs;
 use crate::run::events::{event_time_ms, RunObserver};
 use crate::run::RunContext;
 use crate::{check, config, io, report, warnings, ConfigError, FloeResult};
@@ -226,74 +226,91 @@ pub(super) fn run_validate_split_phase(
                 entity.name
             )))
         })?;
-        let raw_indices = check::column_index_map(&raw_df);
-        let typed_indices = check::column_index_map(&df);
 
+        // Fast-path columnar count check — O(columns), no row iteration.
         let cast_counts = if track_cast_errors {
             check::cast_mismatch_counts(&raw_df, &df, normalized_columns)?
         } else {
             Vec::new()
         };
-        let cast_total = cast_counts.iter().map(|(_, count, _)| *count).sum::<u64>();
+        let cast_total: u64 = cast_counts.iter().map(|(_, c, _)| *c).sum();
+        let not_null_counts = check::not_null_counts(&df, required_cols)?;
+        let not_null_total: u64 = not_null_counts.iter().map(|(_, c)| *c).sum();
+        let quick_total = cast_total + not_null_total;
 
-        let mut error_lists = if entity.policy.severity == "abort" && cast_total > 0 {
-            check::cast_mismatch_errors_sparse(
-                &raw_df,
-                &df,
-                normalized_columns,
-                &raw_indices,
-                &typed_indices,
-            )?
-        } else {
-            let not_null_counts = check::not_null_counts(&df, required_cols)?;
-            let not_null_total = not_null_counts.iter().map(|(_, count)| *count).sum::<u64>();
-            let quick_total = cast_total + not_null_total;
-
-            if quick_total == 0 {
-                check::SparseRowErrors::new(row_count as usize)
-            } else {
-                let mut errors = check::not_null_errors_sparse(&df, required_cols, &typed_indices)?;
-                if track_cast_errors && cast_total > 0 {
-                    let cast_errors = check::cast_mismatch_errors_sparse(
-                        &raw_df,
-                        &df,
-                        normalized_columns,
-                        &raw_indices,
-                        &typed_indices,
-                    )?;
-                    errors.merge(cast_errors);
-                }
-                errors
-            }
-        };
-
+        // Unique check — stateful across rows, unchanged.
         let mut forced_reject_rows = HashSet::new();
-        if !(unique_tracker.is_empty() || (entity.policy.severity == "abort" && cast_total > 0)) {
-            let unique_errors = unique_tracker.apply_sparse_with_forced_rejects(
+        let unique_errors = if !unique_tracker.is_empty() {
+            unique_tracker.apply_sparse_with_forced_rejects(
                 &df,
                 normalized_columns,
                 &mut forced_reject_rows,
-            )?;
-            error_lists.merge(unique_errors);
-        }
+            )?
+        } else {
+            check::SparseRowErrors::new(df.height())
+        };
         let forced_reject_count = forced_reject_rows.len() as u64;
 
-        let accept_rows = error_lists.accept_rows();
-        let errors_json = error_lists.build_errors_formatted(row_error_formatter);
-        let row_error_count = error_lists.error_row_count();
-        let violation_count = error_lists.violation_count();
+        // Expression-based not_null / cast_mismatch — single columnar Polars pass.
+        // Skipped entirely when the count check found zero violations (happy path).
+        let expr_result = if quick_total > 0 {
+            check::run_expr_checks(
+                &df,
+                &raw_df,
+                required_cols,
+                normalized_columns,
+                track_cast_errors && cast_total > 0,
+            )?
+        } else {
+            check::ExprCheckResult::all_accepted(df.height())
+        };
 
         drop(raw_df);
-        let accept_count = accept_rows.iter().filter(|accepted| **accepted).count() as u64;
+
+        // Destructure before moving accept_mask so total_violations stays accessible.
+        let check::ExprCheckResult {
+            accept_mask: expr_accept_mask,
+            col_masks,
+            col_violation_counts,
+        } = expr_result;
+
+        // Combine accept masks: expression checks AND unique checks.
+        let accept_mask: BooleanChunked = if unique_errors.is_empty() {
+            expr_accept_mask
+        } else {
+            let (unique_accept, _) = check::build_row_masks(&unique_errors.accept_rows());
+            (&expr_accept_mask & &unique_accept).with_name("floe_accept".into())
+        };
+
+        let violation_count = col_violation_counts.iter().map(|(_, c)| c).sum::<u64>()
+            + unique_errors.violation_count();
+        let accept_count = accept_mask.sum().unwrap_or(0) as u64;
         let reject_count = row_count.saturating_sub(accept_count);
+        let row_error_count = row_count.saturating_sub(accept_count);
         let has_errors = row_error_count > 0;
+
+        // Build per-row formatted error strings — iterates rejected rows only.
+        let errors_json = check::build_errors_formatted_expr(
+            df.height(),
+            &accept_mask,
+            &col_masks,
+            &unique_errors,
+            row_error_formatter,
+        );
+
+        // Derive accept_rows Vec<bool> for filter operations in the split step.
+        let accept_rows: Vec<bool> = (0..df.height())
+            .map(|i| accept_mask.get(i).unwrap_or(false))
+            .collect();
+
         let mut accepted_df_opt: Option<DataFrame> = None;
         let mut rejected_path = None;
         let mut errors_path = None;
         let mut archived_path = None;
         let mut rules = if has_errors {
-            summarize_validation_sparse(
-                &error_lists,
+            summarize_validation_exprs(
+                &col_violation_counts,
+                &unique_errors,
                 normalized_columns,
                 severity,
                 Some(source_column_map),

--- a/crates/floe-core/src/run/entity/validate_split.rs
+++ b/crates/floe-core/src/run/entity/validate_split.rs
@@ -237,10 +237,13 @@ pub(super) fn run_validate_split_phase(
         let not_null_counts = check::not_null_counts(&df, required_cols)?;
         let not_null_total: u64 = not_null_counts.iter().map(|(_, c)| *c).sum();
         let quick_total = cast_total + not_null_total;
+        let cast_abort_short_circuit = entity.policy.severity == "abort" && cast_total > 0;
 
-        // Unique check — stateful across rows, unchanged.
+        // Unique check — stateful across rows. Skip when abort is already decided by cast errors.
         let mut forced_reject_rows = HashSet::new();
-        let unique_errors = if !unique_tracker.is_empty() {
+        let unique_errors = if cast_abort_short_circuit {
+            check::SparseRowErrors::new(df.height())
+        } else if !unique_tracker.is_empty() {
             unique_tracker.apply_sparse_with_forced_rejects(
                 &df,
                 normalized_columns,
@@ -253,7 +256,9 @@ pub(super) fn run_validate_split_phase(
 
         // Expression-based not_null / cast_mismatch — single columnar Polars pass.
         // Skipped entirely when the count check found zero violations (happy path).
-        let expr_result = if quick_total > 0 {
+        let expr_result = if cast_abort_short_circuit {
+            check::run_expr_checks(&df, &raw_df, &[], normalized_columns, true)?
+        } else if quick_total > 0 {
             check::run_expr_checks(
                 &df,
                 &raw_df,

--- a/crates/floe-core/tests/unit/run/checks.rs
+++ b/crates/floe-core/tests/unit/run/checks.rs
@@ -1,13 +1,13 @@
 use std::collections::HashMap;
 
 use floe_core::check::{
-    build_accept_rows, build_errors_json, cast_mismatch_errors, column_index_map, not_null_errors,
-    row_error_formatter, unique_errors, CsvRowErrorFormatter, RowError, RowErrorFormatter,
-    TextRowErrorFormatter,
+    accept_mask_from_error_cols, build_accept_rows, build_errors_json, cast_mismatch_errors,
+    cast_mismatch_expr, column_index_map, not_null_errors, not_null_expr, row_error_formatter,
+    unique_errors, CsvRowErrorFormatter, RowError, RowErrorFormatter, TextRowErrorFormatter,
 };
 use floe_core::config;
 use polars::df;
-use polars::prelude::{DataFrame, NamedFrom, Series};
+use polars::prelude::{DataFrame, IntoLazy, NamedFrom, Series};
 
 #[test]
 fn not_null_errors_flags_missing_required_values() {
@@ -168,4 +168,73 @@ fn text_formatter_includes_source_when_provided() {
     let formatter = row_error_formatter("text", Some(&sources)).expect("formatter");
     let formatted = formatter.format(&errors);
     assert!(formatted.contains("source=ORDER-ID"));
+}
+
+#[test]
+fn not_null_expr_outputs_nullable_json_error_column() {
+    let df = df!("customer_id" => &[Some("A"), None, Some("B")]).expect("create df");
+    let (err_col, expr) = not_null_expr("customer_id");
+
+    let out = df
+        .lazy()
+        .with_columns([expr])
+        .collect()
+        .expect("collect with not_null expr");
+
+    let errors = out
+        .column(&err_col)
+        .expect("error column")
+        .str()
+        .expect("string errors");
+    assert_eq!(errors.get(0), None);
+    assert_eq!(
+        errors.get(1),
+        Some("{\"rule\":\"not_null\",\"column\":\"customer_id\",\"message\":\"required value missing\"}")
+    );
+    assert_eq!(errors.get(2), None);
+}
+
+#[test]
+fn cast_mismatch_expr_outputs_nullable_json_error_column() {
+    let df = df!(
+        "created_at_raw" => &[Some("2024-01-01"), Some("bad-date"), None],
+        "created_at" => &[Some(1i64), None, None]
+    )
+    .expect("create df");
+    let (err_col, expr) = cast_mismatch_expr("created_at", "created_at_raw");
+
+    let out = df
+        .lazy()
+        .with_columns([expr])
+        .collect()
+        .expect("collect with cast expr");
+
+    let errors = out
+        .column(&err_col)
+        .expect("error column")
+        .str()
+        .expect("string errors");
+    assert_eq!(errors.get(0), None);
+    assert_eq!(
+        errors.get(1),
+        Some("{\"rule\":\"cast_error\",\"column\":\"created_at\",\"message\":\"invalid value for target type\"}")
+    );
+    assert_eq!(errors.get(2), None);
+}
+
+#[test]
+fn accept_mask_from_error_cols_accepts_only_rows_with_all_null_error_columns() {
+    let df = df!(
+        "_e_nn_customer_id" => &[None, Some("missing"), None],
+        "_e_cast_created_at" => &[None, None, Some("bad")]
+    )
+    .expect("create df");
+
+    let mask = accept_mask_from_error_cols(&df, &["_e_nn_customer_id", "_e_cast_created_at"])
+        .expect("accept mask");
+
+    assert_eq!(
+        mask.into_iter().collect::<Vec<_>>(),
+        vec![Some(true), Some(false), Some(false)]
+    );
 }

--- a/crates/floe-core/tests/unit/run/checks.rs
+++ b/crates/floe-core/tests/unit/run/checks.rs
@@ -238,3 +238,200 @@ fn accept_mask_from_error_cols_accepts_only_rows_with_all_null_error_columns() {
         vec![Some(true), Some(false), Some(false)]
     );
 }
+
+#[test]
+fn run_expr_checks_detects_not_null_violations() {
+    use floe_core::check::run_expr_checks;
+
+    let df = df!("customer_id" => &[Some("A"), None, Some("B")]).expect("create df");
+    let raw_df = df.clone();
+    let required = vec!["customer_id".to_string()];
+    let columns = vec![config::ColumnConfig {
+        name: "customer_id".to_string(),
+        source: None,
+        column_type: "string".to_string(),
+        nullable: None,
+        unique: None,
+        width: None,
+        trim: None,
+    }];
+
+    let result =
+        run_expr_checks(&df, &raw_df, &required, &columns, false).expect("run_expr_checks");
+
+    assert_eq!(result.col_violation_counts.len(), 1);
+    assert_eq!(result.col_violation_counts[0].0, "_e_nn_customer_id");
+    assert_eq!(result.col_violation_counts[0].1, 1);
+    assert_eq!(result.accept_mask.get(0), Some(true));
+    assert_eq!(result.accept_mask.get(1), Some(false));
+    assert_eq!(result.accept_mask.get(2), Some(true));
+}
+
+#[test]
+fn run_expr_checks_detects_cast_mismatch_violations() {
+    use floe_core::check::run_expr_checks;
+
+    // raw has a string value but typed is null → cast error on row 1; row 2 raw is null → no error
+    let raw_df = df!("score" => &[Some("10"), Some("bad"), None]).expect("raw df");
+    let typed_series = Series::new("score".into(), &[Some(10i64), None, None]);
+    let typed_df = DataFrame::new(vec![typed_series.into()]).expect("typed df");
+
+    let columns = vec![config::ColumnConfig {
+        name: "score".to_string(),
+        source: None,
+        column_type: "integer".to_string(),
+        nullable: Some(true),
+        unique: None,
+        width: None,
+        trim: None,
+    }];
+
+    let result = run_expr_checks(&typed_df, &raw_df, &[], &columns, true).expect("run_expr_checks");
+
+    assert_eq!(result.col_violation_counts.len(), 1);
+    assert_eq!(result.col_violation_counts[0].0, "_e_cast_score");
+    assert_eq!(result.col_violation_counts[0].1, 1);
+    assert_eq!(result.accept_mask.get(0), Some(true));
+    assert_eq!(result.accept_mask.get(1), Some(false));
+    assert_eq!(result.accept_mask.get(2), Some(true));
+}
+
+#[test]
+fn run_expr_checks_accepts_all_rows_when_no_violations() {
+    use floe_core::check::run_expr_checks;
+
+    let df = df!("id" => &[Some("a"), Some("b")]).expect("create df");
+    let raw_df = df.clone();
+    let required = vec!["id".to_string()];
+    let columns = vec![config::ColumnConfig {
+        name: "id".to_string(),
+        source: None,
+        column_type: "string".to_string(),
+        nullable: None,
+        unique: None,
+        width: None,
+        trim: None,
+    }];
+
+    let result =
+        run_expr_checks(&df, &raw_df, &required, &columns, false).expect("run_expr_checks");
+
+    assert_eq!(result.total_violations(), 0);
+    assert!(result.accept_mask.into_iter().all(|v| v == Some(true)));
+}
+
+#[test]
+fn build_errors_formatted_expr_formats_rejected_rows_only() {
+    use floe_core::check::{build_errors_formatted_expr, SparseRowErrors};
+    use polars::prelude::{BooleanChunked, NewChunkedArray};
+
+    let height = 3;
+    let accept_mask = BooleanChunked::from_slice("floe_accept".into(), &[true, false, true]);
+    // null_mask: true = no error (error col is null), false = has error (error col has value)
+    let null_mask = BooleanChunked::from_slice("_e_nn_col_a".into(), &[true, false, true]);
+    let col_masks = vec![("_e_nn_col_a".to_string(), null_mask)];
+    let unique_errors = SparseRowErrors::new(height);
+    let formatter = TextRowErrorFormatter::default();
+
+    let out =
+        build_errors_formatted_expr(height, &accept_mask, &col_masks, &unique_errors, &formatter);
+
+    assert!(out[0].is_none());
+    assert!(out[2].is_none());
+    let msg = out[1].as_ref().expect("row 1 must have error");
+    assert!(msg.contains("not_null"), "expected 'not_null' in: {msg}");
+    assert!(msg.contains("col_a"), "expected 'col_a' in: {msg}");
+}
+
+#[test]
+fn build_errors_formatted_expr_merges_unique_errors() {
+    use floe_core::check::{build_errors_formatted_expr, SparseRowErrors};
+    use polars::prelude::{BooleanChunked, NewChunkedArray};
+
+    let height = 2;
+    let accept_mask = BooleanChunked::from_slice("floe_accept".into(), &[true, false]);
+    let col_masks: Vec<(String, BooleanChunked)> = vec![];
+    let mut unique_errors = SparseRowErrors::new(height);
+    unique_errors.add_error(1, RowError::new("unique", "order_id", "duplicate value"));
+    let formatter = TextRowErrorFormatter::default();
+
+    let out =
+        build_errors_formatted_expr(height, &accept_mask, &col_masks, &unique_errors, &formatter);
+
+    assert!(out[0].is_none());
+    let msg = out[1].as_ref().expect("row 1 must have error");
+    assert!(msg.contains("unique"), "expected 'unique' in: {msg}");
+    assert!(msg.contains("order_id"), "expected 'order_id' in: {msg}");
+}
+
+#[test]
+fn summarize_validation_exprs_counts_not_null_and_cast_violations() {
+    use floe_core::check::SparseRowErrors;
+    use floe_core::report::build::summarize_validation_exprs;
+    use floe_core::report::{RuleName, Severity};
+
+    let col_violation_counts = vec![
+        ("_e_nn_customer_id".to_string(), 3u64),
+        ("_e_cast_created_at".to_string(), 1u64),
+    ];
+    let unique_errors = SparseRowErrors::new(5);
+    let columns = vec![
+        config::ColumnConfig {
+            name: "customer_id".to_string(),
+            source: None,
+            column_type: "string".to_string(),
+            nullable: None,
+            unique: None,
+            width: None,
+            trim: None,
+        },
+        config::ColumnConfig {
+            name: "created_at".to_string(),
+            source: None,
+            column_type: "datetime".to_string(),
+            nullable: Some(true),
+            unique: None,
+            width: None,
+            trim: None,
+        },
+    ];
+
+    let rules = summarize_validation_exprs(
+        &col_violation_counts,
+        &unique_errors,
+        &columns,
+        Severity::Reject,
+        None,
+    );
+
+    assert_eq!(rules.len(), 2);
+    let not_null_rule = rules
+        .iter()
+        .find(|r| r.rule == RuleName::NotNull)
+        .expect("not_null rule");
+    assert_eq!(not_null_rule.violations, 3);
+    assert_eq!(not_null_rule.columns.len(), 1);
+    assert_eq!(not_null_rule.columns[0].column, "customer_id");
+
+    let cast_rule = rules
+        .iter()
+        .find(|r| r.rule == RuleName::CastError)
+        .expect("cast_error rule");
+    assert_eq!(cast_rule.violations, 1);
+    assert_eq!(cast_rule.columns[0].column, "created_at");
+    assert_eq!(
+        cast_rule.columns[0].target_type,
+        Some("datetime".to_string())
+    );
+}
+
+#[test]
+fn summarize_validation_exprs_returns_empty_when_no_violations() {
+    use floe_core::check::SparseRowErrors;
+    use floe_core::report::build::summarize_validation_exprs;
+    use floe_core::report::Severity;
+
+    let rules =
+        summarize_validation_exprs(&[], &SparseRowErrors::new(0), &[], Severity::Warn, None);
+    assert!(rules.is_empty());
+}


### PR DESCRIPTION
Closes #252

## What

Migrates the core validation path (`validate_split.rs`) from row-by-row iteration to Polars columnar operations, and adds the expression-based APIs needed to support it.

## Changes

**`checks/mod.rs`**
- `ExprCheckResult` — carries the accept mask, per-column error masks, and violation counts from a single expression pass
- `run_expr_checks` — evaluates not_null via a lazy expression pass and cast errors via `BooleanChunked` mask operations on the raw/typed DataFrames directly (no join needed)
- `build_errors_formatted_expr` — assembles per-row error strings iterating rejected rows only; merges unique-check errors

**`report/build.rs`**
- `summarize_validation_exprs` — derives rule summaries from expression-check violation counts (`_e_nn_*` / `_e_cast_*`) plus unique errors

**`run/entity/validate_split.rs`**
- Replaced the row-by-row cast+not_null accumulation with:
  1. Fast-path columnar count check — skips the expression pass entirely when there are no violations
  2. `run_expr_checks` for the expression pass
  3. Unique check unchanged (stateful, cross-row)
  4. Combined accept mask from expression + unique results

**`checks/cast.rs`**
- `is_string_type` promoted to `pub(crate)` so `checks/mod.rs` can call it

**`tests/unit/run/checks.rs`**
- 6 new unit tests covering `run_expr_checks`, `build_errors_formatted_expr`, and `summarize_validation_exprs`

## Non-regression

All existing unit tests (419) and integration tests pass unchanged.

https://claude.ai/code/session_01XL7X5BrBqLuvYGLY5zeYVR