### PR TITLE
release: prepare v0.3.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to Floe are documented in this file.
 
+## v0.3.7
+
+- Windows binary now distributed via [Scoop](https://github.com/malon64/scoop-floe): `scoop bucket add floe https://github.com/malon64/scoop-floe` then `scoop install floe`.
+- Release pipeline extended with a `x86_64-pc-windows-msvc` build target; artifact packaged as `.zip`.
+- GitHub Actions upgraded to Node.js 24 runtime across all workflows.
+
 ## v0.3.6
 
 - Added `--profile <path>` flag to `floe run` for environment-specific variable injection into `{{VAR}}` config placeholders.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3376,7 +3376,7 @@ dependencies = [
 
 [[package]]
 name = "floe-cli"
-version = "0.3.6"
+version = "0.3.7"
 dependencies = [
  "assert_cmd",
  "clap",
@@ -3389,7 +3389,7 @@ dependencies = [
 
 [[package]]
 name = "floe-core"
-version = "0.3.6"
+version = "0.3.7"
 dependencies = [
  "apache-avro 0.16.0",
  "arrow",

--- a/README.md
+++ b/README.md
@@ -68,11 +68,21 @@ Support matrix: [docs/support-matrix.md](docs/support-matrix.md)
 
 ## Quickstart
 
-### Install (Homebrew)
+### Install
+
+**macOS / Linux — [Homebrew](https://brew.sh)**
 
 ```bash
 brew tap malon64/floe
 brew install floe
+floe --version
+```
+
+**Windows — [Scoop](https://scoop.sh)**
+
+```bash
+scoop bucket add floe https://github.com/malon64/scoop-floe
+scoop install floe
 floe --version
 ```
 

--- a/crates/floe-cli/Cargo.toml
+++ b/crates/floe-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "floe-cli"
-version = "0.3.6"
+version = "0.3.7"
 edition = "2021"
 description = "CLI for Floe, a YAML-driven technical ingestion tool."
 license = "MIT"
@@ -17,7 +17,7 @@ path = "src/main.rs"
 
 [dependencies]
 clap = { version = "4", features = ["derive"] }
-floe-core = { path = "../floe-core", version = "0.3.6" }
+floe-core = { path = "../floe-core", version = "0.3.7" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 

--- a/crates/floe-core/Cargo.toml
+++ b/crates/floe-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "floe-core"
-version = "0.3.6"
+version = "0.3.7"
 edition = "2021"
 description = "Core library for Floe, a YAML-driven technical ingestion tool."
 license = "MIT"

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,9 +1,10 @@
 # Installation
 
-Floe ships as a CLI (`floe`). The recommended install method is Homebrew.
-If Homebrew is not available, you can install from source with Cargo.
+Floe ships as a single CLI binary (`floe`). Choose the method that matches your OS.
 
-## Homebrew (recommended)
+## macOS / Linux — Homebrew (recommended)
+
+If you don't have Homebrew yet, install it from [brew.sh](https://brew.sh).
 
 ```bash
 brew tap malon64/floe
@@ -11,20 +12,41 @@ brew install floe
 floe --version
 ```
 
+## Windows — Scoop (recommended)
+
+If you don't have Scoop yet, install it from [scoop.sh](https://scoop.sh).
+
+```powershell
+scoop bucket add floe https://github.com/malon64/scoop-floe
+scoop install floe
+floe --version
+```
+
+## Prebuilt binary (all platforms)
+
+Download the archive for your platform from [GitHub Releases](https://github.com/malon64/floe/releases),
+extract it, and place the `floe` (or `floe.exe`) binary somewhere on your `PATH`.
+
+| Platform | Archive |
+|---|---|
+| macOS arm64 (Apple Silicon) | `floe-vX.Y.Z-aarch64-apple-darwin.tar.gz` |
+| macOS x86_64 | `floe-vX.Y.Z-x86_64-apple-darwin.tar.gz` |
+| Linux x86_64 | `floe-vX.Y.Z-x86_64-unknown-linux-gnu.tar.gz` |
+| Linux arm64 | `floe-vX.Y.Z-aarch64-unknown-linux-gnu.tar.gz` |
+| Windows x86_64 | `floe-vX.Y.Z-x86_64-pc-windows-msvc.zip` |
+
 ## Cargo (from source)
 
 Prereqs:
-- Rust toolchain (stable)
-- A C/C++ toolchain available in `PATH`
-
-Install:
+- Rust toolchain (stable) — install from [rustup.rs](https://rustup.rs)
+- A C/C++ compiler available in `PATH`
 
 ```bash
 cargo install floe-cli
 floe --version
 ```
 
-If you want to build from a local checkout instead:
+To build from a local checkout instead:
 
 ```bash
 cargo build --release
@@ -33,9 +55,7 @@ cargo build --release
 
 ## Docker (GHCR)
 
-Floe is published as a Docker image to GitHub Container Registry (GHCR).
-
-Pull:
+Floe is published as a multi-arch Docker image (linux/amd64 and linux/arm64).
 
 ```bash
 docker pull ghcr.io/malon64/floe:latest
@@ -47,12 +67,10 @@ Run (mount the current directory to `/work`):
 docker run --rm -v "$PWD:/work" ghcr.io/malon64/floe:latest run -c /work/example/config.yml
 ```
 
-Notes:
-- All CLI arguments are identical to local usage.
-- Cloud credentials should be provided via environment variables or runtime identity.
+Cloud credentials should be provided via environment variables or runtime identity — not baked into the image.
 
 ## Troubleshooting
 
-- If `brew` is unavailable, use the Cargo path above.
-- If compilation fails, ensure you have a recent Rust toolchain and a system C
-  compiler installed.
+- **`brew` not found**: install Homebrew from [brew.sh](https://brew.sh), then retry.
+- **`scoop` not found**: install Scoop from [scoop.sh](https://scoop.sh), then retry.
+- **Cargo compilation fails**: ensure you have a recent stable Rust toolchain (`rustup update stable`) and a system C compiler installed.


### PR DESCRIPTION
## Summary

- Bumps `floe-core` and `floe-cli` from `0.3.6` → `0.3.7`
- Adds `## v0.3.7` CHANGELOG entry covering Windows binary / Scoop distribution and the Node.js 24 Actions upgrade

## To release

Once merged, tag `main` as `v0.3.7` — the release workflow will build all 5 targets (Linux x86_64, Linux arm64, macOS x86_64, macOS arm64, Windows x86_64), publish to crates.io, create the GitHub release, update the Homebrew tap, and push the Scoop manifest.

https://claude.ai/code/session_01XL7X5BrBqLuvYGLY5zeYVR

---
_Generated by [Claude Code](https://claude.ai/code/session_01XL7X5BrBqLuvYGLY5zeYVR)_