### PR TITLE
feat(run): add --profile flag to inject profile variables at run time

### DIFF
--- a/crates/floe-cli/src/main.rs
+++ b/crates/floe-cli/src/main.rs
@@ -347,11 +347,7 @@ fn main() -> FloeResult<()> {
                     }
                 };
                 if let Err(err) = validate_profile(&parsed) {
-                    logging::emit_failed_run_events(
-                        &computed_run_id,
-                        err.as_ref(),
-                        &log_format,
-                    );
+                    logging::emit_failed_run_events(&computed_run_id, err.as_ref(), &log_format);
                     let mut err_out = std::io::stderr().lock();
                     let _ = writeln!(err_out, "Error: {err}");
                     let _ = err_out.flush();

--- a/crates/floe-cli/src/main.rs
+++ b/crates/floe-cli/src/main.rs
@@ -151,6 +151,8 @@ enum Command {
         log_format: LogFormat,
         #[arg(long, help = "Resolve and print inputs/outputs without executing")]
         dry_run: bool,
+        #[arg(long, help = "Optional path to a Floe environment profile YAML file")]
+        profile: Option<String>,
     },
     #[command(
         about = "Generate orchestrator manifest JSON",
@@ -267,6 +269,7 @@ fn main() -> FloeResult<()> {
 
             let options = ValidateOptions {
                 entities: entities.clone(),
+                profile_vars: std::collections::HashMap::new(),
             };
 
             let validation_result =
@@ -321,15 +324,49 @@ fn main() -> FloeResult<()> {
             verbose,
             log_format,
             dry_run,
+            profile,
         } => {
             let started_at = floe_core::report::now_rfc3339();
             let computed_run_id =
                 run_id.unwrap_or_else(|| floe_core::report::run_id_from_timestamp(&started_at));
 
+            let profile_config = if let Some(ref profile_path) = profile {
+                let path = std::path::Path::new(profile_path);
+                let parsed = match parse_profile(path) {
+                    Ok(p) => p,
+                    Err(err) => {
+                        logging::emit_failed_run_events(
+                            &computed_run_id,
+                            err.as_ref(),
+                            &log_format,
+                        );
+                        let mut err_out = std::io::stderr().lock();
+                        let _ = writeln!(err_out, "Error: {err}");
+                        let _ = err_out.flush();
+                        std::process::exit(1);
+                    }
+                };
+                if let Err(err) = validate_profile(&parsed) {
+                    logging::emit_failed_run_events(
+                        &computed_run_id,
+                        err.as_ref(),
+                        &log_format,
+                    );
+                    let mut err_out = std::io::stderr().lock();
+                    let _ = writeln!(err_out, "Error: {err}");
+                    let _ = err_out.flush();
+                    std::process::exit(1);
+                }
+                Some(parsed)
+            } else {
+                None
+            };
+
             let options = RunOptions {
                 run_id: Some(computed_run_id.clone()),
                 entities,
                 dry_run,
+                profile: profile_config,
             };
             logging::install_observer(log_format.clone());
 
@@ -402,6 +439,7 @@ fn main() -> FloeResult<()> {
 
                 let options = ValidateOptions {
                     entities: entities.clone(),
+                    profile_vars: std::collections::HashMap::new(),
                 };
                 if let Err(err) =
                     validate_with_base(&config_location.path, config_location.base.clone(), options)

--- a/crates/floe-core/src/config/mod.rs
+++ b/crates/floe-core/src/config/mod.rs
@@ -12,6 +12,6 @@ pub use location::{resolve_config_location, ConfigLocation};
 pub use storage::{resolve_local_path, ConfigBase, ResolvedPath, StorageResolver};
 pub use types::*;
 
-pub(crate) use parse::parse_config;
-pub(crate) use template::apply_templates;
+pub(crate) use parse::{parse_config, parse_config_with_vars};
+pub(crate) use template::apply_templates_with_vars;
 pub(crate) use validate::validate_config;

--- a/crates/floe-core/src/config/mod.rs
+++ b/crates/floe-core/src/config/mod.rs
@@ -12,6 +12,6 @@ pub use location::{resolve_config_location, ConfigLocation};
 pub use storage::{resolve_local_path, ConfigBase, ResolvedPath, StorageResolver};
 pub use types::*;
 
-pub(crate) use parse::{parse_config, parse_config_with_vars};
+pub(crate) use parse::{extract_raw_env_vars, parse_config, parse_config_with_vars};
 pub(crate) use template::apply_templates_with_vars;
 pub(crate) use validate::validate_config;

--- a/crates/floe-core/src/config/parse.rs
+++ b/crates/floe-core/src/config/parse.rs
@@ -5,6 +5,7 @@ use yaml_rust2::yaml::Hash;
 use yaml_rust2::Yaml;
 
 use crate::config::apply_templates_with_vars;
+use crate::config::storage::resolve_local_path;
 use crate::config::yaml_decode::{
     hash_get, load_yaml, validate_known_keys, yaml_array, yaml_hash, yaml_string,
 };
@@ -23,10 +24,12 @@ pub(crate) fn parse_config(path: &Path) -> FloeResult<RootConfig> {
     parse_config_with_vars(path, &std::collections::HashMap::new())
 }
 
-/// Read only the `env.vars` section from a config file without full parsing or
+/// Read `env.file` and `env.vars` from a config file without full parsing or
 /// template substitution.  Used to seed `VarSources.config` when resolving
-/// profile variables so that config-level overrides are respected during
-/// `${REF}` expansion inside profile variable values.
+/// profile variables so that config-level overrides (both sources) are
+/// respected during `${REF}` expansion inside profile variable values.
+///
+/// Priority matches `build_env_vars`: `env.vars` overwrites `env.file`.
 pub(crate) fn extract_raw_env_vars(path: &Path) -> FloeResult<HashMap<String, String>> {
     let docs = load_yaml(path)?;
     if docs.is_empty() {
@@ -36,16 +39,46 @@ pub(crate) fn extract_raw_env_vars(path: &Path) -> FloeResult<HashMap<String, St
         Ok(h) => h,
         Err(_) => return Ok(HashMap::new()),
     };
-    match hash_get(root, "env") {
-        Some(env_node) => match yaml_hash(env_node, "env") {
-            Ok(env_hash) => match hash_get(env_hash, "vars") {
-                Some(vars_node) => parse_string_map(vars_node, "env.vars"),
-                None => Ok(HashMap::new()),
-            },
-            Err(_) => Ok(HashMap::new()),
-        },
-        None => Ok(HashMap::new()),
+    let env_node = match hash_get(root, "env") {
+        Some(n) => n,
+        None => return Ok(HashMap::new()),
+    };
+    let env_hash = match yaml_hash(env_node, "env") {
+        Ok(h) => h,
+        Err(_) => return Ok(HashMap::new()),
+    };
+
+    let config_dir = path.parent().unwrap_or_else(|| Path::new("."));
+    let mut vars = HashMap::new();
+
+    // env.file — lower priority, loaded first
+    if let Some(file_node) = hash_get(env_hash, "file") {
+        if let Ok(file_str) = yaml_string(file_node, "env.file") {
+            let file_path = resolve_local_path(config_dir, &file_str);
+            if let Ok(file_docs) = load_yaml(&file_path) {
+                if let Some(doc) = file_docs.first() {
+                    if let Ok(h) = yaml_hash(doc, "env.file") {
+                        for (k, v) in h {
+                            if let (Ok(key), Ok(val)) =
+                                (yaml_string(k, "env.file"), yaml_string(v, "env.file"))
+                            {
+                                vars.insert(key, val);
+                            }
+                        }
+                    }
+                }
+            }
+        }
     }
+
+    // env.vars — higher priority, overwrites env.file
+    if let Some(vars_node) = hash_get(env_hash, "vars") {
+        if let Ok(inline) = parse_string_map(vars_node, "env.vars") {
+            vars.extend(inline);
+        }
+    }
+
+    Ok(vars)
 }
 
 pub(crate) fn parse_config_with_vars(

--- a/crates/floe-core/src/config/parse.rs
+++ b/crates/floe-core/src/config/parse.rs
@@ -23,6 +23,31 @@ pub(crate) fn parse_config(path: &Path) -> FloeResult<RootConfig> {
     parse_config_with_vars(path, &std::collections::HashMap::new())
 }
 
+/// Read only the `env.vars` section from a config file without full parsing or
+/// template substitution.  Used to seed `VarSources.config` when resolving
+/// profile variables so that config-level overrides are respected during
+/// `${REF}` expansion inside profile variable values.
+pub(crate) fn extract_raw_env_vars(path: &Path) -> FloeResult<HashMap<String, String>> {
+    let docs = load_yaml(path)?;
+    if docs.is_empty() {
+        return Ok(HashMap::new());
+    }
+    let root = match yaml_hash(&docs[0], "root") {
+        Ok(h) => h,
+        Err(_) => return Ok(HashMap::new()),
+    };
+    match hash_get(root, "env") {
+        Some(env_node) => match yaml_hash(env_node, "env") {
+            Ok(env_hash) => match hash_get(env_hash, "vars") {
+                Some(vars_node) => parse_string_map(vars_node, "env.vars"),
+                None => Ok(HashMap::new()),
+            },
+            Err(_) => Ok(HashMap::new()),
+        },
+        None => Ok(HashMap::new()),
+    }
+}
+
 pub(crate) fn parse_config_with_vars(
     path: &Path,
     profile_vars: &std::collections::HashMap<String, String>,

--- a/crates/floe-core/src/config/parse.rs
+++ b/crates/floe-core/src/config/parse.rs
@@ -4,7 +4,7 @@ use std::path::Path;
 use yaml_rust2::yaml::Hash;
 use yaml_rust2::Yaml;
 
-use crate::config::apply_templates;
+use crate::config::apply_templates_with_vars;
 use crate::config::yaml_decode::{
     hash_get, load_yaml, validate_known_keys, yaml_array, yaml_hash, yaml_string,
 };
@@ -20,6 +20,13 @@ use crate::config::{
 use crate::{ConfigError, FloeResult};
 
 pub(crate) fn parse_config(path: &Path) -> FloeResult<RootConfig> {
+    parse_config_with_vars(path, &std::collections::HashMap::new())
+}
+
+pub(crate) fn parse_config_with_vars(
+    path: &Path,
+    profile_vars: &std::collections::HashMap<String, String>,
+) -> FloeResult<RootConfig> {
     let docs = load_yaml(path)?;
     if docs.is_empty() {
         return Err(Box::new(ConfigError("YAML is empty".to_string())));
@@ -31,7 +38,7 @@ pub(crate) fn parse_config(path: &Path) -> FloeResult<RootConfig> {
     }
     let mut config = parse_root(&docs[0])?;
     let config_dir = path.parent().unwrap_or_else(|| Path::new("."));
-    apply_templates(&mut config, config_dir)?;
+    apply_templates_with_vars(&mut config, config_dir, profile_vars)?;
     Ok(config)
 }
 

--- a/crates/floe-core/src/config/template.rs
+++ b/crates/floe-core/src/config/template.rs
@@ -8,8 +8,12 @@ use crate::config::yaml_decode::{load_yaml, yaml_hash, yaml_string};
 use crate::config::{EnvConfig, RootConfig};
 use crate::{ConfigError, FloeResult};
 
-pub fn apply_templates(config: &mut RootConfig, config_dir: &Path) -> FloeResult<()> {
-    let vars = build_env_vars(config_dir, config.env.as_ref())?;
+pub fn apply_templates_with_vars(
+    config: &mut RootConfig,
+    config_dir: &Path,
+    profile_vars: &HashMap<String, String>,
+) -> FloeResult<()> {
+    let vars = build_env_vars(config_dir, config.env.as_ref(), profile_vars)?;
     let mut domain_lookup = HashMap::new();
     for domain in config.domains.iter_mut() {
         let resolved =
@@ -87,17 +91,21 @@ pub fn apply_templates(config: &mut RootConfig, config_dir: &Path) -> FloeResult
 fn build_env_vars(
     config_dir: &Path,
     env: Option<&EnvConfig>,
+    profile_vars: &HashMap<String, String>,
 ) -> FloeResult<HashMap<String, String>> {
-    let mut vars = HashMap::new();
+    // Lowest priority: profile variables
+    let mut vars: HashMap<String, String> = profile_vars.clone();
     let env = match env {
         Some(env) => env,
         None => return Ok(vars),
     };
+    // Then env file (overwrites profile)
     if let Some(file) = env.file.as_ref() {
         let path = resolve_local_path(config_dir, file);
         let file_vars = load_env_file(&path)?;
         vars.extend(file_vars);
     }
+    // Highest priority: inline env.vars (overwrites both)
     vars.extend(env.vars.clone());
     Ok(vars)
 }

--- a/crates/floe-core/src/lib.rs
+++ b/crates/floe-core/src/lib.rs
@@ -22,8 +22,8 @@ pub use config::{resolve_config_location, ConfigLocation};
 pub use errors::ConfigError;
 pub use manifest::build_common_manifest_json;
 pub use profile::{
-    detect_unresolved_placeholders, parse_profile, parse_profile_from_str, validate_merged_vars,
-    validate_profile, ProfileConfig,
+    detect_malformed_placeholder, detect_unresolved_placeholders, parse_profile,
+    parse_profile_from_str, validate_merged_vars, validate_profile, ProfileConfig,
 };
 pub use run::events::{set_observer, RunEvent, RunObserver};
 pub use run::{run, run_with_base, DryRunEntityPreview, EntityOutcome, RunOutcome};

--- a/crates/floe-core/src/lib.rs
+++ b/crates/floe-core/src/lib.rs
@@ -36,6 +36,7 @@ pub type FloeResult<T> = Result<T, Box<dyn std::error::Error + Send + Sync>>;
 #[derive(Debug, Default)]
 pub struct ValidateOptions {
     pub entities: Vec<String>,
+    pub profile_vars: std::collections::HashMap<String, String>,
 }
 
 #[derive(Debug, Default)]
@@ -43,6 +44,7 @@ pub struct RunOptions {
     pub run_id: Option<String>,
     pub entities: Vec<String>,
     pub dry_run: bool,
+    pub profile: Option<ProfileConfig>,
 }
 
 pub fn validate(config_path: &Path, options: ValidateOptions) -> FloeResult<()> {
@@ -55,7 +57,7 @@ pub fn validate_with_base(
     _config_base: config::ConfigBase,
     options: ValidateOptions,
 ) -> FloeResult<()> {
-    let config = config::parse_config(config_path)?;
+    let config = config::parse_config_with_vars(config_path, &options.profile_vars)?;
     config::validate_config(&config)?;
 
     if !options.entities.is_empty() {

--- a/crates/floe-core/src/profile/mod.rs
+++ b/crates/floe-core/src/profile/mod.rs
@@ -7,4 +7,7 @@ pub use types::{
     ProfileConfig, ProfileExecution, ProfileMetadata, ProfileRunner, ProfileValidation,
     PROFILE_API_VERSION, PROFILE_KIND,
 };
-pub use validate::{detect_unresolved_placeholders, validate_merged_vars, validate_profile};
+pub use validate::{
+    detect_malformed_placeholder, detect_unresolved_placeholders, validate_merged_vars,
+    validate_profile,
+};

--- a/crates/floe-core/src/profile/validate.rs
+++ b/crates/floe-core/src/profile/validate.rs
@@ -22,8 +22,6 @@ pub fn validate_profile(profile: &ProfileConfig) -> FloeResult<()> {
         validate_runner_contract(&execution.runner)?;
     }
 
-    validate_no_unresolved_vars(&profile.variables)?;
-
     Ok(())
 }
 

--- a/crates/floe-core/src/profile/validate.rs
+++ b/crates/floe-core/src/profile/validate.rs
@@ -9,7 +9,8 @@ use crate::{ConfigError, FloeResult};
 /// - `metadata.name` is non-empty (guaranteed by parser, double-checked here).
 /// - `execution.runner.type` is one of the recognized values (`local`, `kubernetes_job`, `databricks_job`) when present.
 ///   Orchestration/job-submission for each runner type belongs to connector crates, not floe-core.
-/// - No variable value contains an unresolved `${...}` placeholder.
+/// - No variable value contains a *syntactically malformed* `${...}` placeholder.
+///   Valid `${KEY}` cross-references are allowed — they are expanded by `resolve_vars` later.
 pub fn validate_profile(profile: &ProfileConfig) -> FloeResult<()> {
     if profile.metadata.name.trim().is_empty() {
         return Err(Box::new(ConfigError(
@@ -21,6 +22,8 @@ pub fn validate_profile(profile: &ProfileConfig) -> FloeResult<()> {
         validate_runner_type(&execution.runner.runner_type)?;
         validate_runner_contract(&execution.runner)?;
     }
+
+    validate_no_malformed_vars(&profile.variables)?;
 
     Ok(())
 }
@@ -66,6 +69,49 @@ pub fn detect_unresolved_placeholders(value: &str) -> Option<String> {
         }
     }
     None
+}
+
+/// Detect *syntactically malformed* `${...}` placeholders in a variable value.
+///
+/// Well-formed `${KEY}` references (non-empty key, properly closed brace) are
+/// intentional cross-variable references expanded by `resolve_vars` — they pass
+/// through as `None`.  Only structural errors are returned:
+/// - `${}` — empty key inside the placeholder
+/// - `${UNCLOSED` — `${` with no matching `}`
+pub fn detect_malformed_placeholder(value: &str) -> Option<String> {
+    let mut rest = value;
+    while let Some(start) = rest.find("${") {
+        rest = &rest[start + 2..];
+        match rest.find('}') {
+            Some(end) => {
+                let key = rest[..end].trim();
+                if key.is_empty() {
+                    return Some("${} (empty placeholder)".to_string());
+                }
+                rest = &rest[end + 1..];
+            }
+            None => {
+                return Some(
+                    format!("${{... (unclosed placeholder in: {value:?})}}")
+                        .chars()
+                        .take(120)
+                        .collect(),
+                );
+            }
+        }
+    }
+    None
+}
+
+fn validate_no_malformed_vars(vars: &HashMap<String, String>) -> FloeResult<()> {
+    for (key, value) in vars {
+        if let Some(placeholder) = detect_malformed_placeholder(value) {
+            return Err(Box::new(ConfigError(format!(
+                "profile variable \"{key}\" contains malformed placeholder: {placeholder}"
+            ))));
+        }
+    }
+    Ok(())
 }
 
 fn validate_no_unresolved_vars(vars: &HashMap<String, String>) -> FloeResult<()> {

--- a/crates/floe-core/src/run/context.rs
+++ b/crates/floe-core/src/run/context.rs
@@ -1,8 +1,9 @@
+use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::time::Instant;
 
 use crate::io::storage::Target;
-use crate::{config, report, vars, FloeResult, RunOptions};
+use crate::{config, report, FloeResult, RunOptions};
 
 pub struct RunContext {
     pub config: config::RootConfig,
@@ -22,19 +23,8 @@ impl RunContext {
         config_path: &Path,
         config_base: config::ConfigBase,
         options: &RunOptions,
+        profile_vars: HashMap<String, String>,
     ) -> FloeResult<Self> {
-        let profile_vars = options
-            .profile
-            .as_ref()
-            .map(|p| {
-                vars::resolve_vars(vars::VarSources {
-                    profile: &p.variables,
-                    cli: &std::collections::HashMap::new(),
-                    config: &std::collections::HashMap::new(),
-                })
-            })
-            .transpose()?
-            .unwrap_or_default();
         let config = config::parse_config_with_vars(config_path, &profile_vars)?;
         let storage_resolver = config::StorageResolver::new(&config, config_base)?;
         let catalog_resolver = config::CatalogResolver::new(&config)?;

--- a/crates/floe-core/src/run/context.rs
+++ b/crates/floe-core/src/run/context.rs
@@ -2,7 +2,7 @@ use std::path::{Path, PathBuf};
 use std::time::Instant;
 
 use crate::io::storage::Target;
-use crate::{config, report, FloeResult, RunOptions};
+use crate::{config, report, vars, FloeResult, RunOptions};
 
 pub struct RunContext {
     pub config: config::RootConfig,
@@ -23,7 +23,19 @@ impl RunContext {
         config_base: config::ConfigBase,
         options: &RunOptions,
     ) -> FloeResult<Self> {
-        let config = config::parse_config(config_path)?;
+        let profile_vars = options
+            .profile
+            .as_ref()
+            .map(|p| {
+                vars::resolve_vars(vars::VarSources {
+                    profile: &p.variables,
+                    cli: &std::collections::HashMap::new(),
+                    config: &std::collections::HashMap::new(),
+                })
+            })
+            .transpose()?
+            .unwrap_or_default();
+        let config = config::parse_config_with_vars(config_path, &profile_vars)?;
         let storage_resolver = config::StorageResolver::new(&config, config_base)?;
         let catalog_resolver = config::CatalogResolver::new(&config)?;
         let config_dir =

--- a/crates/floe-core/src/run/mod.rs
+++ b/crates/floe-core/src/run/mod.rs
@@ -100,6 +100,7 @@ pub fn run_with_runtime(
     runtime: &mut dyn Runtime,
 ) -> FloeResult<RunOutcome> {
     init_thread_pool();
+    let raw_config_env_vars = config::extract_raw_env_vars(config_path).unwrap_or_default();
     let profile_vars = options
         .profile
         .as_ref()
@@ -107,7 +108,7 @@ pub fn run_with_runtime(
             crate::resolve_vars(crate::VarSources {
                 profile: &p.variables,
                 cli: &std::collections::HashMap::new(),
-                config: &std::collections::HashMap::new(),
+                config: &raw_config_env_vars,
             })
         })
         .transpose()?

--- a/crates/floe-core/src/run/mod.rs
+++ b/crates/floe-core/src/run/mod.rs
@@ -115,10 +115,10 @@ pub fn run_with_runtime(
         .unwrap_or_default();
     let validate_options = ValidateOptions {
         entities: options.entities.clone(),
-        profile_vars,
+        profile_vars: profile_vars.clone(),
     };
     crate::validate_with_base(config_path, config_base.clone(), validate_options)?;
-    let context = RunContext::new(config_path, config_base, &options)?;
+    let context = RunContext::new(config_path, config_base, &options, profile_vars)?;
     if !options.entities.is_empty() {
         validate_entities(&context.config, &options.entities)?;
     }

--- a/crates/floe-core/src/run/mod.rs
+++ b/crates/floe-core/src/run/mod.rs
@@ -100,8 +100,21 @@ pub fn run_with_runtime(
     runtime: &mut dyn Runtime,
 ) -> FloeResult<RunOutcome> {
     init_thread_pool();
+    let profile_vars = options
+        .profile
+        .as_ref()
+        .map(|p| {
+            crate::resolve_vars(crate::VarSources {
+                profile: &p.variables,
+                cli: &std::collections::HashMap::new(),
+                config: &std::collections::HashMap::new(),
+            })
+        })
+        .transpose()?
+        .unwrap_or_default();
     let validate_options = ValidateOptions {
         entities: options.entities.clone(),
+        profile_vars,
     };
     crate::validate_with_base(config_path, config_base.clone(), validate_options)?;
     let context = RunContext::new(config_path, config_base, &options)?;

--- a/crates/floe-core/tests/integration/archive_run.rs
+++ b/crates/floe-core/tests/integration/archive_run.rs
@@ -100,7 +100,7 @@ fn archive_moves_only_processed_input_not_local_siblings() {
 
     let outcome = run(
         &config_path,
-        RunOptions {
+        RunOptions { profile: None,
             run_id: Some("archive-sibling-it".to_string()),
             entities: Vec::new(),
             dry_run: false,
@@ -157,7 +157,7 @@ fn archive_repeated_runs_do_not_overwrite_same_source_filename() {
     fs::write(&source_path, "id,name\n1,first\n").expect("write first source");
     run(
         &config_path,
-        RunOptions {
+        RunOptions { profile: None,
             run_id: Some("archive-run-1".to_string()),
             entities: Vec::new(),
             dry_run: false,
@@ -168,7 +168,7 @@ fn archive_repeated_runs_do_not_overwrite_same_source_filename() {
     fs::write(&source_path, "id,name\n2,second\n").expect("write second source");
     run(
         &config_path,
-        RunOptions {
+        RunOptions { profile: None,
             run_id: Some("archive-run-2".to_string()),
             entities: Vec::new(),
             dry_run: false,
@@ -219,7 +219,7 @@ fn legacy_archive_config_still_archives_inputs() {
 
     let outcome = run(
         &config_path,
-        RunOptions {
+        RunOptions { profile: None,
             run_id: Some("archive-legacy-compat".to_string()),
             entities: Vec::new(),
             dry_run: false,

--- a/crates/floe-core/tests/integration/archive_run.rs
+++ b/crates/floe-core/tests/integration/archive_run.rs
@@ -100,7 +100,8 @@ fn archive_moves_only_processed_input_not_local_siblings() {
 
     let outcome = run(
         &config_path,
-        RunOptions { profile: None,
+        RunOptions {
+            profile: None,
             run_id: Some("archive-sibling-it".to_string()),
             entities: Vec::new(),
             dry_run: false,
@@ -157,7 +158,8 @@ fn archive_repeated_runs_do_not_overwrite_same_source_filename() {
     fs::write(&source_path, "id,name\n1,first\n").expect("write first source");
     run(
         &config_path,
-        RunOptions { profile: None,
+        RunOptions {
+            profile: None,
             run_id: Some("archive-run-1".to_string()),
             entities: Vec::new(),
             dry_run: false,
@@ -168,7 +170,8 @@ fn archive_repeated_runs_do_not_overwrite_same_source_filename() {
     fs::write(&source_path, "id,name\n2,second\n").expect("write second source");
     run(
         &config_path,
-        RunOptions { profile: None,
+        RunOptions {
+            profile: None,
             run_id: Some("archive-run-2".to_string()),
             entities: Vec::new(),
             dry_run: false,
@@ -219,7 +222,8 @@ fn legacy_archive_config_still_archives_inputs() {
 
     let outcome = run(
         &config_path,
-        RunOptions { profile: None,
+        RunOptions {
+            profile: None,
             run_id: Some("archive-legacy-compat".to_string()),
             entities: Vec::new(),
             dry_run: false,

--- a/crates/floe-core/tests/integration/composite_unique.rs
+++ b/crates/floe-core/tests/integration/composite_unique.rs
@@ -76,7 +76,8 @@ entities:
 
     let outcome = run(
         &config_path,
-        RunOptions { profile: None,
+        RunOptions {
+            profile: None,
             run_id: Some("it-composite-unique".to_string()),
             entities: Vec::new(),
             dry_run: false,

--- a/crates/floe-core/tests/integration/composite_unique.rs
+++ b/crates/floe-core/tests/integration/composite_unique.rs
@@ -76,7 +76,7 @@ entities:
 
     let outcome = run(
         &config_path,
-        RunOptions {
+        RunOptions { profile: None,
             run_id: Some("it-composite-unique".to_string()),
             entities: Vec::new(),
             dry_run: false,

--- a/crates/floe-core/tests/integration/delta_run.rs
+++ b/crates/floe-core/tests/integration/delta_run.rs
@@ -200,7 +200,8 @@ entities:
 
     let outcome = run(
         &config_path,
-        RunOptions { profile: None,
+        RunOptions {
+            profile: None,
             run_id: Some("it-delta-partitioned".to_string()),
             entities: Vec::new(),
             dry_run: false,
@@ -270,7 +271,8 @@ entities:
 
     let outcome = run(
         &config_path,
-        RunOptions { profile: None,
+        RunOptions {
+            profile: None,
             run_id: Some("it-delta-unpartitioned".to_string()),
             entities: Vec::new(),
             dry_run: false,
@@ -339,7 +341,8 @@ entities:
 
     run(
         &config_path,
-        RunOptions { profile: None,
+        RunOptions {
+            profile: None,
             run_id: Some("it-delta-schema-evolution-init".to_string()),
             entities: Vec::new(),
             dry_run: false,
@@ -382,7 +385,8 @@ entities:
 
     let outcome = run(
         &config_path,
-        RunOptions { profile: None,
+        RunOptions {
+            profile: None,
             run_id: Some("it-delta-schema-evolution-append".to_string()),
             entities: Vec::new(),
             dry_run: false,
@@ -486,7 +490,8 @@ entities:
 
     run(
         &config_path,
-        RunOptions { profile: None,
+        RunOptions {
+            profile: None,
             run_id: Some("it-delta-schema-evolution-overwrite-init".to_string()),
             entities: Vec::new(),
             dry_run: false,
@@ -496,7 +501,8 @@ entities:
 
     let outcome = run(
         &config_path,
-        RunOptions { profile: None,
+        RunOptions {
+            profile: None,
             run_id: Some("it-delta-schema-evolution-overwrite-noop".to_string()),
             entities: Vec::new(),
             dry_run: false,
@@ -559,7 +565,8 @@ entities:
 
     run(
         &config_path,
-        RunOptions { profile: None,
+        RunOptions {
+            profile: None,
             run_id: Some("it-delta-overwrite-empty-init".to_string()),
             entities: Vec::new(),
             dry_run: false,
@@ -572,7 +579,8 @@ entities:
 
     let outcome = run(
         &config_path,
-        RunOptions { profile: None,
+        RunOptions {
+            profile: None,
             run_id: Some("it-delta-overwrite-empty-second".to_string()),
             entities: Vec::new(),
             dry_run: false,
@@ -640,7 +648,8 @@ entities:
 
     run(
         &config_path,
-        RunOptions { profile: None,
+        RunOptions {
+            profile: None,
             run_id: Some("it-delta-append-empty-init".to_string()),
             entities: Vec::new(),
             dry_run: false,
@@ -653,7 +662,8 @@ entities:
 
     let outcome = run(
         &config_path,
-        RunOptions { profile: None,
+        RunOptions {
+            profile: None,
             run_id: Some("it-delta-append-empty-second".to_string()),
             entities: Vec::new(),
             dry_run: false,
@@ -720,7 +730,8 @@ entities:
 
     run(
         &config_path,
-        RunOptions { profile: None,
+        RunOptions {
+            profile: None,
             run_id: Some("it-delta-append-noop-init".to_string()),
             entities: Vec::new(),
             dry_run: false,
@@ -733,7 +744,8 @@ entities:
 
     let outcome = run(
         &config_path,
-        RunOptions { profile: None,
+        RunOptions {
+            profile: None,
             run_id: Some("it-delta-append-noop-second".to_string()),
             entities: Vec::new(),
             dry_run: false,
@@ -792,7 +804,8 @@ entities:
 
     run(
         &config_path,
-        RunOptions { profile: None,
+        RunOptions {
+            profile: None,
             run_id: Some("it-delta-strict-init".to_string()),
             entities: Vec::new(),
             dry_run: false,
@@ -833,7 +846,8 @@ entities:
 
     let err = run(
         &config_path,
-        RunOptions { profile: None,
+        RunOptions {
+            profile: None,
             run_id: Some("it-delta-strict-extra-column".to_string()),
             entities: Vec::new(),
             dry_run: false,
@@ -897,7 +911,8 @@ entities:
 
     run(
         &config_path,
-        RunOptions { profile: None,
+        RunOptions {
+            profile: None,
             run_id: Some("it-delta-merge-init".to_string()),
             entities: Vec::new(),
             dry_run: false,
@@ -914,7 +929,8 @@ entities:
 
     let outcome = run(
         &config_path,
-        RunOptions { profile: None,
+        RunOptions {
+            profile: None,
             run_id: Some("it-delta-merge-upsert".to_string()),
             entities: Vec::new(),
             dry_run: false,
@@ -1027,7 +1043,8 @@ entities:
 
     run(
         &config_path,
-        RunOptions { profile: None,
+        RunOptions {
+            profile: None,
             run_id: Some("it-delta-merge-scd1-evolution-init".to_string()),
             entities: Vec::new(),
             dry_run: false,
@@ -1080,7 +1097,8 @@ entities:
 
     let outcome = run(
         &config_path,
-        RunOptions { profile: None,
+        RunOptions {
+            profile: None,
             run_id: Some("it-delta-merge-scd1-evolution-upsert".to_string()),
             entities: Vec::new(),
             dry_run: false,
@@ -1202,7 +1220,8 @@ entities:
 
     let outcome = run(
         &config_path,
-        RunOptions { profile: None,
+        RunOptions {
+            profile: None,
             run_id: Some("it-delta-merge-dup-source".to_string()),
             entities: Vec::new(),
             dry_run: false,
@@ -1275,7 +1294,8 @@ entities:
 
     run(
         &config_path,
-        RunOptions { profile: None,
+        RunOptions {
+            profile: None,
             run_id: Some("it-delta-merge-scd2-init".to_string()),
             entities: Vec::new(),
             dry_run: false,
@@ -1292,7 +1312,8 @@ entities:
 
     let outcome = run(
         &config_path,
-        RunOptions { profile: None,
+        RunOptions {
+            profile: None,
             run_id: Some("it-delta-merge-scd2-upsert".to_string()),
             entities: Vec::new(),
             dry_run: false,
@@ -1419,7 +1440,8 @@ entities:
 
     run(
         &config_path,
-        RunOptions { profile: None,
+        RunOptions {
+            profile: None,
             run_id: Some("it-delta-merge-scd2-evolution-init".to_string()),
             entities: Vec::new(),
             dry_run: false,
@@ -1472,7 +1494,8 @@ entities:
 
     let outcome = run(
         &config_path,
-        RunOptions { profile: None,
+        RunOptions {
+            profile: None,
             run_id: Some("it-delta-merge-scd2-evolution-upsert".to_string()),
             entities: Vec::new(),
             dry_run: false,
@@ -1613,7 +1636,8 @@ entities:
 
     run(
         &config_path,
-        RunOptions { profile: None,
+        RunOptions {
+            profile: None,
             run_id: Some("it-delta-merge-schema-evolution-init".to_string()),
             entities: Vec::new(),
             dry_run: false,
@@ -1626,7 +1650,8 @@ entities:
 
     let outcome = run(
         &config_path,
-        RunOptions { profile: None,
+        RunOptions {
+            profile: None,
             run_id: Some("it-delta-merge-schema-evolution-empty".to_string()),
             entities: Vec::new(),
             dry_run: false,
@@ -1698,7 +1723,8 @@ entities:
 
     run(
         &config_path,
-        RunOptions { profile: None,
+        RunOptions {
+            profile: None,
             run_id: Some("it-delta-merge-noop-init".to_string()),
             entities: Vec::new(),
             dry_run: false,
@@ -1711,7 +1737,8 @@ entities:
 
     let outcome = run(
         &config_path,
-        RunOptions { profile: None,
+        RunOptions {
+            profile: None,
             run_id: Some("it-delta-merge-noop-second".to_string()),
             entities: Vec::new(),
             dry_run: false,
@@ -1787,7 +1814,8 @@ entities:
 
     run(
         &config_path,
-        RunOptions { profile: None,
+        RunOptions {
+            profile: None,
             run_id: Some("it-delta-merge-scd2-custom-cols-init".to_string()),
             entities: Vec::new(),
             dry_run: false,
@@ -1804,7 +1832,8 @@ entities:
 
     run(
         &config_path,
-        RunOptions { profile: None,
+        RunOptions {
+            profile: None,
             run_id: Some("it-delta-merge-scd2-custom-cols-upsert".to_string()),
             entities: Vec::new(),
             dry_run: false,
@@ -1877,7 +1906,8 @@ entities:
 
     run(
         &config_path,
-        RunOptions { profile: None,
+        RunOptions {
+            profile: None,
             run_id: Some("it-delta-merge-scd2-compare-init".to_string()),
             entities: Vec::new(),
             dry_run: false,
@@ -1894,7 +1924,8 @@ entities:
 
     let outcome = run(
         &config_path,
-        RunOptions { profile: None,
+        RunOptions {
+            profile: None,
             run_id: Some("it-delta-merge-scd2-compare-second".to_string()),
             entities: Vec::new(),
             dry_run: false,
@@ -1974,7 +2005,8 @@ entities:
 
     run(
         &config_path,
-        RunOptions { profile: None,
+        RunOptions {
+            profile: None,
             run_id: Some("it-delta-merge-scd2-compare-normalized-init".to_string()),
             entities: Vec::new(),
             dry_run: false,
@@ -1991,7 +2023,8 @@ entities:
 
     let outcome = run(
         &config_path,
-        RunOptions { profile: None,
+        RunOptions {
+            profile: None,
             run_id: Some("it-delta-merge-scd2-compare-normalized-second".to_string()),
             entities: Vec::new(),
             dry_run: false,
@@ -2053,7 +2086,8 @@ entities:
 
     run(
         &config_path,
-        RunOptions { profile: None,
+        RunOptions {
+            profile: None,
             run_id: Some("it-delta-merge-scd2-nullable-init".to_string()),
             entities: Vec::new(),
             dry_run: false,
@@ -2066,7 +2100,8 @@ entities:
 
     run(
         &config_path,
-        RunOptions { profile: None,
+        RunOptions {
+            profile: None,
             run_id: Some("it-delta-merge-scd2-nullable-second".to_string()),
             entities: Vec::new(),
             dry_run: false,
@@ -2156,7 +2191,8 @@ entities:
 
     run(
         &config_path,
-        RunOptions { profile: None,
+        RunOptions {
+            profile: None,
             run_id: Some("it-delta-merge-scd2-city-init".to_string()),
             entities: Vec::new(),
             dry_run: false,
@@ -2198,7 +2234,8 @@ entities:
 
     let err = run(
         &config_path,
-        RunOptions { profile: None,
+        RunOptions {
+            profile: None,
             run_id: Some("it-delta-merge-scd2-city-drift".to_string()),
             entities: Vec::new(),
             dry_run: false,
@@ -2253,7 +2290,8 @@ entities:
 
     run(
         &config_path,
-        RunOptions { profile: None,
+        RunOptions {
+            profile: None,
             run_id: Some("it-delta-merge-scd1-nonadditive-init".to_string()),
             entities: Vec::new(),
             dry_run: false,
@@ -2297,7 +2335,8 @@ entities:
 
     let err = run(
         &config_path,
-        RunOptions { profile: None,
+        RunOptions {
+            profile: None,
             run_id: Some("it-delta-merge-scd1-nonadditive-upsert".to_string()),
             entities: Vec::new(),
             dry_run: false,
@@ -2349,7 +2388,8 @@ entities:
 
     run(
         &config_path,
-        RunOptions { profile: None,
+        RunOptions {
+            profile: None,
             run_id: Some("it-delta-merge-scd1-merge-key-init".to_string()),
             entities: Vec::new(),
             dry_run: false,
@@ -2393,7 +2433,8 @@ entities:
 
     let err = run(
         &config_path,
-        RunOptions { profile: None,
+        RunOptions {
+            profile: None,
             run_id: Some("it-delta-merge-scd1-merge-key-upsert".to_string()),
             entities: Vec::new(),
             dry_run: false,

--- a/crates/floe-core/tests/integration/delta_run.rs
+++ b/crates/floe-core/tests/integration/delta_run.rs
@@ -200,7 +200,7 @@ entities:
 
     let outcome = run(
         &config_path,
-        RunOptions {
+        RunOptions { profile: None,
             run_id: Some("it-delta-partitioned".to_string()),
             entities: Vec::new(),
             dry_run: false,
@@ -270,7 +270,7 @@ entities:
 
     let outcome = run(
         &config_path,
-        RunOptions {
+        RunOptions { profile: None,
             run_id: Some("it-delta-unpartitioned".to_string()),
             entities: Vec::new(),
             dry_run: false,
@@ -339,7 +339,7 @@ entities:
 
     run(
         &config_path,
-        RunOptions {
+        RunOptions { profile: None,
             run_id: Some("it-delta-schema-evolution-init".to_string()),
             entities: Vec::new(),
             dry_run: false,
@@ -382,7 +382,7 @@ entities:
 
     let outcome = run(
         &config_path,
-        RunOptions {
+        RunOptions { profile: None,
             run_id: Some("it-delta-schema-evolution-append".to_string()),
             entities: Vec::new(),
             dry_run: false,
@@ -486,7 +486,7 @@ entities:
 
     run(
         &config_path,
-        RunOptions {
+        RunOptions { profile: None,
             run_id: Some("it-delta-schema-evolution-overwrite-init".to_string()),
             entities: Vec::new(),
             dry_run: false,
@@ -496,7 +496,7 @@ entities:
 
     let outcome = run(
         &config_path,
-        RunOptions {
+        RunOptions { profile: None,
             run_id: Some("it-delta-schema-evolution-overwrite-noop".to_string()),
             entities: Vec::new(),
             dry_run: false,
@@ -559,7 +559,7 @@ entities:
 
     run(
         &config_path,
-        RunOptions {
+        RunOptions { profile: None,
             run_id: Some("it-delta-overwrite-empty-init".to_string()),
             entities: Vec::new(),
             dry_run: false,
@@ -572,7 +572,7 @@ entities:
 
     let outcome = run(
         &config_path,
-        RunOptions {
+        RunOptions { profile: None,
             run_id: Some("it-delta-overwrite-empty-second".to_string()),
             entities: Vec::new(),
             dry_run: false,
@@ -640,7 +640,7 @@ entities:
 
     run(
         &config_path,
-        RunOptions {
+        RunOptions { profile: None,
             run_id: Some("it-delta-append-empty-init".to_string()),
             entities: Vec::new(),
             dry_run: false,
@@ -653,7 +653,7 @@ entities:
 
     let outcome = run(
         &config_path,
-        RunOptions {
+        RunOptions { profile: None,
             run_id: Some("it-delta-append-empty-second".to_string()),
             entities: Vec::new(),
             dry_run: false,
@@ -720,7 +720,7 @@ entities:
 
     run(
         &config_path,
-        RunOptions {
+        RunOptions { profile: None,
             run_id: Some("it-delta-append-noop-init".to_string()),
             entities: Vec::new(),
             dry_run: false,
@@ -733,7 +733,7 @@ entities:
 
     let outcome = run(
         &config_path,
-        RunOptions {
+        RunOptions { profile: None,
             run_id: Some("it-delta-append-noop-second".to_string()),
             entities: Vec::new(),
             dry_run: false,
@@ -792,7 +792,7 @@ entities:
 
     run(
         &config_path,
-        RunOptions {
+        RunOptions { profile: None,
             run_id: Some("it-delta-strict-init".to_string()),
             entities: Vec::new(),
             dry_run: false,
@@ -833,7 +833,7 @@ entities:
 
     let err = run(
         &config_path,
-        RunOptions {
+        RunOptions { profile: None,
             run_id: Some("it-delta-strict-extra-column".to_string()),
             entities: Vec::new(),
             dry_run: false,
@@ -897,7 +897,7 @@ entities:
 
     run(
         &config_path,
-        RunOptions {
+        RunOptions { profile: None,
             run_id: Some("it-delta-merge-init".to_string()),
             entities: Vec::new(),
             dry_run: false,
@@ -914,7 +914,7 @@ entities:
 
     let outcome = run(
         &config_path,
-        RunOptions {
+        RunOptions { profile: None,
             run_id: Some("it-delta-merge-upsert".to_string()),
             entities: Vec::new(),
             dry_run: false,
@@ -1027,7 +1027,7 @@ entities:
 
     run(
         &config_path,
-        RunOptions {
+        RunOptions { profile: None,
             run_id: Some("it-delta-merge-scd1-evolution-init".to_string()),
             entities: Vec::new(),
             dry_run: false,
@@ -1080,7 +1080,7 @@ entities:
 
     let outcome = run(
         &config_path,
-        RunOptions {
+        RunOptions { profile: None,
             run_id: Some("it-delta-merge-scd1-evolution-upsert".to_string()),
             entities: Vec::new(),
             dry_run: false,
@@ -1202,7 +1202,7 @@ entities:
 
     let outcome = run(
         &config_path,
-        RunOptions {
+        RunOptions { profile: None,
             run_id: Some("it-delta-merge-dup-source".to_string()),
             entities: Vec::new(),
             dry_run: false,
@@ -1275,7 +1275,7 @@ entities:
 
     run(
         &config_path,
-        RunOptions {
+        RunOptions { profile: None,
             run_id: Some("it-delta-merge-scd2-init".to_string()),
             entities: Vec::new(),
             dry_run: false,
@@ -1292,7 +1292,7 @@ entities:
 
     let outcome = run(
         &config_path,
-        RunOptions {
+        RunOptions { profile: None,
             run_id: Some("it-delta-merge-scd2-upsert".to_string()),
             entities: Vec::new(),
             dry_run: false,
@@ -1419,7 +1419,7 @@ entities:
 
     run(
         &config_path,
-        RunOptions {
+        RunOptions { profile: None,
             run_id: Some("it-delta-merge-scd2-evolution-init".to_string()),
             entities: Vec::new(),
             dry_run: false,
@@ -1472,7 +1472,7 @@ entities:
 
     let outcome = run(
         &config_path,
-        RunOptions {
+        RunOptions { profile: None,
             run_id: Some("it-delta-merge-scd2-evolution-upsert".to_string()),
             entities: Vec::new(),
             dry_run: false,
@@ -1613,7 +1613,7 @@ entities:
 
     run(
         &config_path,
-        RunOptions {
+        RunOptions { profile: None,
             run_id: Some("it-delta-merge-schema-evolution-init".to_string()),
             entities: Vec::new(),
             dry_run: false,
@@ -1626,7 +1626,7 @@ entities:
 
     let outcome = run(
         &config_path,
-        RunOptions {
+        RunOptions { profile: None,
             run_id: Some("it-delta-merge-schema-evolution-empty".to_string()),
             entities: Vec::new(),
             dry_run: false,
@@ -1698,7 +1698,7 @@ entities:
 
     run(
         &config_path,
-        RunOptions {
+        RunOptions { profile: None,
             run_id: Some("it-delta-merge-noop-init".to_string()),
             entities: Vec::new(),
             dry_run: false,
@@ -1711,7 +1711,7 @@ entities:
 
     let outcome = run(
         &config_path,
-        RunOptions {
+        RunOptions { profile: None,
             run_id: Some("it-delta-merge-noop-second".to_string()),
             entities: Vec::new(),
             dry_run: false,
@@ -1787,7 +1787,7 @@ entities:
 
     run(
         &config_path,
-        RunOptions {
+        RunOptions { profile: None,
             run_id: Some("it-delta-merge-scd2-custom-cols-init".to_string()),
             entities: Vec::new(),
             dry_run: false,
@@ -1804,7 +1804,7 @@ entities:
 
     run(
         &config_path,
-        RunOptions {
+        RunOptions { profile: None,
             run_id: Some("it-delta-merge-scd2-custom-cols-upsert".to_string()),
             entities: Vec::new(),
             dry_run: false,
@@ -1877,7 +1877,7 @@ entities:
 
     run(
         &config_path,
-        RunOptions {
+        RunOptions { profile: None,
             run_id: Some("it-delta-merge-scd2-compare-init".to_string()),
             entities: Vec::new(),
             dry_run: false,
@@ -1894,7 +1894,7 @@ entities:
 
     let outcome = run(
         &config_path,
-        RunOptions {
+        RunOptions { profile: None,
             run_id: Some("it-delta-merge-scd2-compare-second".to_string()),
             entities: Vec::new(),
             dry_run: false,
@@ -1974,7 +1974,7 @@ entities:
 
     run(
         &config_path,
-        RunOptions {
+        RunOptions { profile: None,
             run_id: Some("it-delta-merge-scd2-compare-normalized-init".to_string()),
             entities: Vec::new(),
             dry_run: false,
@@ -1991,7 +1991,7 @@ entities:
 
     let outcome = run(
         &config_path,
-        RunOptions {
+        RunOptions { profile: None,
             run_id: Some("it-delta-merge-scd2-compare-normalized-second".to_string()),
             entities: Vec::new(),
             dry_run: false,
@@ -2053,7 +2053,7 @@ entities:
 
     run(
         &config_path,
-        RunOptions {
+        RunOptions { profile: None,
             run_id: Some("it-delta-merge-scd2-nullable-init".to_string()),
             entities: Vec::new(),
             dry_run: false,
@@ -2066,7 +2066,7 @@ entities:
 
     run(
         &config_path,
-        RunOptions {
+        RunOptions { profile: None,
             run_id: Some("it-delta-merge-scd2-nullable-second".to_string()),
             entities: Vec::new(),
             dry_run: false,
@@ -2156,7 +2156,7 @@ entities:
 
     run(
         &config_path,
-        RunOptions {
+        RunOptions { profile: None,
             run_id: Some("it-delta-merge-scd2-city-init".to_string()),
             entities: Vec::new(),
             dry_run: false,
@@ -2198,7 +2198,7 @@ entities:
 
     let err = run(
         &config_path,
-        RunOptions {
+        RunOptions { profile: None,
             run_id: Some("it-delta-merge-scd2-city-drift".to_string()),
             entities: Vec::new(),
             dry_run: false,
@@ -2253,7 +2253,7 @@ entities:
 
     run(
         &config_path,
-        RunOptions {
+        RunOptions { profile: None,
             run_id: Some("it-delta-merge-scd1-nonadditive-init".to_string()),
             entities: Vec::new(),
             dry_run: false,
@@ -2297,7 +2297,7 @@ entities:
 
     let err = run(
         &config_path,
-        RunOptions {
+        RunOptions { profile: None,
             run_id: Some("it-delta-merge-scd1-nonadditive-upsert".to_string()),
             entities: Vec::new(),
             dry_run: false,
@@ -2349,7 +2349,7 @@ entities:
 
     run(
         &config_path,
-        RunOptions {
+        RunOptions { profile: None,
             run_id: Some("it-delta-merge-scd1-merge-key-init".to_string()),
             entities: Vec::new(),
             dry_run: false,
@@ -2393,7 +2393,7 @@ entities:
 
     let err = run(
         &config_path,
-        RunOptions {
+        RunOptions { profile: None,
             run_id: Some("it-delta-merge-scd1-merge-key-upsert".to_string()),
             entities: Vec::new(),
             dry_run: false,

--- a/crates/floe-core/tests/integration/dry_run.rs
+++ b/crates/floe-core/tests/integration/dry_run.rs
@@ -62,7 +62,7 @@ entities:
 
     let outcome = run(
         &config_path,
-        RunOptions {
+        RunOptions { profile: None,
             run_id: Some("it-dry".to_string()),
             entities: Vec::new(),
             dry_run: true,
@@ -122,7 +122,7 @@ entities:
 
     let err = run(
         &config_path,
-        RunOptions {
+        RunOptions { profile: None,
             run_id: Some("it-dry-missing".to_string()),
             entities: Vec::new(),
             dry_run: true,

--- a/crates/floe-core/tests/integration/dry_run.rs
+++ b/crates/floe-core/tests/integration/dry_run.rs
@@ -62,7 +62,8 @@ entities:
 
     let outcome = run(
         &config_path,
-        RunOptions { profile: None,
+        RunOptions {
+            profile: None,
             run_id: Some("it-dry".to_string()),
             entities: Vec::new(),
             dry_run: true,
@@ -122,7 +123,8 @@ entities:
 
     let err = run(
         &config_path,
-        RunOptions { profile: None,
+        RunOptions {
+            profile: None,
             run_id: Some("it-dry-missing".to_string()),
             entities: Vec::new(),
             dry_run: true,

--- a/crates/floe-core/tests/integration/fixed_width.rs
+++ b/crates/floe-core/tests/integration/fixed_width.rs
@@ -59,7 +59,7 @@ entities:
 
     let outcome = run(
         &config_path,
-        RunOptions {
+        RunOptions { profile: None,
             run_id: Some("fixed-width-parse".to_string()),
             entities: Vec::new(),
             dry_run: false,
@@ -133,7 +133,7 @@ entities:
 
     let outcome = run(
         &config_path,
-        RunOptions {
+        RunOptions { profile: None,
             run_id: Some("fixed-width-cast".to_string()),
             entities: Vec::new(),
             dry_run: false,
@@ -193,7 +193,7 @@ entities:
 
     let outcome = run(
         &config_path,
-        RunOptions {
+        RunOptions { profile: None,
             run_id: Some("fixed-width-unicode".to_string()),
             entities: Vec::new(),
             dry_run: false,

--- a/crates/floe-core/tests/integration/fixed_width.rs
+++ b/crates/floe-core/tests/integration/fixed_width.rs
@@ -59,7 +59,8 @@ entities:
 
     let outcome = run(
         &config_path,
-        RunOptions { profile: None,
+        RunOptions {
+            profile: None,
             run_id: Some("fixed-width-parse".to_string()),
             entities: Vec::new(),
             dry_run: false,
@@ -133,7 +134,8 @@ entities:
 
     let outcome = run(
         &config_path,
-        RunOptions { profile: None,
+        RunOptions {
+            profile: None,
             run_id: Some("fixed-width-cast".to_string()),
             entities: Vec::new(),
             dry_run: false,
@@ -193,7 +195,8 @@ entities:
 
     let outcome = run(
         &config_path,
-        RunOptions { profile: None,
+        RunOptions {
+            profile: None,
             run_id: Some("fixed-width-unicode".to_string()),
             entities: Vec::new(),
             dry_run: false,

--- a/crates/floe-core/tests/integration/iceberg_gcs_run.rs
+++ b/crates/floe-core/tests/integration/iceberg_gcs_run.rs
@@ -64,7 +64,7 @@ entities:
 
     let outcome = run(
         &config_path,
-        RunOptions {
+        RunOptions { profile: None,
             run_id: Some("it-iceberg-gcs-dry".to_string()),
             entities: Vec::new(),
             dry_run: true,
@@ -120,7 +120,7 @@ fn manual_gcs_iceberg_append_and_overwrite_write_layout_and_cleanup() {
     );
     let out1 = run(
         &append_cfg,
-        RunOptions {
+        RunOptions { profile: None,
             run_id: Some("it-iceberg-gcs-append1".to_string()),
             entities: Vec::new(),
             dry_run: false,
@@ -140,7 +140,7 @@ fn manual_gcs_iceberg_append_and_overwrite_write_layout_and_cleanup() {
     write_csv(&input_dir, "data.csv", "id,name\n3,cara\n");
     let out2 = run(
         &append_cfg,
-        RunOptions {
+        RunOptions { profile: None,
             run_id: Some("it-iceberg-gcs-append2".to_string()),
             entities: Vec::new(),
             dry_run: false,
@@ -171,7 +171,7 @@ fn manual_gcs_iceberg_append_and_overwrite_write_layout_and_cleanup() {
     );
     let out3 = run(
         &overwrite_cfg,
-        RunOptions {
+        RunOptions { profile: None,
             run_id: Some("it-iceberg-gcs-overwrite".to_string()),
             entities: Vec::new(),
             dry_run: false,

--- a/crates/floe-core/tests/integration/iceberg_gcs_run.rs
+++ b/crates/floe-core/tests/integration/iceberg_gcs_run.rs
@@ -64,7 +64,8 @@ entities:
 
     let outcome = run(
         &config_path,
-        RunOptions { profile: None,
+        RunOptions {
+            profile: None,
             run_id: Some("it-iceberg-gcs-dry".to_string()),
             entities: Vec::new(),
             dry_run: true,
@@ -120,7 +121,8 @@ fn manual_gcs_iceberg_append_and_overwrite_write_layout_and_cleanup() {
     );
     let out1 = run(
         &append_cfg,
-        RunOptions { profile: None,
+        RunOptions {
+            profile: None,
             run_id: Some("it-iceberg-gcs-append1".to_string()),
             entities: Vec::new(),
             dry_run: false,
@@ -140,7 +142,8 @@ fn manual_gcs_iceberg_append_and_overwrite_write_layout_and_cleanup() {
     write_csv(&input_dir, "data.csv", "id,name\n3,cara\n");
     let out2 = run(
         &append_cfg,
-        RunOptions { profile: None,
+        RunOptions {
+            profile: None,
             run_id: Some("it-iceberg-gcs-append2".to_string()),
             entities: Vec::new(),
             dry_run: false,
@@ -171,7 +174,8 @@ fn manual_gcs_iceberg_append_and_overwrite_write_layout_and_cleanup() {
     );
     let out3 = run(
         &overwrite_cfg,
-        RunOptions { profile: None,
+        RunOptions {
+            profile: None,
             run_id: Some("it-iceberg-gcs-overwrite".to_string()),
             entities: Vec::new(),
             dry_run: false,

--- a/crates/floe-core/tests/integration/iceberg_glue_run.rs
+++ b/crates/floe-core/tests/integration/iceberg_glue_run.rs
@@ -83,7 +83,8 @@ entities:
 
     let outcome = run(
         &config_path,
-        RunOptions { profile: None,
+        RunOptions {
+            profile: None,
             run_id: Some("it-iceberg-glue-dry".to_string()),
             entities: Vec::new(),
             dry_run: true,
@@ -145,7 +146,8 @@ fn manual_glue_iceberg_append_and_overwrite_updates_glue_table_and_s3_layout() {
     );
     let out1 = run(
         &append_cfg,
-        RunOptions { profile: None,
+        RunOptions {
+            profile: None,
             run_id: Some("it-iceberg-glue-append1".to_string()),
             entities: Vec::new(),
             dry_run: false,
@@ -186,7 +188,8 @@ fn manual_glue_iceberg_append_and_overwrite_updates_glue_table_and_s3_layout() {
     write_csv(&input_dir, "data.csv", "id,name\n3,cara\n");
     let out2 = run(
         &append_cfg,
-        RunOptions { profile: None,
+        RunOptions {
+            profile: None,
             run_id: Some("it-iceberg-glue-append2".to_string()),
             entities: Vec::new(),
             dry_run: false,
@@ -219,7 +222,8 @@ fn manual_glue_iceberg_append_and_overwrite_updates_glue_table_and_s3_layout() {
     );
     let out3 = run(
         &overwrite_cfg,
-        RunOptions { profile: None,
+        RunOptions {
+            profile: None,
             run_id: Some("it-iceberg-glue-overwrite".to_string()),
             entities: Vec::new(),
             dry_run: false,

--- a/crates/floe-core/tests/integration/iceberg_glue_run.rs
+++ b/crates/floe-core/tests/integration/iceberg_glue_run.rs
@@ -83,7 +83,7 @@ entities:
 
     let outcome = run(
         &config_path,
-        RunOptions {
+        RunOptions { profile: None,
             run_id: Some("it-iceberg-glue-dry".to_string()),
             entities: Vec::new(),
             dry_run: true,
@@ -145,7 +145,7 @@ fn manual_glue_iceberg_append_and_overwrite_updates_glue_table_and_s3_layout() {
     );
     let out1 = run(
         &append_cfg,
-        RunOptions {
+        RunOptions { profile: None,
             run_id: Some("it-iceberg-glue-append1".to_string()),
             entities: Vec::new(),
             dry_run: false,
@@ -186,7 +186,7 @@ fn manual_glue_iceberg_append_and_overwrite_updates_glue_table_and_s3_layout() {
     write_csv(&input_dir, "data.csv", "id,name\n3,cara\n");
     let out2 = run(
         &append_cfg,
-        RunOptions {
+        RunOptions { profile: None,
             run_id: Some("it-iceberg-glue-append2".to_string()),
             entities: Vec::new(),
             dry_run: false,
@@ -219,7 +219,7 @@ fn manual_glue_iceberg_append_and_overwrite_updates_glue_table_and_s3_layout() {
     );
     let out3 = run(
         &overwrite_cfg,
-        RunOptions {
+        RunOptions { profile: None,
             run_id: Some("it-iceberg-glue-overwrite".to_string()),
             entities: Vec::new(),
             dry_run: false,

--- a/crates/floe-core/tests/integration/iceberg_run.rs
+++ b/crates/floe-core/tests/integration/iceberg_run.rs
@@ -61,7 +61,7 @@ entities:
 
     let outcome = run(
         &config_path,
-        RunOptions {
+        RunOptions { profile: None,
             run_id: Some("it-iceberg".to_string()),
             entities: Vec::new(),
             dry_run: false,
@@ -166,7 +166,7 @@ entities:
 
     run(
         &config_path,
-        RunOptions {
+        RunOptions { profile: None,
             run_id: Some("it-iceberg-partition-spec".to_string()),
             entities: Vec::new(),
             dry_run: false,

--- a/crates/floe-core/tests/integration/iceberg_run.rs
+++ b/crates/floe-core/tests/integration/iceberg_run.rs
@@ -61,7 +61,8 @@ entities:
 
     let outcome = run(
         &config_path,
-        RunOptions { profile: None,
+        RunOptions {
+            profile: None,
             run_id: Some("it-iceberg".to_string()),
             entities: Vec::new(),
             dry_run: false,
@@ -166,7 +167,8 @@ entities:
 
     run(
         &config_path,
-        RunOptions { profile: None,
+        RunOptions {
+            profile: None,
             run_id: Some("it-iceberg-partition-spec".to_string()),
             entities: Vec::new(),
             dry_run: false,

--- a/crates/floe-core/tests/integration/iceberg_s3_run.rs
+++ b/crates/floe-core/tests/integration/iceberg_s3_run.rs
@@ -65,7 +65,8 @@ entities:
 
     let outcome = run(
         &config_path,
-        RunOptions { profile: None,
+        RunOptions {
+            profile: None,
             run_id: Some("it-iceberg-s3-dry".to_string()),
             entities: Vec::new(),
             dry_run: true,
@@ -125,7 +126,8 @@ fn manual_s3_iceberg_append_and_overwrite_write_layout_and_cleanup() {
     );
     let out1 = run(
         &append_cfg,
-        RunOptions { profile: None,
+        RunOptions {
+            profile: None,
             run_id: Some("it-iceberg-s3-append1".to_string()),
             entities: Vec::new(),
             dry_run: false,
@@ -145,7 +147,8 @@ fn manual_s3_iceberg_append_and_overwrite_write_layout_and_cleanup() {
     write_csv(&input_dir, "data.csv", "id,name\n3,cara\n");
     let out2 = run(
         &append_cfg,
-        RunOptions { profile: None,
+        RunOptions {
+            profile: None,
             run_id: Some("it-iceberg-s3-append2".to_string()),
             entities: Vec::new(),
             dry_run: false,
@@ -177,7 +180,8 @@ fn manual_s3_iceberg_append_and_overwrite_write_layout_and_cleanup() {
     );
     let out3 = run(
         &overwrite_cfg,
-        RunOptions { profile: None,
+        RunOptions {
+            profile: None,
             run_id: Some("it-iceberg-s3-overwrite".to_string()),
             entities: Vec::new(),
             dry_run: false,

--- a/crates/floe-core/tests/integration/iceberg_s3_run.rs
+++ b/crates/floe-core/tests/integration/iceberg_s3_run.rs
@@ -65,7 +65,7 @@ entities:
 
     let outcome = run(
         &config_path,
-        RunOptions {
+        RunOptions { profile: None,
             run_id: Some("it-iceberg-s3-dry".to_string()),
             entities: Vec::new(),
             dry_run: true,
@@ -125,7 +125,7 @@ fn manual_s3_iceberg_append_and_overwrite_write_layout_and_cleanup() {
     );
     let out1 = run(
         &append_cfg,
-        RunOptions {
+        RunOptions { profile: None,
             run_id: Some("it-iceberg-s3-append1".to_string()),
             entities: Vec::new(),
             dry_run: false,
@@ -145,7 +145,7 @@ fn manual_s3_iceberg_append_and_overwrite_write_layout_and_cleanup() {
     write_csv(&input_dir, "data.csv", "id,name\n3,cara\n");
     let out2 = run(
         &append_cfg,
-        RunOptions {
+        RunOptions { profile: None,
             run_id: Some("it-iceberg-s3-append2".to_string()),
             entities: Vec::new(),
             dry_run: false,
@@ -177,7 +177,7 @@ fn manual_s3_iceberg_append_and_overwrite_write_layout_and_cleanup() {
     );
     let out3 = run(
         &overwrite_cfg,
-        RunOptions {
+        RunOptions { profile: None,
             run_id: Some("it-iceberg-s3-overwrite".to_string()),
             entities: Vec::new(),
             dry_run: false,

--- a/crates/floe-core/tests/integration/json_selectors.rs
+++ b/crates/floe-core/tests/integration/json_selectors.rs
@@ -82,7 +82,7 @@ entities:
 
     let outcome = run(
         &config_path,
-        RunOptions {
+        RunOptions { profile: None,
             run_id: Some("it-json-strict".to_string()),
             entities: Vec::new(),
             dry_run: false,
@@ -155,7 +155,7 @@ entities:
 
     let outcome = run(
         &config_path,
-        RunOptions {
+        RunOptions { profile: None,
             run_id: Some("it-json-coerce".to_string()),
             entities: Vec::new(),
             dry_run: false,
@@ -235,7 +235,7 @@ entities:
 
     let outcome = run(
         &config_path,
-        RunOptions {
+        RunOptions { profile: None,
             run_id: Some("it-json-mismatch".to_string()),
             entities: Vec::new(),
             dry_run: false,

--- a/crates/floe-core/tests/integration/json_selectors.rs
+++ b/crates/floe-core/tests/integration/json_selectors.rs
@@ -82,7 +82,8 @@ entities:
 
     let outcome = run(
         &config_path,
-        RunOptions { profile: None,
+        RunOptions {
+            profile: None,
             run_id: Some("it-json-strict".to_string()),
             entities: Vec::new(),
             dry_run: false,
@@ -155,7 +156,8 @@ entities:
 
     let outcome = run(
         &config_path,
-        RunOptions { profile: None,
+        RunOptions {
+            profile: None,
             run_id: Some("it-json-coerce".to_string()),
             entities: Vec::new(),
             dry_run: false,
@@ -235,7 +237,8 @@ entities:
 
     let outcome = run(
         &config_path,
-        RunOptions { profile: None,
+        RunOptions {
+            profile: None,
             run_id: Some("it-json-mismatch".to_string()),
             entities: Vec::new(),
             dry_run: false,

--- a/crates/floe-core/tests/integration/local_run.rs
+++ b/crates/floe-core/tests/integration/local_run.rs
@@ -61,7 +61,8 @@ entities:
 
     let outcome = run(
         &config_path,
-        RunOptions { profile: None,
+        RunOptions {
+            profile: None,
             run_id: Some("it-run".to_string()),
             entities: Vec::new(),
             dry_run: false,
@@ -159,7 +160,8 @@ entities:
 
     let outcome = run(
         &config_path,
-        RunOptions { profile: None,
+        RunOptions {
+            profile: None,
             run_id: Some("it-run-parquet-metrics".to_string()),
             entities: Vec::new(),
             dry_run: false,

--- a/crates/floe-core/tests/integration/local_run.rs
+++ b/crates/floe-core/tests/integration/local_run.rs
@@ -61,7 +61,7 @@ entities:
 
     let outcome = run(
         &config_path,
-        RunOptions {
+        RunOptions { profile: None,
             run_id: Some("it-run".to_string()),
             entities: Vec::new(),
             dry_run: false,
@@ -159,7 +159,7 @@ entities:
 
     let outcome = run(
         &config_path,
-        RunOptions {
+        RunOptions { profile: None,
             run_id: Some("it-run-parquet-metrics".to_string()),
             entities: Vec::new(),
             dry_run: false,

--- a/crates/floe-core/tests/integration/path_normalization.rs
+++ b/crates/floe-core/tests/integration/path_normalization.rs
@@ -52,7 +52,8 @@ entities:
 
     let outcome = run(
         &config_path,
-        RunOptions { profile: None,
+        RunOptions {
+            profile: None,
             run_id: Some("path-norm-it".to_string()),
             entities: Vec::new(),
             dry_run: false,

--- a/crates/floe-core/tests/integration/path_normalization.rs
+++ b/crates/floe-core/tests/integration/path_normalization.rs
@@ -52,7 +52,7 @@ entities:
 
     let outcome = run(
         &config_path,
-        RunOptions {
+        RunOptions { profile: None,
             run_id: Some("path-norm-it".to_string()),
             entities: Vec::new(),
             dry_run: false,

--- a/crates/floe-core/tests/integration/run_entities_filter.rs
+++ b/crates/floe-core/tests/integration/run_entities_filter.rs
@@ -90,7 +90,8 @@ entities:
 
     let outcome = run(
         &config_path,
-        RunOptions { profile: None,
+        RunOptions {
+            profile: None,
             run_id: Some("it-run".to_string()),
             entities: vec!["employees".to_string()],
             dry_run: false,

--- a/crates/floe-core/tests/integration/run_entities_filter.rs
+++ b/crates/floe-core/tests/integration/run_entities_filter.rs
@@ -90,7 +90,7 @@ entities:
 
     let outcome = run(
         &config_path,
-        RunOptions {
+        RunOptions { profile: None,
             run_id: Some("it-run".to_string()),
             entities: vec!["employees".to_string()],
             dry_run: false,

--- a/crates/floe-core/tests/unit/io/read/avro_input.rs
+++ b/crates/floe-core/tests/unit/io/read/avro_input.rs
@@ -44,7 +44,8 @@ fn write_config(dir: &Path, contents: &str) -> PathBuf {
 fn run_config(path: &Path) -> floe_core::RunOutcome {
     run(
         path,
-        RunOptions { profile: None,
+        RunOptions {
+            profile: None,
             run_id: Some("test-run".to_string()),
             entities: Vec::new(),
             dry_run: false,

--- a/crates/floe-core/tests/unit/io/read/avro_input.rs
+++ b/crates/floe-core/tests/unit/io/read/avro_input.rs
@@ -44,7 +44,7 @@ fn write_config(dir: &Path, contents: &str) -> PathBuf {
 fn run_config(path: &Path) -> floe_core::RunOutcome {
     run(
         path,
-        RunOptions {
+        RunOptions { profile: None,
             run_id: Some("test-run".to_string()),
             entities: Vec::new(),
             dry_run: false,

--- a/crates/floe-core/tests/unit/io/read/json_array.rs
+++ b/crates/floe-core/tests/unit/io/read/json_array.rs
@@ -32,7 +32,8 @@ fn write_config(dir: &Path, contents: &str) -> PathBuf {
 fn run_config(path: &Path) -> floe_core::RunOutcome {
     run(
         path,
-        RunOptions { profile: None,
+        RunOptions {
+            profile: None,
             run_id: Some("test-run".to_string()),
             entities: Vec::new(),
             dry_run: false,

--- a/crates/floe-core/tests/unit/io/read/json_array.rs
+++ b/crates/floe-core/tests/unit/io/read/json_array.rs
@@ -32,7 +32,7 @@ fn write_config(dir: &Path, contents: &str) -> PathBuf {
 fn run_config(path: &Path) -> floe_core::RunOutcome {
     run(
         path,
-        RunOptions {
+        RunOptions { profile: None,
             run_id: Some("test-run".to_string()),
             entities: Vec::new(),
             dry_run: false,

--- a/crates/floe-core/tests/unit/io/read/json_ndjson.rs
+++ b/crates/floe-core/tests/unit/io/read/json_ndjson.rs
@@ -32,7 +32,8 @@ fn write_config(dir: &Path, contents: &str) -> PathBuf {
 fn run_config(path: &Path) -> floe_core::RunOutcome {
     run(
         path,
-        RunOptions { profile: None,
+        RunOptions {
+            profile: None,
             run_id: Some("test-run".to_string()),
             entities: Vec::new(),
             dry_run: false,

--- a/crates/floe-core/tests/unit/io/read/json_ndjson.rs
+++ b/crates/floe-core/tests/unit/io/read/json_ndjson.rs
@@ -32,7 +32,7 @@ fn write_config(dir: &Path, contents: &str) -> PathBuf {
 fn run_config(path: &Path) -> floe_core::RunOutcome {
     run(
         path,
-        RunOptions {
+        RunOptions { profile: None,
             run_id: Some("test-run".to_string()),
             entities: Vec::new(),
             dry_run: false,

--- a/crates/floe-core/tests/unit/io/read/orc_input.rs
+++ b/crates/floe-core/tests/unit/io/read/orc_input.rs
@@ -62,7 +62,8 @@ fn write_config(dir: &Path, contents: &str) -> PathBuf {
 fn run_config(path: &Path) -> floe_core::RunOutcome {
     run(
         path,
-        RunOptions { profile: None,
+        RunOptions {
+            profile: None,
             run_id: Some("test-run".to_string()),
             entities: Vec::new(),
             dry_run: false,

--- a/crates/floe-core/tests/unit/io/read/orc_input.rs
+++ b/crates/floe-core/tests/unit/io/read/orc_input.rs
@@ -62,7 +62,7 @@ fn write_config(dir: &Path, contents: &str) -> PathBuf {
 fn run_config(path: &Path) -> floe_core::RunOutcome {
     run(
         path,
-        RunOptions {
+        RunOptions { profile: None,
             run_id: Some("test-run".to_string()),
             entities: Vec::new(),
             dry_run: false,

--- a/crates/floe-core/tests/unit/io/read/parquet_input.rs
+++ b/crates/floe-core/tests/unit/io/read/parquet_input.rs
@@ -35,7 +35,7 @@ fn write_config(dir: &Path, contents: &str) -> PathBuf {
 fn run_config(path: &Path) -> floe_core::RunOutcome {
     run(
         path,
-        RunOptions {
+        RunOptions { profile: None,
             run_id: Some("test-run".to_string()),
             entities: Vec::new(),
             dry_run: false,

--- a/crates/floe-core/tests/unit/io/read/parquet_input.rs
+++ b/crates/floe-core/tests/unit/io/read/parquet_input.rs
@@ -35,7 +35,8 @@ fn write_config(dir: &Path, contents: &str) -> PathBuf {
 fn run_config(path: &Path) -> floe_core::RunOutcome {
     run(
         path,
-        RunOptions { profile: None,
+        RunOptions {
+            profile: None,
             run_id: Some("test-run".to_string()),
             entities: Vec::new(),
             dry_run: false,

--- a/crates/floe-core/tests/unit/io/read/xlsx_input.rs
+++ b/crates/floe-core/tests/unit/io/read/xlsx_input.rs
@@ -27,7 +27,8 @@ fn write_config(dir: &Path, contents: &str) -> PathBuf {
 fn run_config(path: &Path) -> floe_core::RunOutcome {
     run(
         path,
-        RunOptions { profile: None,
+        RunOptions {
+            profile: None,
             run_id: Some("test-run".to_string()),
             entities: Vec::new(),
             dry_run: false,

--- a/crates/floe-core/tests/unit/io/read/xlsx_input.rs
+++ b/crates/floe-core/tests/unit/io/read/xlsx_input.rs
@@ -27,7 +27,7 @@ fn write_config(dir: &Path, contents: &str) -> PathBuf {
 fn run_config(path: &Path) -> floe_core::RunOutcome {
     run(
         path,
-        RunOptions {
+        RunOptions { profile: None,
             run_id: Some("test-run".to_string()),
             entities: Vec::new(),
             dry_run: false,

--- a/crates/floe-core/tests/unit/io/read/xml.rs
+++ b/crates/floe-core/tests/unit/io/read/xml.rs
@@ -32,7 +32,8 @@ fn write_config(dir: &Path, contents: &str) -> PathBuf {
 fn run_config(path: &Path) -> floe_core::RunOutcome {
     run(
         path,
-        RunOptions { profile: None,
+        RunOptions {
+            profile: None,
             run_id: Some("test-run".to_string()),
             entities: Vec::new(),
             dry_run: false,

--- a/crates/floe-core/tests/unit/io/read/xml.rs
+++ b/crates/floe-core/tests/unit/io/read/xml.rs
@@ -32,7 +32,7 @@ fn write_config(dir: &Path, contents: &str) -> PathBuf {
 fn run_config(path: &Path) -> floe_core::RunOutcome {
     run(
         path,
-        RunOptions {
+        RunOptions { profile: None,
             run_id: Some("test-run".to_string()),
             entities: Vec::new(),
             dry_run: false,

--- a/crates/floe-core/tests/unit/io/write/delta_merge.rs
+++ b/crates/floe-core/tests/unit/io/write/delta_merge.rs
@@ -60,7 +60,7 @@ entities:
 
     let outcome = run(
         &config_path,
-        RunOptions {
+        RunOptions { profile: None,
             run_id: Some("unit-delta-merge-dup".to_string()),
             entities: Vec::new(),
             dry_run: false,
@@ -124,7 +124,7 @@ entities:
 
     run(
         &config_path,
-        RunOptions {
+        RunOptions { profile: None,
             run_id: Some("unit-delta-merge-init".to_string()),
             entities: Vec::new(),
             dry_run: false,
@@ -141,7 +141,7 @@ entities:
 
     let outcome = run(
         &config_path,
-        RunOptions {
+        RunOptions { profile: None,
             run_id: Some("unit-delta-merge-upsert".to_string()),
             entities: Vec::new(),
             dry_run: false,
@@ -210,7 +210,7 @@ entities:
 
     run(
         &config_path,
-        RunOptions {
+        RunOptions { profile: None,
             run_id: Some("unit-delta-merge-schema-evolution-init".to_string()),
             entities: Vec::new(),
             dry_run: false,
@@ -263,7 +263,7 @@ entities:
 
     let outcome = run(
         &config_path,
-        RunOptions {
+        RunOptions { profile: None,
             run_id: Some("unit-delta-merge-schema-evolution-upsert".to_string()),
             entities: Vec::new(),
             dry_run: false,

--- a/crates/floe-core/tests/unit/io/write/delta_merge.rs
+++ b/crates/floe-core/tests/unit/io/write/delta_merge.rs
@@ -60,7 +60,8 @@ entities:
 
     let outcome = run(
         &config_path,
-        RunOptions { profile: None,
+        RunOptions {
+            profile: None,
             run_id: Some("unit-delta-merge-dup".to_string()),
             entities: Vec::new(),
             dry_run: false,
@@ -124,7 +125,8 @@ entities:
 
     run(
         &config_path,
-        RunOptions { profile: None,
+        RunOptions {
+            profile: None,
             run_id: Some("unit-delta-merge-init".to_string()),
             entities: Vec::new(),
             dry_run: false,
@@ -141,7 +143,8 @@ entities:
 
     let outcome = run(
         &config_path,
-        RunOptions { profile: None,
+        RunOptions {
+            profile: None,
             run_id: Some("unit-delta-merge-upsert".to_string()),
             entities: Vec::new(),
             dry_run: false,
@@ -210,7 +213,8 @@ entities:
 
     run(
         &config_path,
-        RunOptions { profile: None,
+        RunOptions {
+            profile: None,
             run_id: Some("unit-delta-merge-schema-evolution-init".to_string()),
             entities: Vec::new(),
             dry_run: false,
@@ -263,7 +267,8 @@ entities:
 
     let outcome = run(
         &config_path,
-        RunOptions { profile: None,
+        RunOptions {
+            profile: None,
             run_id: Some("unit-delta-merge-schema-evolution-upsert".to_string()),
             entities: Vec::new(),
             dry_run: false,

--- a/crates/floe-core/tests/unit/profile/validate.rs
+++ b/crates/floe-core/tests/unit/profile/validate.rs
@@ -149,6 +149,36 @@ variables:
     assert!(err.to_string().contains("unclosed"), "got: {err}");
 }
 
+#[test]
+fn validate_profile_rejects_empty_placeholder() {
+    let yaml = r#"
+apiVersion: floe/v1
+kind: EnvironmentProfile
+metadata:
+  name: dev
+variables:
+  BAD: /path/${}
+"#;
+    let profile = parse_profile_from_str(yaml).expect("parse");
+    let err = validate_profile(&profile).unwrap_err();
+    assert!(err.to_string().contains("malformed"), "got: {err}");
+}
+
+#[test]
+fn validate_profile_rejects_unclosed_placeholder() {
+    let yaml = r#"
+apiVersion: floe/v1
+kind: EnvironmentProfile
+metadata:
+  name: dev
+variables:
+  BAD: /some/${UNCLOSED
+"#;
+    let profile = parse_profile_from_str(yaml).expect("parse");
+    let err = validate_profile(&profile).unwrap_err();
+    assert!(err.to_string().contains("malformed"), "got: {err}");
+}
+
 // ---------------------------------------------------------------------------
 // validate_profile – runner type acceptance
 // ---------------------------------------------------------------------------

--- a/crates/floe-core/tests/unit/profile/validate.rs
+++ b/crates/floe-core/tests/unit/profile/validate.rs
@@ -1,7 +1,8 @@
 use std::collections::HashMap;
 
 use floe_core::{
-    detect_unresolved_placeholders, parse_profile_from_str, validate_merged_vars, validate_profile,
+    detect_unresolved_placeholders, parse_profile_from_str, resolve_vars, validate_merged_vars,
+    validate_profile, VarSources,
 };
 
 // ---------------------------------------------------------------------------
@@ -83,11 +84,30 @@ validation:
 }
 
 // ---------------------------------------------------------------------------
-// validate_profile – failure: unresolved variables
+// validate_profile – cross-variable references are allowed in raw profiles
 // ---------------------------------------------------------------------------
 
 #[test]
-fn validate_profile_unresolved_var_fails() {
+fn validate_profile_allows_cross_references() {
+    // ${VAR} syntax is valid in a raw profile — it is a reference to another
+    // variable that resolve_vars will expand later. validate_profile must not
+    // reject it.
+    let yaml = r#"
+apiVersion: floe/v1
+kind: EnvironmentProfile
+metadata:
+  name: dev
+variables:
+  BASE_DIR: /data
+  CATALOG: ${BASE_DIR}/catalog
+"#;
+    let profile = parse_profile_from_str(yaml).expect("parse");
+    validate_profile(&profile).expect("cross-references must be accepted by validate_profile");
+}
+
+#[test]
+fn resolve_vars_fails_on_undefined_reference() {
+    // resolve_vars must catch references to keys that are not defined.
     let yaml = r#"
 apiVersion: floe/v1
 kind: EnvironmentProfile
@@ -97,16 +117,19 @@ variables:
   CATALOG: ${UNDEFINED_VAR}
 "#;
     let profile = parse_profile_from_str(yaml).expect("parse");
-    let err = validate_profile(&profile).unwrap_err();
-    assert!(
-        err.to_string().contains("unresolved placeholder"),
-        "got: {err}"
-    );
-    assert!(err.to_string().contains("CATALOG"), "got: {err}");
+    let empty = HashMap::new();
+    let err = resolve_vars(VarSources {
+        profile: &profile.variables,
+        cli: &empty,
+        config: &empty,
+    })
+    .unwrap_err();
+    assert!(err.to_string().contains("UNDEFINED_VAR"), "got: {err}");
 }
 
 #[test]
-fn validate_profile_unclosed_placeholder_fails() {
+fn resolve_vars_fails_on_unclosed_placeholder() {
+    // resolve_vars must catch unclosed ${ syntax in variable values.
     let yaml = r#"
 apiVersion: floe/v1
 kind: EnvironmentProfile
@@ -116,11 +139,14 @@ variables:
   PATH_VAR: /some/${UNCLOSED
 "#;
     let profile = parse_profile_from_str(yaml).expect("parse");
-    let err = validate_profile(&profile).unwrap_err();
-    assert!(
-        err.to_string().contains("unresolved placeholder"),
-        "got: {err}"
-    );
+    let empty = HashMap::new();
+    let err = resolve_vars(VarSources {
+        profile: &profile.variables,
+        cli: &empty,
+        config: &empty,
+    })
+    .unwrap_err();
+    assert!(err.to_string().contains("unclosed"), "got: {err}");
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/floe-core/tests/unit/run/check_order.rs
+++ b/crates/floe-core/tests/unit/run/check_order.rs
@@ -33,7 +33,8 @@ fn write_config(dir: &Path, contents: &str) -> PathBuf {
 fn run_config(path: &Path) -> floe_core::RunOutcome {
     run(
         path,
-        RunOptions { profile: None,
+        RunOptions {
+            profile: None,
             run_id: Some("test-run".to_string()),
             entities: Vec::new(),
             dry_run: false,

--- a/crates/floe-core/tests/unit/run/check_order.rs
+++ b/crates/floe-core/tests/unit/run/check_order.rs
@@ -33,7 +33,7 @@ fn write_config(dir: &Path, contents: &str) -> PathBuf {
 fn run_config(path: &Path) -> floe_core::RunOutcome {
     run(
         path,
-        RunOptions {
+        RunOptions { profile: None,
             run_id: Some("test-run".to_string()),
             entities: Vec::new(),
             dry_run: false,

--- a/crates/floe-core/tests/unit/run/entity/accepted_output.rs
+++ b/crates/floe-core/tests/unit/run/entity/accepted_output.rs
@@ -32,7 +32,8 @@ fn write_config(dir: &Path, contents: &str) -> PathBuf {
 fn run_config(path: &Path) -> floe_core::RunOutcome {
     run(
         path,
-        RunOptions { profile: None,
+        RunOptions {
+            profile: None,
             run_id: Some("test-run".to_string()),
             entities: Vec::new(),
             dry_run: false,

--- a/crates/floe-core/tests/unit/run/entity/accepted_output.rs
+++ b/crates/floe-core/tests/unit/run/entity/accepted_output.rs
@@ -32,7 +32,7 @@ fn write_config(dir: &Path, contents: &str) -> PathBuf {
 fn run_config(path: &Path) -> floe_core::RunOutcome {
     run(
         path,
-        RunOptions {
+        RunOptions { profile: None,
             run_id: Some("test-run".to_string()),
             entities: Vec::new(),
             dry_run: false,

--- a/crates/floe-core/tests/unit/run/entity/incremental.rs
+++ b/crates/floe-core/tests/unit/run/entity/incremental.rs
@@ -158,7 +158,7 @@ fn list_files(dir: &Path) -> Vec<PathBuf> {
 fn run_config(path: &Path, run_id: &str) -> floe_core::RunOutcome {
     run(
         path,
-        RunOptions {
+        RunOptions { profile: None,
             run_id: Some(run_id.to_string()),
             entities: Vec::new(),
             dry_run: false,
@@ -325,7 +325,7 @@ fn incremental_file_mode_fails_on_mismatched_state_entity() {
 
     let err = run(
         &config_path,
-        RunOptions {
+        RunOptions { profile: None,
             run_id: Some("incremental-entity-mismatch".to_string()),
             entities: Vec::new(),
             dry_run: false,
@@ -371,7 +371,7 @@ fn incremental_file_mode_fails_on_mismatched_state_schema() {
 
     let err = run(
         &config_path,
-        RunOptions {
+        RunOptions { profile: None,
             run_id: Some("incremental-schema-mismatch".to_string()),
             entities: Vec::new(),
             dry_run: false,

--- a/crates/floe-core/tests/unit/run/entity/incremental.rs
+++ b/crates/floe-core/tests/unit/run/entity/incremental.rs
@@ -158,7 +158,8 @@ fn list_files(dir: &Path) -> Vec<PathBuf> {
 fn run_config(path: &Path, run_id: &str) -> floe_core::RunOutcome {
     run(
         path,
-        RunOptions { profile: None,
+        RunOptions {
+            profile: None,
             run_id: Some(run_id.to_string()),
             entities: Vec::new(),
             dry_run: false,
@@ -325,7 +326,8 @@ fn incremental_file_mode_fails_on_mismatched_state_entity() {
 
     let err = run(
         &config_path,
-        RunOptions { profile: None,
+        RunOptions {
+            profile: None,
             run_id: Some("incremental-entity-mismatch".to_string()),
             entities: Vec::new(),
             dry_run: false,
@@ -371,7 +373,8 @@ fn incremental_file_mode_fails_on_mismatched_state_schema() {
 
     let err = run(
         &config_path,
-        RunOptions { profile: None,
+        RunOptions {
+            profile: None,
             run_id: Some("incremental-schema-mismatch".to_string()),
             entities: Vec::new(),
             dry_run: false,

--- a/crates/floe-core/tests/unit/run/schema_mismatch.rs
+++ b/crates/floe-core/tests/unit/run/schema_mismatch.rs
@@ -127,7 +127,8 @@ entities:
 fn run_config(path: &Path) -> floe_core::RunOutcome {
     run(
         path,
-        RunOptions { profile: None,
+        RunOptions {
+            profile: None,
             run_id: Some("test-run".to_string()),
             entities: Vec::new(),
             dry_run: false,

--- a/crates/floe-core/tests/unit/run/schema_mismatch.rs
+++ b/crates/floe-core/tests/unit/run/schema_mismatch.rs
@@ -127,7 +127,7 @@ entities:
 fn run_config(path: &Path) -> floe_core::RunOutcome {
     run(
         path,
-        RunOptions {
+        RunOptions { profile: None,
             run_id: Some("test-run".to_string()),
             entities: Vec::new(),
             dry_run: false,


### PR DESCRIPTION
## Summary

Closes #228

- Add `--profile <path>` argument to `floe run` in the CLI
- Extend `RunOptions` with `profile: Option<ProfileConfig>` and `ValidateOptions` with `profile_vars`
- `parse_config_with_vars` threads profile variables into config template substitution (`{{VAR}}` placeholders) before the config is parsed or validated
- `apply_templates_with_vars` merges profile vars at the lowest priority layer — `env.vars` and `env.file` in the config still take precedence, so existing behavior is unchanged when no profile is provided
- Both `RunContext` and the pre-run validation step use the resolved profile vars, so paths, storage definitions, and report paths all benefit from substitution

## How it works

```bash
floe run --config floe.yaml --profile profiles/prod.yaml
```

Profile variables (resolved with `${REF}` support) substitute `{{PLACEHOLDER}}` tokens in the config before it is parsed. This lets environment-specific values like bucket names or paths live in a profile file rather than being hardcoded in the config.

Priority (highest → lowest): `env.vars` in config → `env.file` → profile variables

## Test plan

- [x] `cargo build -p floe-core -p floe-cli` — clean build, no warnings
- [x] `cargo test -p floe-core --test unit` — 433 passed, 0 failed
- [x] All existing `RunOptions` and `ValidateOptions` usages updated in tests

---
_Generated by [Claude Code](https://claude.ai/code/session_01XL7X5BrBqLuvYGLY5zeYVR)_