### PR TITLE
chore: upgrade GitHub Actions to Node.js 24 runtime versions

### DIFF
--- a/.github/workflows/airflow-floe.yml
+++ b/.github/workflows/airflow-floe.yml
@@ -19,8 +19,8 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
       - name: Syntax check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
   rustfmt:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt
@@ -22,7 +22,7 @@ jobs:
   clippy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy
@@ -37,8 +37,8 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: dorny/paths-filter@v3
+      - uses: actions/checkout@v6
+      - uses: dorny/paths-filter@v4
         id: changes
         with:
           filters: |

--- a/.github/workflows/dagster-floe.yml
+++ b/.github/workflows/dagster-floe.yml
@@ -19,8 +19,8 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
           cache: pip

--- a/.github/workflows/release-airflow-floe.yml
+++ b/.github/workflows/release-airflow-floe.yml
@@ -14,8 +14,8 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
       - name: Build

--- a/.github/workflows/release-dagster-floe.yml
+++ b/.github/workflows/release-dagster-floe.yml
@@ -14,8 +14,8 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
       - name: Build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
       tag: ${{ steps.meta.outputs.tag }}
       on_main: ${{ steps.guard.outputs.on_main }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - id: meta
@@ -50,10 +50,10 @@ jobs:
     env:
       VERSION: ${{ needs.meta.outputs.version }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Download build artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           path: dist
           pattern: dist-*
@@ -75,20 +75,20 @@ jobs:
         run: ./dist/docker/linux/amd64/floe --help > /dev/null
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Login to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push (multi-arch)
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: ./Dockerfile.release
@@ -108,7 +108,7 @@ jobs:
       VERSION: ${{ needs.meta.outputs.version }}
       CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
       - name: Set Cargo versions from tag
         run: bash .github/scripts/set_versions.sh "${VERSION}"
@@ -183,7 +183,7 @@ jobs:
     env:
       VERSION: ${{ needs.meta.outputs.version }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: ${{ matrix.target }}
@@ -252,7 +252,7 @@ jobs:
           sha_path = Path(str(archive_path) + ".sha256")
           sha_path.write_text(f"{sha}  {archive_path.name}\n", encoding="utf-8")
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: dist-${{ matrix.target }}
           path: dist/*
@@ -265,14 +265,14 @@ jobs:
       VERSION: ${{ needs.meta.outputs.version }}
       TAG: ${{ needs.meta.outputs.tag }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Download artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           path: dist
           merge-multiple: true
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ env.TAG }}
           name: Floe v${{ env.VERSION }}
@@ -299,7 +299,7 @@ jobs:
         env:
           HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
       - name: Checkout Homebrew tap
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: malon64/homebrew-floe
           token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
@@ -335,7 +335,7 @@ jobs:
         env:
           SCOOP_BUCKET_TOKEN: ${{ secrets.SCOOP_BUCKET_TOKEN }}
       - name: Checkout Scoop bucket
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: malon64/scoop-floe
           token: ${{ secrets.SCOOP_BUCKET_TOKEN }}


### PR DESCRIPTION
## Summary

Bumps all GitHub Actions dependencies to their latest major versions that run on the Node.js 24 runtime, eliminating the node20 deprecation warnings (GitHub is removing node20 support in fall 2026).

| Action | Before | After |
|--------|--------|-------|
| `actions/checkout` | v4 | v6 |
| `actions/upload-artifact` | v4 | v6 |
| `actions/download-artifact` | v4 | v7 |
| `actions/setup-python` | v5 | v6 |
| `docker/setup-qemu-action` | v3 | v4 |
| `docker/setup-buildx-action` | v3 | v4 |
| `docker/login-action` | v3 | v4 |
| `docker/build-push-action` | v6 | v7 |
| `softprops/action-gh-release` | v2 | v3 |
| `dorny/paths-filter` | v3 | v4 |

`dtolnay/rust-toolchain`, `taiki-e/install-action`, `Swatinem/rust-cache`, and `pypa/gh-action-pypi-publish` are unchanged (already on their latest stable version or use their own runtime mechanism).

Changes apply across all 6 workflow files: `ci.yml`, `release.yml`, `airflow-floe.yml`, `dagster-floe.yml`, `release-airflow-floe.yml`, `release-dagster-floe.yml`.

https://claude.ai/code/session_01XL7X5BrBqLuvYGLY5zeYVR

---
_Generated by [Claude Code](https://claude.ai/code/session_01XL7X5BrBqLuvYGLY5zeYVR)_