### PR TITLE
feat: JIT per-file downloads with LocalInputFile abstraction (issue #127)

### DIFF
--- a/crates/floe-core/src/io/format.rs
+++ b/crates/floe-core/src/io/format.rs
@@ -10,11 +10,22 @@ use crate::{check, config, io, ConfigError, FloeResult};
 #[derive(Debug, Clone)]
 pub struct InputFile {
     pub source_uri: String,
-    pub source_local_path: PathBuf,
     pub source_name: String,
     pub source_stem: String,
     pub source_size: Option<u64>,
     pub source_mtime: Option<String>,
+}
+
+/// An `InputFile` paired with a guaranteed local filesystem path.
+///
+/// For local sources the path is the normalized source path (no copy).
+/// For cloud sources the path is a temp file downloaded just-in-time;
+/// `is_ephemeral` is true and the file should be deleted after use.
+#[derive(Debug, Clone)]
+pub struct LocalInputFile {
+    pub file: InputFile,
+    pub local_path: PathBuf,
+    pub is_ephemeral: bool,
 }
 
 #[derive(Debug, Clone)]
@@ -122,14 +133,14 @@ pub trait InputAdapter: Send + Sync {
     fn read_input_columns(
         &self,
         entity: &config::EntityConfig,
-        input_file: &InputFile,
+        input_file: &LocalInputFile,
         columns: &[config::ColumnConfig],
     ) -> Result<Vec<String>, FileReadError>;
 
     fn read_inputs(
         &self,
         entity: &config::EntityConfig,
-        files: &[InputFile],
+        files: &[LocalInputFile],
         columns: &[config::ColumnConfig],
         normalize_strategy: Option<&str>,
         collect_raw: bool,
@@ -138,7 +149,7 @@ pub trait InputAdapter: Send + Sync {
     fn read_inputs_with_prechecked_columns(
         &self,
         entity: &config::EntityConfig,
-        files: &[InputFile],
+        files: &[LocalInputFile],
         columns: &[config::ColumnConfig],
         normalize_strategy: Option<&str>,
         collect_raw: bool,
@@ -382,7 +393,7 @@ pub fn rejected_sink_adapter(format: &str) -> FloeResult<&'static dyn RejectedSi
 }
 
 pub(crate) fn read_input_from_df(
-    input_file: &InputFile,
+    input_file: &LocalInputFile,
     df: &DataFrame,
     columns: &[config::ColumnConfig],
     normalize_strategy: Option<&str>,
@@ -404,7 +415,7 @@ pub(crate) fn read_input_from_df(
 }
 
 pub(crate) fn finalize_read_input(
-    input_file: &InputFile,
+    input_file: &LocalInputFile,
     mut raw_df: Option<DataFrame>,
     mut typed_df: DataFrame,
     normalize_strategy: Option<&str>,
@@ -416,7 +427,7 @@ pub(crate) fn finalize_read_input(
         crate::checks::normalize::normalize_dataframe_columns(&mut typed_df, strategy)?;
     }
     Ok(ReadInput::Data {
-        input_file: input_file.clone(),
+        input_file: input_file.file.clone(),
         raw_df,
         typed_df,
     })

--- a/crates/floe-core/src/io/read/avro.rs
+++ b/crates/floe-core/src/io/read/avro.rs
@@ -6,7 +6,7 @@ use apache_avro::{Reader, Schema};
 use polars::prelude::{DataFrame, NamedFrom, Series};
 
 use crate::checks::normalize::normalize_name;
-use crate::io::format::{self, FileReadError, InputAdapter, InputFile, ReadInput};
+use crate::io::format::{self, FileReadError, InputAdapter, LocalInputFile, ReadInput};
 use crate::{config, FloeResult};
 
 struct AvroInputAdapter;
@@ -239,10 +239,10 @@ impl InputAdapter for AvroInputAdapter {
     fn read_input_columns(
         &self,
         _entity: &config::EntityConfig,
-        input_file: &InputFile,
+        input_file: &LocalInputFile,
         _columns: &[config::ColumnConfig],
     ) -> Result<Vec<String>, FileReadError> {
-        read_avro_schema_fields(&input_file.source_local_path).map_err(|err| FileReadError {
+        read_avro_schema_fields(&input_file.local_path).map_err(|err| FileReadError {
             rule: err.rule,
             message: err.message,
         })
@@ -251,7 +251,7 @@ impl InputAdapter for AvroInputAdapter {
     fn read_inputs(
         &self,
         entity: &config::EntityConfig,
-        files: &[InputFile],
+        files: &[LocalInputFile],
         columns: &[config::ColumnConfig],
         normalize_strategy: Option<&str>,
         collect_raw: bool,
@@ -264,7 +264,7 @@ impl InputAdapter for AvroInputAdapter {
         let mut inputs = Vec::with_capacity(files.len());
         for input_file in files {
             match read_avro_file(
-                &input_file.source_local_path,
+                &input_file.local_path,
                 cast_mode,
                 &declared_columns,
                 normalize_strategy,
@@ -281,7 +281,7 @@ impl InputAdapter for AvroInputAdapter {
                 }
                 Err(err) => {
                     inputs.push(ReadInput::FileError {
-                        input_file: input_file.clone(),
+                        input_file: input_file.file.clone(),
                         error: FileReadError {
                             rule: err.rule,
                             message: err.message,

--- a/crates/floe-core/src/io/read/csv.rs
+++ b/crates/floe-core/src/io/read/csv.rs
@@ -6,7 +6,7 @@ use polars::prelude::{
 };
 
 use crate::errors::{IoError, RunError};
-use crate::io::format::{self, FileReadError, InputAdapter, InputFile, ReadInput};
+use crate::io::format::{self, FileReadError, InputAdapter, LocalInputFile, ReadInput};
 use crate::{config, FloeResult};
 
 struct DelimitedInputAdapter {
@@ -87,23 +87,23 @@ impl InputAdapter for DelimitedInputAdapter {
     fn read_input_columns(
         &self,
         entity: &config::EntityConfig,
-        input_file: &InputFile,
+        input_file: &LocalInputFile,
         columns: &[config::ColumnConfig],
     ) -> Result<Vec<String>, FileReadError> {
         let default_options = config::SourceOptions::defaults_for_format(self.format);
         let source_options = entity.source.options.as_ref().unwrap_or(&default_options);
-        resolve_input_columns(&input_file.source_local_path, source_options, columns).map_err(
-            |err| FileReadError {
+        resolve_input_columns(&input_file.local_path, source_options, columns).map_err(|err| {
+            FileReadError {
                 rule: format!("{}_read_error", self.format),
                 message: err.to_string(),
-            },
-        )
+            }
+        })
     }
 
     fn read_inputs(
         &self,
         entity: &config::EntityConfig,
-        files: &[InputFile],
+        files: &[LocalInputFile],
         columns: &[config::ColumnConfig],
         normalize_strategy: Option<&str>,
         collect_raw: bool,
@@ -113,7 +113,7 @@ impl InputAdapter for DelimitedInputAdapter {
         let mut inputs = Vec::with_capacity(files.len());
         for input_file in files {
             let input_columns =
-                resolve_input_columns(&input_file.source_local_path, source_options, columns)?;
+                resolve_input_columns(&input_file.local_path, source_options, columns)?;
             inputs.push(read_csv_input_with_columns(
                 input_file,
                 source_options,
@@ -129,7 +129,7 @@ impl InputAdapter for DelimitedInputAdapter {
     fn read_inputs_with_prechecked_columns(
         &self,
         entity: &config::EntityConfig,
-        files: &[InputFile],
+        files: &[LocalInputFile],
         columns: &[config::ColumnConfig],
         normalize_strategy: Option<&str>,
         collect_raw: bool,
@@ -152,14 +152,14 @@ impl InputAdapter for DelimitedInputAdapter {
 }
 
 fn read_csv_input_with_columns(
-    input_file: &InputFile,
+    input_file: &LocalInputFile,
     source_options: &config::SourceOptions,
     columns: &[config::ColumnConfig],
     normalize_strategy: Option<&str>,
     collect_raw: bool,
     input_columns: Vec<String>,
 ) -> FloeResult<ReadInput> {
-    let path = &input_file.source_local_path;
+    let path = &input_file.local_path;
     let typed_projection = if collect_raw {
         projected_columns(&input_columns, columns)
     } else {

--- a/crates/floe-core/src/io/read/fixed_width.rs
+++ b/crates/floe-core/src/io/read/fixed_width.rs
@@ -4,7 +4,7 @@ use std::path::Path;
 
 use polars::prelude::{DataFrame, NamedFrom, Series};
 
-use crate::io::format::{self, FileReadError, InputAdapter, InputFile, ReadInput};
+use crate::io::format::{self, FileReadError, InputAdapter, LocalInputFile, ReadInput};
 use crate::{config, FloeResult};
 
 struct FixedWidthInputAdapter;
@@ -36,7 +36,7 @@ impl InputAdapter for FixedWidthInputAdapter {
     fn read_input_columns(
         &self,
         _entity: &config::EntityConfig,
-        _input_file: &InputFile,
+        _input_file: &LocalInputFile,
         columns: &[config::ColumnConfig],
     ) -> Result<Vec<String>, FileReadError> {
         let specs = build_specs(columns).map_err(|err| FileReadError {
@@ -49,14 +49,14 @@ impl InputAdapter for FixedWidthInputAdapter {
     fn read_inputs(
         &self,
         _entity: &config::EntityConfig,
-        files: &[InputFile],
+        files: &[LocalInputFile],
         columns: &[config::ColumnConfig],
         normalize_strategy: Option<&str>,
         collect_raw: bool,
     ) -> FloeResult<Vec<ReadInput>> {
         let mut inputs = Vec::with_capacity(files.len());
         for input_file in files {
-            let path = &input_file.source_local_path;
+            let path = &input_file.local_path;
             match read_fixed_width_file(path, columns) {
                 Ok(df) => {
                     let input = format::read_input_from_df(
@@ -70,7 +70,7 @@ impl InputAdapter for FixedWidthInputAdapter {
                 }
                 Err(err) => {
                     inputs.push(ReadInput::FileError {
-                        input_file: input_file.clone(),
+                        input_file: input_file.file.clone(),
                         error: FileReadError {
                             rule: err.rule,
                             message: err.message,

--- a/crates/floe-core/src/io/read/json.rs
+++ b/crates/floe-core/src/io/read/json.rs
@@ -5,7 +5,7 @@ use std::path::Path;
 use polars::prelude::{DataFrame, NamedFrom, Series};
 use serde_json::Value;
 
-use crate::io::format::{self, FileReadError, InputAdapter, InputFile, ReadInput};
+use crate::io::format::{self, FileReadError, InputAdapter, LocalInputFile, ReadInput};
 use crate::io::read::json_selector::{
     compact_json, evaluate_selector, parse_selector, SelectorToken, SelectorValue,
 };
@@ -314,7 +314,7 @@ impl InputAdapter for JsonInputAdapter {
     fn read_input_columns(
         &self,
         entity: &config::EntityConfig,
-        input_file: &InputFile,
+        input_file: &LocalInputFile,
         _columns: &[config::ColumnConfig],
     ) -> Result<Vec<String>, FileReadError> {
         let json_mode = entity
@@ -323,7 +323,7 @@ impl InputAdapter for JsonInputAdapter {
             .as_ref()
             .and_then(|options| options.json_mode.as_deref())
             .unwrap_or("array");
-        let path = &input_file.source_local_path;
+        let path = &input_file.local_path;
         let read_result = match json_mode {
             "ndjson" => read_ndjson_columns(path),
             "array" => read_json_array_columns(path),
@@ -344,7 +344,7 @@ impl InputAdapter for JsonInputAdapter {
     fn read_inputs(
         &self,
         entity: &config::EntityConfig,
-        files: &[InputFile],
+        files: &[LocalInputFile],
         columns: &[config::ColumnConfig],
         normalize_strategy: Option<&str>,
         collect_raw: bool,
@@ -358,7 +358,7 @@ impl InputAdapter for JsonInputAdapter {
             .unwrap_or("array");
         let cast_mode = entity.source.cast_mode.as_deref().unwrap_or("strict");
         for input_file in files {
-            let path = &input_file.source_local_path;
+            let path = &input_file.local_path;
             let read_result = match json_mode {
                 "ndjson" => read_ndjson_file(path, columns, cast_mode),
                 "array" => read_json_array_file(path, columns, cast_mode),
@@ -383,7 +383,7 @@ impl InputAdapter for JsonInputAdapter {
                 }
                 Err(err) => {
                     inputs.push(ReadInput::FileError {
-                        input_file: input_file.clone(),
+                        input_file: input_file.file.clone(),
                         error: FileReadError {
                             rule: err.rule,
                             message: err.message,

--- a/crates/floe-core/src/io/read/orc.rs
+++ b/crates/floe-core/src/io/read/orc.rs
@@ -9,7 +9,7 @@ use orc_rust::projection::ProjectionMask;
 use polars::prelude::DataFrame;
 
 use crate::errors::IoError;
-use crate::io::format::{self, FileReadError, InputAdapter, InputFile, ReadInput};
+use crate::io::format::{self, FileReadError, InputAdapter, LocalInputFile, ReadInput};
 use crate::{config, FloeResult};
 
 struct OrcInputAdapter;
@@ -107,10 +107,10 @@ impl InputAdapter for OrcInputAdapter {
     fn read_input_columns(
         &self,
         _entity: &config::EntityConfig,
-        input_file: &InputFile,
+        input_file: &LocalInputFile,
         _columns: &[config::ColumnConfig],
     ) -> Result<Vec<String>, FileReadError> {
-        read_orc_schema_names(&input_file.source_local_path).map_err(|err| FileReadError {
+        read_orc_schema_names(&input_file.local_path).map_err(|err| FileReadError {
             rule: "orc_read_error".to_string(),
             message: err.to_string(),
         })
@@ -119,14 +119,14 @@ impl InputAdapter for OrcInputAdapter {
     fn read_inputs(
         &self,
         _entity: &config::EntityConfig,
-        files: &[InputFile],
+        files: &[LocalInputFile],
         columns: &[config::ColumnConfig],
         normalize_strategy: Option<&str>,
         collect_raw: bool,
     ) -> FloeResult<Vec<ReadInput>> {
         let mut inputs = Vec::with_capacity(files.len());
         for input_file in files {
-            let path = &input_file.source_local_path;
+            let path = &input_file.local_path;
             let input_columns = read_orc_schema_names(path)?;
             let projection = projected_columns(&input_columns, columns);
             let df = read_orc_df(path, projection.as_deref())?;

--- a/crates/floe-core/src/io/read/parquet.rs
+++ b/crates/floe-core/src/io/read/parquet.rs
@@ -3,7 +3,7 @@ use std::path::Path;
 use polars::prelude::{col, DataFrame, LazyFrame, ParquetReader, PlPath, SerReader};
 
 use crate::errors::IoError;
-use crate::io::format::{self, FileReadError, InputAdapter, InputFile, ReadInput};
+use crate::io::format::{self, FileReadError, InputAdapter, LocalInputFile, ReadInput};
 use crate::{config, FloeResult};
 
 struct ParquetInputAdapter;
@@ -61,10 +61,10 @@ impl InputAdapter for ParquetInputAdapter {
     fn read_input_columns(
         &self,
         _entity: &config::EntityConfig,
-        input_file: &InputFile,
+        input_file: &LocalInputFile,
         _columns: &[config::ColumnConfig],
     ) -> Result<Vec<String>, FileReadError> {
-        read_parquet_schema_names(&input_file.source_local_path).map_err(|err| FileReadError {
+        read_parquet_schema_names(&input_file.local_path).map_err(|err| FileReadError {
             rule: "parquet_read_error".to_string(),
             message: err.to_string(),
         })
@@ -73,14 +73,14 @@ impl InputAdapter for ParquetInputAdapter {
     fn read_inputs(
         &self,
         _entity: &config::EntityConfig,
-        files: &[InputFile],
+        files: &[LocalInputFile],
         columns: &[config::ColumnConfig],
         normalize_strategy: Option<&str>,
         collect_raw: bool,
     ) -> FloeResult<Vec<ReadInput>> {
         let mut inputs = Vec::with_capacity(files.len());
         for input_file in files {
-            let path = &input_file.source_local_path;
+            let path = &input_file.local_path;
             let input_columns = read_parquet_schema_names(path)?;
             let projection = projected_columns(&input_columns, columns);
             let df = read_parquet_lazy(path, projection.as_deref())?;

--- a/crates/floe-core/src/io/read/xlsx.rs
+++ b/crates/floe-core/src/io/read/xlsx.rs
@@ -6,7 +6,7 @@ use calamine::{open_workbook, Data, Reader, Xlsx};
 use polars::prelude::{DataFrame, NamedFrom, Series};
 
 use crate::errors::IoError;
-use crate::io::format::{self, FileReadError, InputAdapter, InputFile, ReadInput};
+use crate::io::format::{self, FileReadError, InputAdapter, LocalInputFile, ReadInput};
 use crate::{config, FloeResult};
 
 struct XlsxInputAdapter;
@@ -234,23 +234,22 @@ impl InputAdapter for XlsxInputAdapter {
     fn read_input_columns(
         &self,
         entity: &config::EntityConfig,
-        input_file: &InputFile,
+        input_file: &LocalInputFile,
         _columns: &[config::ColumnConfig],
     ) -> Result<Vec<String>, FileReadError> {
         let options = XlsxOptions::from_source_options(entity.source.options.as_ref());
-        let header = read_xlsx_header(&input_file.source_local_path, &options).map_err(|err| {
-            FileReadError {
+        let header =
+            read_xlsx_header(&input_file.local_path, &options).map_err(|err| FileReadError {
                 rule: err.rule,
                 message: err.message,
-            }
-        })?;
+            })?;
         Ok(header)
     }
 
     fn read_inputs(
         &self,
         entity: &config::EntityConfig,
-        files: &[InputFile],
+        files: &[LocalInputFile],
         columns: &[config::ColumnConfig],
         normalize_strategy: Option<&str>,
         collect_raw: bool,
@@ -258,7 +257,7 @@ impl InputAdapter for XlsxInputAdapter {
         let options = XlsxOptions::from_source_options(entity.source.options.as_ref());
         let mut inputs = Vec::with_capacity(files.len());
         for input_file in files {
-            let path = &input_file.source_local_path;
+            let path = &input_file.local_path;
             let df = read_xlsx_file(path, &options).map_err(|err| {
                 Box::new(IoError(err.to_string())) as Box<dyn std::error::Error + Send + Sync>
             })?;

--- a/crates/floe-core/src/io/read/xml.rs
+++ b/crates/floe-core/src/io/read/xml.rs
@@ -4,7 +4,7 @@ use std::path::Path;
 use polars::prelude::{DataFrame, NamedFrom, Series};
 use roxmltree::{Document, Node};
 
-use crate::io::format::{self, FileReadError, InputAdapter, InputFile, ReadInput};
+use crate::io::format::{self, FileReadError, InputAdapter, LocalInputFile, ReadInput};
 use crate::io::read::xml_selector::{parse_selector, SelectorToken};
 use crate::{config, FloeResult};
 
@@ -285,7 +285,7 @@ impl InputAdapter for XmlInputAdapter {
     fn read_input_columns(
         &self,
         entity: &config::EntityConfig,
-        input_file: &InputFile,
+        input_file: &LocalInputFile,
         _columns: &[config::ColumnConfig],
     ) -> Result<Vec<String>, FileReadError> {
         let (row_tag, namespace, _value_tag) =
@@ -293,21 +293,18 @@ impl InputAdapter for XmlInputAdapter {
                 rule: err.rule,
                 message: err.message,
             })?;
-        read_xml_columns(
-            &input_file.source_local_path,
-            &row_tag,
-            namespace.as_deref(),
-        )
-        .map_err(|err| FileReadError {
-            rule: err.rule,
-            message: err.message,
+        read_xml_columns(&input_file.local_path, &row_tag, namespace.as_deref()).map_err(|err| {
+            FileReadError {
+                rule: err.rule,
+                message: err.message,
+            }
         })
     }
 
     fn read_inputs(
         &self,
         entity: &config::EntityConfig,
-        files: &[InputFile],
+        files: &[LocalInputFile],
         columns: &[config::ColumnConfig],
         normalize_strategy: Option<&str>,
         collect_raw: bool,
@@ -318,7 +315,7 @@ impl InputAdapter for XmlInputAdapter {
             Err(err) => {
                 for input_file in files {
                     inputs.push(ReadInput::FileError {
-                        input_file: input_file.clone(),
+                        input_file: input_file.file.clone(),
                         error: FileReadError {
                             rule: err.rule.clone(),
                             message: err.message.clone(),
@@ -330,7 +327,7 @@ impl InputAdapter for XmlInputAdapter {
         };
 
         for input_file in files {
-            let path = &input_file.source_local_path;
+            let path = &input_file.local_path;
             let read_result = read_xml_file(
                 path,
                 columns,
@@ -351,7 +348,7 @@ impl InputAdapter for XmlInputAdapter {
                 }
                 Err(err) => {
                     inputs.push(ReadInput::FileError {
-                        input_file: input_file.clone(),
+                        input_file: input_file.file.clone(),
                         error: FileReadError {
                             rule: err.rule,
                             message: err.message,

--- a/crates/floe-core/src/io/storage/ops/inputs.rs
+++ b/crates/floe-core/src/io/storage/ops/inputs.rs
@@ -3,6 +3,7 @@ use std::time::SystemTime;
 
 use glob::{MatchOptions, Pattern};
 
+use crate::errors::RunError;
 use crate::io::storage::{planner, Target};
 use crate::{config, io, report, FloeResult};
 
@@ -91,6 +92,7 @@ pub fn resolve_inputs(
             let resolved =
                 adapter.resolve_local_inputs(config_dir, &entity.name, &entity.source, storage)?;
             let listed = build_local_listing(&resolved.files, storage_client);
+            // Download mode lists files for processing; ListOnly produces only URIs for dry-run.
             let files = match resolution_mode {
                 ResolveInputsMode::Download => {
                     build_local_inputs(&resolved.files, entity, storage_client)
@@ -120,30 +122,19 @@ fn resolve_cloud_inputs_for_prefix(
     storage: &str,
     location: &str,
     resolution_mode: ResolveInputsMode,
-    temp_dir: Option<&Path>,
+    _temp_dir: Option<&Path>,
 ) -> FloeResult<ResolvedInputs> {
     let objects = list_cloud_objects(client, prefix, adapter, entity, storage, location)?;
     let listed = objects.iter().map(|obj| obj.uri.clone()).collect();
+    // Download mode now lists metadata only; actual downloads happen JIT in the entity run.
     let files = match resolution_mode {
-        ResolveInputsMode::Download => {
-            let temp_dir = require_temp_dir(temp_dir, storage)?;
-            build_cloud_inputs(client, &objects, temp_dir, entity)?
-        }
+        ResolveInputsMode::Download => list_cloud_inputs(&objects, entity),
         ResolveInputsMode::ListOnly => Vec::new(),
     };
     Ok(ResolvedInputs {
         files,
         listed,
         mode: report::ResolvedInputMode::Directory,
-    })
-}
-
-fn require_temp_dir<'a>(temp_dir: Option<&'a Path>, label: &str) -> FloeResult<&'a Path> {
-    temp_dir.ok_or_else(|| -> Box<dyn std::error::Error + Send + Sync> {
-        Box::new(crate::errors::RunError(format!(
-            "{} tempdir missing",
-            label
-        )))
     })
 }
 
@@ -191,30 +182,28 @@ fn list_cloud_objects(
     Ok(filtered)
 }
 
-fn build_cloud_inputs(
-    client: &dyn crate::io::storage::StorageClient,
+/// Builds `InputFile` metadata from cloud object refs without downloading.
+/// Downloads happen later, JIT per file, via [`localize_input`].
+fn list_cloud_inputs(
     objects: &[io::storage::planner::ObjectRef],
-    temp_dir: &Path,
     entity: &config::EntityConfig,
-) -> FloeResult<Vec<io::format::InputFile>> {
-    let mut inputs = Vec::with_capacity(objects.len());
-    for object in objects {
-        let local_path = client.download_to_temp(&object.uri, temp_dir)?;
-        let source_name =
-            planner::file_name_from_key(&object.key).unwrap_or_else(|| entity.name.clone());
-        let source_stem =
-            planner::file_stem_from_name(&source_name).unwrap_or_else(|| entity.name.clone());
-        let source_uri = object.uri.clone();
-        inputs.push(io::format::InputFile {
-            source_uri,
-            source_local_path: local_path,
-            source_name,
-            source_stem,
-            source_size: object.size,
-            source_mtime: object.last_modified.clone(),
-        });
-    }
-    Ok(inputs)
+) -> Vec<io::format::InputFile> {
+    objects
+        .iter()
+        .map(|object| {
+            let source_name =
+                planner::file_name_from_key(&object.key).unwrap_or_else(|| entity.name.clone());
+            let source_stem =
+                planner::file_stem_from_name(&source_name).unwrap_or_else(|| entity.name.clone());
+            io::format::InputFile {
+                source_uri: object.uri.clone(),
+                source_name,
+                source_stem,
+                source_size: object.size,
+                source_mtime: object.last_modified.clone(),
+            }
+        })
+        .collect()
 }
 
 fn build_local_inputs(
@@ -246,7 +235,6 @@ fn build_local_inputs(
                 .unwrap_or_else(|| normalized_path.display().to_string());
             io::format::InputFile {
                 source_uri: uri,
-                source_local_path: normalized_path,
                 source_name,
                 source_stem,
                 source_size: metadata.as_ref().map(|metadata| metadata.len()),
@@ -257,6 +245,54 @@ fn build_local_inputs(
             }
         })
         .collect()
+}
+
+/// Resolves an `InputFile` to a `LocalInputFile` with a guaranteed local path.
+///
+/// For cloud URIs (s3://, gs://, abfs://) the file is downloaded to `temp_dir`
+/// and `is_ephemeral` is set to `true` so callers can delete it after use.
+/// For local URIs the source path is used directly with no copy.
+pub fn localize_input(
+    input_file: io::format::InputFile,
+    storage_client: Option<&dyn crate::io::storage::StorageClient>,
+    temp_dir: Option<&Path>,
+) -> FloeResult<io::format::LocalInputFile> {
+    if is_cloud_uri(&input_file.source_uri) {
+        let client = storage_client.ok_or_else(|| {
+            Box::new(RunError(format!(
+                "storage client required to download {}",
+                input_file.source_uri
+            ))) as Box<dyn std::error::Error + Send + Sync>
+        })?;
+        let temp = temp_dir.ok_or_else(|| {
+            Box::new(RunError(format!(
+                "temp_dir required to download {}",
+                input_file.source_uri
+            ))) as Box<dyn std::error::Error + Send + Sync>
+        })?;
+        let local_path = client.download_to_temp(&input_file.source_uri, temp)?;
+        Ok(io::format::LocalInputFile {
+            file: input_file,
+            local_path,
+            is_ephemeral: true,
+        })
+    } else {
+        // Local URI: strip the "local://" scheme if present; the rest is the path.
+        let path_str = input_file.source_uri.trim_start_matches("local://");
+        Ok(io::format::LocalInputFile {
+            local_path: PathBuf::from(path_str),
+            file: input_file,
+            is_ephemeral: false,
+        })
+    }
+}
+
+fn is_cloud_uri(uri: &str) -> bool {
+    uri.starts_with("s3://")
+        || uri.starts_with("gs://")
+        || uri.starts_with("abfs://")
+        || uri.starts_with("az://")
+        || uri.starts_with("gcs://")
 }
 
 fn system_time_to_rfc3339(value: SystemTime) -> Option<String> {

--- a/crates/floe-core/src/run/entity/precheck.rs
+++ b/crates/floe-core/src/run/entity/precheck.rs
@@ -74,6 +74,7 @@ pub(super) fn run_precheck(
         });
 
         // JIT download: resolve listed InputFile to a LocalInputFile before any reads.
+        let listed_source_uri = listed_file.source_uri.clone();
         let storage_client = cloud
             .client_for_context(&context.storage_resolver, storage_name, &entity.name)
             .ok()
@@ -91,9 +92,8 @@ pub(super) fn run_precheck(
                 } else {
                     report::MismatchAction::RejectedFile
                 };
-                let source_uri = err.to_string();
                 let file_report = report::FileReport {
-                    input_file: source_uri.clone(),
+                    input_file: listed_source_uri.clone(),
                     status,
                     row_count: 0,
                     accepted_count: 0,
@@ -125,6 +125,22 @@ pub(super) fn run_precheck(
                 totals.errors_total += 1;
                 file_reports.push(file_report);
                 file_timings_ms.push(Some(file_timer.elapsed().as_millis() as u64));
+                observer.on_event(crate::run::events::RunEvent::FileFinished {
+                    run_id: context.run_id.clone(),
+                    entity: entity.name.clone(),
+                    input: listed_source_uri.clone(),
+                    status: if status == report::FileStatus::Aborted {
+                        "aborted"
+                    } else {
+                        "rejected"
+                    }
+                    .to_string(),
+                    rows: 0,
+                    accepted: 0,
+                    rejected: 0,
+                    elapsed_ms: file_timer.elapsed().as_millis() as u64,
+                    ts_ms: crate::run::events::event_time_ms(),
+                });
                 if status == report::FileStatus::Aborted {
                     abort_run = true;
                     break;

--- a/crates/floe-core/src/run/entity/precheck.rs
+++ b/crates/floe-core/src/run/entity/precheck.rs
@@ -60,8 +60,10 @@ pub(super) fn run_precheck(
     let mismatch_columns =
         check::resolve_mismatch_columns(entity, normalized_columns, normalize_strategy.as_deref())?;
 
-    // Resolve the storage client once for JIT downloads.
-    let storage_name = entity.source.storage.as_deref().unwrap_or("local");
+    // Use the resolved source target's storage name so that default-remote configs
+    // (where source.storage is unset but the resolver default is S3/GCS/ADLS) get
+    // the correct client instead of falling back to "local".
+    let storage_name = resolved_targets.source.storage();
     let temp_dir_path = temp_dir.as_ref().map(|d| d.path());
 
     for listed_file in input_files {

--- a/crates/floe-core/src/run/entity/precheck.rs
+++ b/crates/floe-core/src/run/entity/precheck.rs
@@ -6,10 +6,11 @@ use crate::{check, config, io, report, warnings, ConfigError, FloeResult};
 use super::super::output::{validate_rejected_target, write_rejected_raw_output};
 use super::ResolvedEntityTargets;
 use crate::run::RunContext;
-use io::format::InputAdapter;
+use io::format::{InputAdapter, InputFile, LocalInputFile};
+use io::storage::inputs::localize_input;
 
 pub(super) struct PrecheckedInput {
-    pub(super) input_file: io::format::InputFile,
+    pub(super) input_file: LocalInputFile,
     pub(super) input_columns: Vec<String>,
     pub(super) mismatch: check::MismatchOutcome,
     pub(super) file_timer: Instant,
@@ -37,7 +38,7 @@ pub(super) struct PrecheckContext<'a> {
 
 pub(super) fn run_precheck(
     context: PrecheckContext<'_>,
-    input_files: Vec<io::format::InputFile>,
+    input_files: Vec<InputFile>,
 ) -> FloeResult<PrecheckResult> {
     let PrecheckContext {
         context,
@@ -58,16 +59,82 @@ pub(super) fn run_precheck(
     let normalize_strategy = resolve_normalize_strategy(entity)?;
     let mismatch_columns =
         check::resolve_mismatch_columns(entity, normalized_columns, normalize_strategy.as_deref())?;
-    for input_file in input_files {
+
+    // Resolve the storage client once for JIT downloads.
+    let storage_name = entity.source.storage.as_deref().unwrap_or("local");
+    let temp_dir_path = temp_dir.as_ref().map(|d| d.path());
+
+    for listed_file in input_files {
         let file_timer = Instant::now();
         observer.on_event(crate::run::events::RunEvent::FileStarted {
             run_id: context.run_id.clone(),
             entity: entity.name.clone(),
-            input: input_file.source_uri.clone(),
+            input: listed_file.source_uri.clone(),
             ts_ms: crate::run::events::event_time_ms(),
         });
+
+        // JIT download: resolve listed InputFile to a LocalInputFile before any reads.
+        let storage_client = cloud
+            .client_for_context(&context.storage_resolver, storage_name, &entity.name)
+            .ok()
+            .map(|c| c as &dyn io::storage::StorageClient);
+        let local_file = match localize_input(listed_file, storage_client, temp_dir_path) {
+            Ok(f) => f,
+            Err(err) => {
+                let status = if entity.policy.severity == "abort" {
+                    report::FileStatus::Aborted
+                } else {
+                    report::FileStatus::Rejected
+                };
+                let mismatch_action = if status == report::FileStatus::Aborted {
+                    report::MismatchAction::Aborted
+                } else {
+                    report::MismatchAction::RejectedFile
+                };
+                let source_uri = err.to_string();
+                let file_report = report::FileReport {
+                    input_file: source_uri.clone(),
+                    status,
+                    row_count: 0,
+                    accepted_count: 0,
+                    rejected_count: 0,
+                    mismatch: report::FileMismatch {
+                        declared_columns_count: mismatch_columns.len() as u64,
+                        input_columns_count: 0,
+                        missing_columns: Vec::new(),
+                        extra_columns: Vec::new(),
+                        mismatch_action,
+                        error: Some(report::MismatchIssue {
+                            rule: "download_error".to_string(),
+                            message: format!("entity.name={} {err}", entity.name),
+                        }),
+                        warning: None,
+                    },
+                    output: report::FileOutput {
+                        accepted_path: None,
+                        rejected_path: None,
+                        errors_path: None,
+                        archived_path: None,
+                    },
+                    validation: report::FileValidation {
+                        errors: 1,
+                        warnings: 0,
+                        rules: Vec::new(),
+                    },
+                };
+                totals.errors_total += 1;
+                file_reports.push(file_report);
+                file_timings_ms.push(Some(file_timer.elapsed().as_millis() as u64));
+                if status == report::FileStatus::Aborted {
+                    abort_run = true;
+                    break;
+                }
+                continue;
+            }
+        };
+
         let input_columns =
-            match input_adapter.read_input_columns(entity, &input_file, normalized_columns) {
+            match input_adapter.read_input_columns(entity, &local_file, normalized_columns) {
                 Ok(columns) => columns,
                 Err(error) => {
                     let status = if entity.policy.severity == "abort" {
@@ -87,8 +154,8 @@ pub(super) fn run_precheck(
                         .map(|target| {
                             write_rejected_raw_output(
                                 target,
-                                &input_file,
-                                temp_dir.as_ref().map(|dir| dir.path()),
+                                &local_file,
+                                temp_dir_path,
                                 cloud,
                                 &context.storage_resolver,
                                 entity,
@@ -97,7 +164,7 @@ pub(super) fn run_precheck(
                         .transpose()?;
 
                     let file_report = report::FileReport {
-                        input_file: input_file.source_uri.clone(),
+                        input_file: local_file.file.source_uri.clone(),
                         status,
                         row_count: 0,
                         accepted_count: 0,
@@ -133,7 +200,7 @@ pub(super) fn run_precheck(
                     observer.on_event(crate::run::events::RunEvent::FileFinished {
                         run_id: context.run_id.clone(),
                         entity: entity.name.clone(),
-                        input: input_file.source_uri.clone(),
+                        input: local_file.file.source_uri.clone(),
                         status: if status == report::FileStatus::Aborted {
                             "aborted"
                         } else {
@@ -147,6 +214,9 @@ pub(super) fn run_precheck(
                         ts_ms: crate::run::events::event_time_ms(),
                     });
 
+                    if local_file.is_ephemeral {
+                        let _ = std::fs::remove_file(&local_file.local_path);
+                    }
                     if status == report::FileStatus::Aborted {
                         abort_run = true;
                         break;
@@ -160,7 +230,7 @@ pub(super) fn run_precheck(
             warnings::emit(
                 &context.run_id,
                 Some(&entity.name),
-                Some(&input_file.source_uri),
+                Some(&local_file.file.source_uri),
                 Some("schema_mismatch_warn_override"),
                 message,
             );
@@ -180,8 +250,8 @@ pub(super) fn run_precheck(
             })?;
             let rejected_path = Some(write_rejected_raw_output(
                 rejected_target,
-                &input_file,
-                temp_dir.as_ref().map(|dir| dir.path()),
+                &local_file,
+                temp_dir_path,
                 cloud,
                 &context.storage_resolver,
                 entity,
@@ -193,7 +263,7 @@ pub(super) fn run_precheck(
                 &context.run_id,
                 entity,
                 archive_target,
-                &input_file,
+                &local_file.file,
             )?;
 
             let status = if mismatch.aborted {
@@ -208,7 +278,7 @@ pub(super) fn run_precheck(
             let warnings = mismatch.warnings;
 
             let file_report = report::FileReport {
-                input_file: input_file.source_uri.clone(),
+                input_file: local_file.file.source_uri.clone(),
                 status,
                 row_count,
                 accepted_count,
@@ -237,7 +307,7 @@ pub(super) fn run_precheck(
             observer.on_event(crate::run::events::RunEvent::FileFinished {
                 run_id: context.run_id.clone(),
                 entity: entity.name.clone(),
-                input: input_file.source_uri.clone(),
+                input: local_file.file.source_uri.clone(),
                 status: if status == report::FileStatus::Aborted {
                     "aborted"
                 } else {
@@ -251,6 +321,9 @@ pub(super) fn run_precheck(
                 ts_ms: crate::run::events::event_time_ms(),
             });
 
+            if local_file.is_ephemeral {
+                let _ = std::fs::remove_file(&local_file.local_path);
+            }
             if mismatch.aborted {
                 abort_run = true;
                 break;
@@ -259,7 +332,7 @@ pub(super) fn run_precheck(
         }
 
         prechecked_inputs.push(PrecheckedInput {
-            input_file,
+            input_file: local_file,
             input_columns,
             mismatch,
             file_timer,

--- a/crates/floe-core/src/run/entity/validate_split.rs
+++ b/crates/floe-core/src/run/entity/validate_split.rs
@@ -102,7 +102,7 @@ pub(super) fn run_validate_split_phase(
 
     for prechecked in prechecked_inputs {
         let PrecheckedInput {
-            input_file,
+            input_file: local_file,
             input_columns,
             mismatch,
             file_timer,
@@ -110,7 +110,7 @@ pub(super) fn run_validate_split_phase(
         let read_parse_start = perf_enabled.then(Instant::now);
         let mut inputs = input_adapter.read_inputs_with_prechecked_columns(
             entity,
-            std::slice::from_ref(&input_file),
+            std::slice::from_ref(&local_file),
             read_columns,
             normalize_strategy,
             collect_raw,
@@ -154,7 +154,7 @@ pub(super) fn run_validate_split_phase(
                     .map(|target| {
                         write_rejected_raw_output(
                             target,
-                            &input_file,
+                            &local_file,
                             temp_dir,
                             runtime.storage(),
                             &run_context.storage_resolver,
@@ -200,6 +200,9 @@ pub(super) fn run_validate_split_phase(
                 file_reports.push(file_report);
                 file_timings_ms.push(Some(file_timer.elapsed().as_millis() as u64));
 
+                if local_file.is_ephemeral {
+                    let _ = std::fs::remove_file(&local_file.local_path);
+                }
                 if status == report::FileStatus::Aborted {
                     abort_run = true;
                     break;
@@ -464,7 +467,7 @@ pub(super) fn run_validate_split_phase(
                     let rejected_write_start = perf_enabled.then(Instant::now);
                     let rejected_path_value = write_rejected_raw_output(
                         rejected_target,
-                        &input_file,
+                        &local_file,
                         temp_dir,
                         runtime.storage(),
                         &run_context.storage_resolver,
@@ -607,6 +610,9 @@ pub(super) fn run_validate_split_phase(
             ts_ms: event_time_ms(),
         });
 
+        if local_file.is_ephemeral {
+            let _ = std::fs::remove_file(&local_file.local_path);
+        }
         if status == report::FileStatus::Aborted {
             abort_run = true;
             break;

--- a/crates/floe-core/src/run/output.rs
+++ b/crates/floe-core/src/run/output.rs
@@ -5,7 +5,7 @@ use polars::prelude::DataFrame;
 use crate::errors::RunError;
 use crate::{check, config, io, ConfigError, FloeResult};
 
-use io::format::{self, InputFile};
+use io::format::{self, LocalInputFile};
 use io::storage::Target;
 
 pub(super) struct AcceptedOutputContext<'a> {
@@ -89,7 +89,7 @@ pub(super) fn write_rejected_output(context: RejectedOutputContext<'_>) -> FloeR
 
 pub(super) fn write_rejected_raw_output(
     target: &Target,
-    input_file: &InputFile,
+    input_file: &LocalInputFile,
     temp_dir: Option<&Path>,
     cloud: &mut io::storage::CloudClient,
     resolver: &config::StorageResolver,
@@ -98,13 +98,13 @@ pub(super) fn write_rejected_raw_output(
     io::storage::output::write_output(
         target,
         io::storage::OutputPlacement::Output,
-        &input_file.source_name,
+        &input_file.file.source_name,
         temp_dir,
         cloud,
         resolver,
         entity,
         |path| {
-            io::write::write_rejected_raw(&input_file.source_local_path, path)?;
+            io::write::write_rejected_raw(&input_file.local_path, path)?;
             Ok(())
         },
     )

--- a/crates/floe-core/tests/unit/io/storage/inputs.rs
+++ b/crates/floe-core/tests/unit/io/storage/inputs.rs
@@ -150,7 +150,7 @@ impl io::format::InputAdapter for MockAdapter {
     fn read_input_columns(
         &self,
         _entity: &config::EntityConfig,
-        _input_file: &io::format::InputFile,
+        _input_file: &io::format::LocalInputFile,
         _columns: &[config::ColumnConfig],
     ) -> Result<Vec<String>, io::format::FileReadError> {
         Ok(vec!["id".to_string()])
@@ -159,7 +159,7 @@ impl io::format::InputAdapter for MockAdapter {
     fn read_inputs(
         &self,
         _entity: &config::EntityConfig,
-        _files: &[io::format::InputFile],
+        _files: &[io::format::LocalInputFile],
         _columns: &[config::ColumnConfig],
         _normalize_strategy: Option<&str>,
         _collect_raw: bool,
@@ -182,7 +182,7 @@ impl io::format::InputAdapter for MockParquetAdapter {
     fn read_input_columns(
         &self,
         _entity: &config::EntityConfig,
-        _input_file: &io::format::InputFile,
+        _input_file: &io::format::LocalInputFile,
         _columns: &[config::ColumnConfig],
     ) -> Result<Vec<String>, io::format::FileReadError> {
         Ok(vec!["id".to_string()])
@@ -191,7 +191,7 @@ impl io::format::InputAdapter for MockParquetAdapter {
     fn read_inputs(
         &self,
         _entity: &config::EntityConfig,
-        _files: &[io::format::InputFile],
+        _files: &[io::format::LocalInputFile],
         _columns: &[config::ColumnConfig],
         _normalize_strategy: Option<&str>,
         _collect_raw: bool,
@@ -277,9 +277,6 @@ fn resolve_inputs_s3_filters_and_downloads() -> FloeResult<()> {
     assert_eq!(resolved.listed.len(), 2);
     assert!(resolved.files[0].source_uri.ends_with("data/a.csv"));
     assert!(resolved.files[1].source_uri.ends_with("data/b.csv"));
-    for input in resolved.files {
-        assert!(input.source_local_path.exists());
-    }
     Ok(())
 }
 
@@ -508,7 +505,6 @@ fn resolve_inputs_local_normalizes_resolved_file_paths() -> FloeResult<()> {
 
     assert_eq!(resolved.files.len(), 1);
     let normalized = temp_dir.path().join("in/data.csv");
-    assert_eq!(resolved.files[0].source_local_path, normalized);
     assert_eq!(
         resolved.files[0].source_uri,
         normalized.display().to_string()


### PR DESCRIPTION
## Summary

Closes #127.

Refactors remote input handling so cloud files are downloaded just-in-time per-file instead of all upfront, giving better memory control and per-file error reporting.

**Key changes:**

- Split `InputFile` (identity/metadata only) from `LocalInputFile` (adds `local_path` + `is_ephemeral` flag) in `io/format.rs`
- Updated `InputAdapter` trait: `read_input_columns` and `read_inputs` now take `&LocalInputFile` / `&[LocalInputFile]`
- Added `localize_input()` in `io/storage/ops/inputs.rs`: detects cloud URIs by scheme prefix, downloads to temp; for local paths strips `local://` prefix. `resolve_inputs` now only lists metadata (no upfront downloads).
- Rewrote `run_precheck` to download each file JIT before schema check; download errors produce per-file `FileReport` with `rule: "download_error"` instead of aborting the whole batch.
- Updated `validate_split` to use `LocalInputFile` from `PrecheckedInput` and delete ephemeral temp files after each file is processed.
- Updated all 8 read adapters and write helpers for the new types.

https://claude.ai/code/session_01XL7X5BrBqLuvYGLY5zeYVR

---
_Generated by [Claude Code](https://claude.ai/code/session_01XL7X5BrBqLuvYGLY5zeYVR)_