### PR TITLE
fix: skip set_versions.sh on workflow_dispatch dry runs

### DIFF
--- a/.github/scripts/render_scoop_manifest.py
+++ b/.github/scripts/render_scoop_manifest.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+
+def build_manifest(version: str, windows_sha: str) -> dict:
+    base = (
+        "https://github.com/malon64/floe/releases/download/"
+        f"v{version}/floe-v{version}-x86_64-pc-windows-msvc.zip"
+    )
+    return {
+        "version": version,
+        "description": "YAML-driven technical ingestion tool",
+        "homepage": "https://github.com/malon64/floe",
+        "license": "MIT",
+        "architecture": {
+            "64bit": {
+                "url": base,
+                "hash": windows_sha,
+                "bin": "floe.exe",
+                "extract_dir": ".",
+            }
+        },
+        "checkver": {"github": "https://github.com/malon64/floe"},
+        "autoupdate": {
+            "architecture": {
+                "64bit": {
+                    "url": (
+                        "https://github.com/malon64/floe/releases/download/"
+                        "v$version/floe-v$version-x86_64-pc-windows-msvc.zip"
+                    )
+                }
+            }
+        },
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Render the Scoop bucket manifest.")
+    parser.add_argument("--version", required=True)
+    parser.add_argument("--windows-sha", required=True)
+    parser.add_argument("--out", required=True)
+    args = parser.parse_args()
+
+    manifest = build_manifest(args.version, args.windows_sha)
+    out_path = Path(args.out)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(
+        json.dumps(manifest, indent=2, ensure_ascii=False) + "\n",
+        encoding="utf-8",
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -163,15 +163,23 @@ jobs:
           - os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
             use_cross: true
+            archive_ext: tar.gz
           - os: ubuntu-latest
             target: aarch64-unknown-linux-gnu
             use_cross: true
+            archive_ext: tar.gz
           - os: macos-latest
             target: x86_64-apple-darwin
             use_cross: false
+            archive_ext: tar.gz
           - os: macos-latest
             target: aarch64-apple-darwin
             use_cross: false
+            archive_ext: tar.gz
+          - os: windows-latest
+            target: x86_64-pc-windows-msvc
+            use_cross: false
+            archive_ext: zip
     env:
       VERSION: ${{ needs.meta.outputs.version }}
     steps:
@@ -187,6 +195,7 @@ jobs:
       - name: Set Cargo versions from tag
         run: bash .github/scripts/set_versions.sh "${VERSION}"
       - name: Build floe
+        shell: bash
         run: |
           features=""
           if [[ "${{ matrix.target }}" == *unknown-linux* ]]; then
@@ -197,7 +206,8 @@ jobs:
           else
             cargo build -p floe-cli ${features} --release --target ${{ matrix.target }}
           fi
-      - name: Package binary
+      - name: Package binary (Unix)
+        if: matrix.archive_ext == 'tar.gz'
         shell: bash
         run: |
           set -euo pipefail
@@ -220,6 +230,27 @@ jobs:
           sha_path = tarball.with_suffix(tarball.suffix + ".sha256")
           sha_path.write_text(f"{sha}  {tarball.name}\n", encoding="utf-8")
           PY
+      - name: Package binary (Windows)
+        if: matrix.archive_ext == 'zip'
+        shell: python
+        env:
+          TARGET: ${{ matrix.target }}
+        run: |
+          import hashlib, os, zipfile
+          from pathlib import Path
+
+          target = os.environ["TARGET"]
+          version = os.environ["VERSION"]
+          bin_path = Path(f"target/{target}/release/floe.exe")
+          if not bin_path.exists():
+              raise FileNotFoundError(f"Binary not found: {bin_path}")
+          archive_path = Path(f"dist/floe-v{version}-{target}.zip")
+          archive_path.parent.mkdir(parents=True, exist_ok=True)
+          with zipfile.ZipFile(archive_path, "w", zipfile.ZIP_DEFLATED) as zf:
+              zf.write(bin_path, "floe.exe")
+          sha = hashlib.sha256(archive_path.read_bytes()).hexdigest()
+          sha_path = Path(str(archive_path) + ".sha256")
+          sha_path.write_text(f"{sha}  {archive_path.name}\n", encoding="utf-8")
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
@@ -254,9 +285,11 @@ jobs:
           linux="dist/floe-v${version}-x86_64-unknown-linux-gnu.tar.gz.sha256"
           mac_x86="dist/floe-v${version}-x86_64-apple-darwin.tar.gz.sha256"
           mac_arm="dist/floe-v${version}-aarch64-apple-darwin.tar.gz.sha256"
+          windows="dist/floe-v${version}-x86_64-pc-windows-msvc.zip.sha256"
           echo "linux_sha=$(cut -d ' ' -f1 "${linux}")" >> "$GITHUB_OUTPUT"
           echo "mac_x86_sha=$(cut -d ' ' -f1 "${mac_x86}")" >> "$GITHUB_OUTPUT"
           echo "mac_arm_sha=$(cut -d ' ' -f1 "${mac_arm}")" >> "$GITHUB_OUTPUT"
+          echo "windows_sha=$(cut -d ' ' -f1 "${windows}")" >> "$GITHUB_OUTPUT"
       - name: Verify Homebrew tap token
         run: |
           if [ -z "${HOMEBREW_TAP_TOKEN}" ]; then
@@ -289,6 +322,40 @@ jobs:
           git add Formula/floe.rb
           if git diff --cached --quiet; then
             echo "No Homebrew changes to commit."
+            exit 0
+          fi
+          git commit -m "bump floe to v${VERSION}"
+          git push
+      - name: Verify Scoop bucket token
+        run: |
+          if [ -z "${SCOOP_BUCKET_TOKEN}" ]; then
+            echo "SCOOP_BUCKET_TOKEN is required to update the Scoop bucket."
+            exit 1
+          fi
+        env:
+          SCOOP_BUCKET_TOKEN: ${{ secrets.SCOOP_BUCKET_TOKEN }}
+      - name: Checkout Scoop bucket
+        uses: actions/checkout@v4
+        with:
+          repository: malon64/scoop-floe
+          token: ${{ secrets.SCOOP_BUCKET_TOKEN }}
+          path: scoop
+      - name: Render Scoop manifest
+        run: |
+          python .github/scripts/render_scoop_manifest.py \
+            --version "${VERSION}" \
+            --windows-sha "${{ steps.shas.outputs.windows_sha }}" \
+            --out "scoop/bucket/floe.json"
+      - name: Commit and push Scoop manifest
+        shell: bash
+        run: |
+          set -euo pipefail
+          cd scoop
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add bucket/floe.json
+          if git diff --cached --quiet; then
+            echo "No Scoop changes to commit."
             exit 0
           fi
           git commit -m "bump floe to v${VERSION}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -193,6 +193,7 @@ jobs:
         with:
           tool: cross
       - name: Set Cargo versions from tag
+        if: startsWith(github.ref, 'refs/tags/')
         run: bash .github/scripts/set_versions.sh "${VERSION}"
       - name: Build floe
         shell: bash


### PR DESCRIPTION
## Root cause

When the release workflow is triggered via `workflow_dispatch` from `main`, `GITHUB_REF_NAME` is `"main"`, so the `meta` job sets `VERSION="main"`. The `set_versions.sh` step then wrote `version = "main"` into both `Cargo.toml` files — which is not valid semver. Cargo fails to parse the manifest before the build even starts, causing every matrix entry to fail.

## Fix

Added `if: startsWith(github.ref, 'refs/tags/')` to the `Set Cargo versions from tag` step in the `build` job. For dry runs (triggered from a branch), the step is skipped and the existing version in `Cargo.toml` is used — which is fine for testing the build pipeline. For real tag releases the step runs as before.

## Test plan

- [ ] Merge and re-trigger `workflow_dispatch` dry run — all 5 build matrix entries should now succeed
- [ ] Verify that a real tag release still updates `Cargo.toml` versions correctly

https://claude.ai/code/session_01XL7X5BrBqLuvYGLY5zeYVR

---
_Generated by [Claude Code](https://claude.ai/code/session_01XL7X5BrBqLuvYGLY5zeYVR)_