### PR TITLE
fix: prevent CRLF corruption of version string on Windows build

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,20 @@
+# Ensure consistent line endings across platforms.
+# Shell scripts must always be checked out with LF so bash on Windows
+# does not include \r in variable assignments.
+*.sh        text eol=lf
+
+# YAML and TOML are text files — normalise to LF in the repo.
+*.yml       text eol=lf
+*.yaml      text eol=lf
+*.toml      text eol=lf
+*.md        text eol=lf
+*.py        text eol=lf
+*.rb        text eol=lf
+*.json      text eol=lf
+
+# Binaries — never touch line endings.
+*.png       binary
+*.jpg       binary
+*.jpeg      binary
+*.gz        binary
+*.zip       binary

--- a/.github/scripts/set_versions.sh
+++ b/.github/scripts/set_versions.sh
@@ -6,7 +6,7 @@ if [ $# -ne 1 ]; then
   exit 1
 fi
 
-version="$1"
+version="${1//$'\r'/}"
 
 VERSION="${version}" python - <<'PY'
 import os

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -192,9 +192,6 @@ jobs:
         uses: taiki-e/install-action@v2
         with:
           tool: cross
-      - name: Install NASM (Windows MSVC)
-        if: matrix.os == 'windows-latest'
-        uses: ilammy/setup-nasm@v1
       - name: Set Cargo versions from tag
         if: startsWith(github.ref, 'refs/tags/')
         run: bash .github/scripts/set_versions.sh "${VERSION}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -192,6 +192,9 @@ jobs:
         uses: taiki-e/install-action@v2
         with:
           tool: cross
+      - name: Install NASM (Windows MSVC)
+        if: matrix.os == 'windows-latest'
+        uses: ilammy/setup-nasm@v1
       - name: Set Cargo versions from tag
         if: startsWith(github.ref, 'refs/tags/')
         run: bash .github/scripts/set_versions.sh "${VERSION}"


### PR DESCRIPTION
## Root cause

`set_versions.sh` is checked out on Windows with CRLF line endings (git `autocrlf=true`). Bash on Windows includes the trailing `\r` in variable assignments, so `version="$1"` becomes `version="0.3.7\r"`. That `\r` is then written into `Cargo.toml`, producing `version = "0.3.7\r"` — invalid semver. The `\r` also moves the terminal cursor back to the start of the line, making the logs show `version = ""` instead of the actual value.

## Fix

Two-layer fix:
- **`.gitattributes`** — forces LF checkout for `*.sh`, `*.yml`, `*.toml`, `*.py` and other text files on all platforms, so shell scripts always have clean line endings.
- **`set_versions.sh`** — strips `\r` from `$1` defensively (`version="${1//$'\r'/}"`) as a belt-and-suspenders guard.

The speculative `ilammy/setup-nasm` step added in the first commit has been removed — NASM was not the cause.

## Test plan

- [ ] Merge and re-trigger a release workflow dry run — the Windows build job should now complete successfully

https://claude.ai/code/session_01XL7X5BrBqLuvYGLY5zeYVR