### PR TITLE
Make Iceberg catalog layer modular (CatalogTypeConfig enum + Glue hardening)

### DIFF
--- a/crates/floe-core/src/config/catalog.rs
+++ b/crates/floe-core/src/config/catalog.rs
@@ -1,9 +1,31 @@
 use std::collections::HashMap;
 
 use crate::config::{
-    CatalogDefinition, EntityConfig, ResolvedPath, RootConfig, SinkTarget, StorageResolver,
+    CatalogDefinition, CatalogTypeConfig, EntityConfig, ResolvedPath, RootConfig, SinkTarget,
+    StorageResolver,
 };
 use crate::{ConfigError, FloeResult};
+
+/// Normalizes an identifier for use as a catalog namespace, table, or database name.
+/// Lowercases, replaces non-alphanumeric/non-underscore/non-hyphen chars with `_`,
+/// and trims leading/trailing underscores.
+pub(crate) fn normalize_catalog_ident(value: &str) -> String {
+    let mut out = String::with_capacity(value.len());
+    for ch in value.chars() {
+        let mapped = if ch.is_ascii_alphanumeric() || ch == '_' || ch == '-' {
+            ch.to_ascii_lowercase()
+        } else {
+            '_'
+        };
+        out.push(mapped);
+    }
+    let trimmed = out.trim_matches('_');
+    if trimmed.is_empty() {
+        "default".to_string()
+    } else {
+        trimmed.to_string()
+    }
+}
 
 #[derive(Debug, Clone)]
 pub struct CatalogResolver {
@@ -12,12 +34,12 @@ pub struct CatalogResolver {
     definitions: HashMap<String, CatalogDefinition>,
 }
 
+/// Fully resolved Iceberg catalog target for a single entity write/seed operation.
+/// Type-specific fields (region, database, etc.) are carried in `type_config`.
 #[derive(Debug, Clone)]
 pub struct ResolvedIcebergCatalogTarget {
     pub catalog_name: String,
-    pub catalog_type: String,
-    pub region: String,
-    pub database: String,
+    pub type_config: CatalogTypeConfig,
     pub namespace: String,
     pub table: String,
     pub table_location: ResolvedPath,
@@ -60,6 +82,10 @@ impl CatalogResolver {
         self.definitions.get(name).cloned()
     }
 
+    pub fn default_name(&self) -> Option<String> {
+        self.default_name.clone()
+    }
+
     pub fn resolve_iceberg_target(
         &self,
         storage_resolver: &StorageResolver,
@@ -86,13 +112,15 @@ impl CatalogResolver {
             ))) as Box<dyn std::error::Error + Send + Sync>
         })?;
 
-        let (region, database) = resolve_catalog_type_fields(&definition)?;
-
+        // namespace and table names use the shared normalizer — same rules for all catalog types
+        let database_for_namespace = match &definition.type_config {
+            CatalogTypeConfig::Glue { database, .. } => database.as_str(),
+        };
         let namespace_source = iceberg_cfg
             .namespace
             .as_deref()
             .or(entity.domain.as_deref())
-            .unwrap_or(database.as_str());
+            .unwrap_or(database_for_namespace);
         let namespace = normalize_catalog_ident(namespace_source);
         let table_source = iceberg_cfg.table.as_deref().unwrap_or(entity.name.as_str());
         let table = normalize_catalog_ident(table_source);
@@ -146,60 +174,10 @@ impl CatalogResolver {
 
         Ok(Some(ResolvedIcebergCatalogTarget {
             catalog_name,
-            catalog_type: definition.catalog_type,
-            region,
-            database,
+            type_config: definition.type_config,
             namespace,
             table,
             table_location,
         }))
-    }
-}
-
-// Validates and extracts the fields required by each catalog type.
-// Returns an error for unknown types, making the set of supported catalogs explicit.
-fn resolve_catalog_type_fields(definition: &CatalogDefinition) -> FloeResult<(String, String)> {
-    match definition.catalog_type.as_str() {
-        "glue" => {
-            let region = definition.region.clone().ok_or_else(|| {
-                Box::new(ConfigError(format!(
-                    "catalogs.definitions name={} type=glue requires region",
-                    definition.name
-                ))) as Box<dyn std::error::Error + Send + Sync>
-            })?;
-            let database =
-                normalize_catalog_ident(definition.database.as_deref().ok_or_else(|| {
-                    Box::new(ConfigError(format!(
-                        "catalogs.definitions name={} type=glue requires database",
-                        definition.name
-                    ))) as Box<dyn std::error::Error + Send + Sync>
-                })?);
-            Ok((region, database))
-        }
-        other => Err(Box::new(ConfigError(format!(
-            "catalogs.definitions name={} has unsupported catalog_type={} (supported: glue)",
-            definition.name, other
-        )))),
-    }
-}
-
-/// Normalizes an identifier for use as a catalog namespace, table, or database name.
-/// Lowercases the value, replaces non-alphanumeric/non-underscore/non-hyphen chars with `_`,
-/// and trims leading/trailing underscores.
-pub(crate) fn normalize_catalog_ident(value: &str) -> String {
-    let mut out = String::with_capacity(value.len());
-    for ch in value.chars() {
-        let mapped = if ch.is_ascii_alphanumeric() || ch == '_' || ch == '-' {
-            ch.to_ascii_lowercase()
-        } else {
-            '_'
-        };
-        out.push(mapped);
-    }
-    let trimmed = out.trim_matches('_');
-    if trimmed.is_empty() {
-        "default".to_string()
-    } else {
-        trimmed.to_string()
     }
 }

--- a/crates/floe-core/src/config/catalog.rs
+++ b/crates/floe-core/src/config/catalog.rs
@@ -86,27 +86,16 @@ impl CatalogResolver {
             ))) as Box<dyn std::error::Error + Send + Sync>
         })?;
 
-        let region = definition.region.clone().ok_or_else(|| {
-            Box::new(ConfigError(format!(
-                "catalogs.definitions name={} requires region for type {}",
-                definition.name, definition.catalog_type
-            ))) as Box<dyn std::error::Error + Send + Sync>
-        })?;
-        let database = normalize_glue_ident(definition.database.as_deref().ok_or_else(|| {
-            Box::new(ConfigError(format!(
-                "catalogs.definitions name={} requires database for type {}",
-                definition.name, definition.catalog_type
-            ))) as Box<dyn std::error::Error + Send + Sync>
-        })?);
+        let (region, database) = resolve_catalog_type_fields(&definition)?;
 
         let namespace_source = iceberg_cfg
             .namespace
             .as_deref()
             .or(entity.domain.as_deref())
             .unwrap_or(database.as_str());
-        let namespace = normalize_glue_ident(namespace_source);
+        let namespace = normalize_catalog_ident(namespace_source);
         let table_source = iceberg_cfg.table.as_deref().unwrap_or(entity.name.as_str());
-        let table = normalize_glue_ident(table_source);
+        let table = normalize_catalog_ident(table_source);
 
         let table_location = if let Some(location) = iceberg_cfg.location.as_deref() {
             let storage_name = definition
@@ -167,7 +156,37 @@ impl CatalogResolver {
     }
 }
 
-fn normalize_glue_ident(value: &str) -> String {
+// Validates and extracts the fields required by each catalog type.
+// Returns an error for unknown types, making the set of supported catalogs explicit.
+fn resolve_catalog_type_fields(definition: &CatalogDefinition) -> FloeResult<(String, String)> {
+    match definition.catalog_type.as_str() {
+        "glue" => {
+            let region = definition.region.clone().ok_or_else(|| {
+                Box::new(ConfigError(format!(
+                    "catalogs.definitions name={} type=glue requires region",
+                    definition.name
+                ))) as Box<dyn std::error::Error + Send + Sync>
+            })?;
+            let database =
+                normalize_catalog_ident(definition.database.as_deref().ok_or_else(|| {
+                    Box::new(ConfigError(format!(
+                        "catalogs.definitions name={} type=glue requires database",
+                        definition.name
+                    ))) as Box<dyn std::error::Error + Send + Sync>
+                })?);
+            Ok((region, database))
+        }
+        other => Err(Box::new(ConfigError(format!(
+            "catalogs.definitions name={} has unsupported catalog_type={} (supported: glue)",
+            definition.name, other
+        )))),
+    }
+}
+
+/// Normalizes an identifier for use as a catalog namespace, table, or database name.
+/// Lowercases the value, replaces non-alphanumeric/non-underscore/non-hyphen chars with `_`,
+/// and trims leading/trailing underscores.
+pub(crate) fn normalize_catalog_ident(value: &str) -> String {
     let mut out = String::with_capacity(value.len());
     for ch in value.chars() {
         let mapped = if ch.is_ascii_alphanumeric() || ch == '_' || ch == '-' {

--- a/crates/floe-core/src/config/parse.rs
+++ b/crates/floe-core/src/config/parse.rs
@@ -10,13 +10,13 @@ use crate::config::yaml_decode::{
     hash_get, load_yaml, validate_known_keys, yaml_array, yaml_hash, yaml_string,
 };
 use crate::config::{
-    ArchiveTarget, CatalogDefinition, CatalogsConfig, ColumnConfig, DomainConfig, EntityConfig,
-    EntityMetadata, EntityStateConfig, EnvConfig, IcebergPartitionFieldConfig,
-    IcebergSinkTargetConfig, IncrementalMode, MergeOptionsConfig, MergeScd2OptionsConfig,
-    NormalizeColumnsConfig, PolicyConfig, ProjectMetadata, ReportConfig, RootConfig, SchemaConfig,
-    SchemaEvolutionConfig, SchemaEvolutionIncompatibleAction, SchemaEvolutionMode,
-    SchemaMismatchConfig, SinkConfig, SinkOptions, SinkTarget, SourceConfig, SourceOptions,
-    StorageDefinition, StoragesConfig, WriteMode,
+    ArchiveTarget, CatalogDefinition, CatalogTypeConfig, CatalogsConfig, ColumnConfig,
+    DomainConfig, EntityConfig, EntityMetadata, EntityStateConfig, EnvConfig,
+    IcebergPartitionFieldConfig, IcebergSinkTargetConfig, IncrementalMode, MergeOptionsConfig,
+    MergeScd2OptionsConfig, NormalizeColumnsConfig, PolicyConfig, ProjectMetadata, ReportConfig,
+    RootConfig, SchemaConfig, SchemaEvolutionConfig, SchemaEvolutionIncompatibleAction,
+    SchemaEvolutionMode, SchemaMismatchConfig, SinkConfig, SinkOptions, SinkTarget, SourceConfig,
+    SourceOptions, StorageDefinition, StoragesConfig, WriteMode,
 };
 use crate::{ConfigError, FloeResult};
 
@@ -708,18 +708,45 @@ fn parse_catalog_definition(value: &Yaml) -> FloeResult<CatalogDefinition> {
             "type",
             "region",
             "database",
+            "create_database_if_missing",
+            "allow_takeover",
             "warehouse_storage",
             "warehouse_prefix",
         ],
     )?;
+    let name = get_string(hash, "name", "catalogs.definitions")?;
+    let catalog_type = get_string(hash, "type", "catalogs.definitions")?;
+    let type_config = parse_catalog_type_config(&name, &catalog_type, hash)?;
     Ok(CatalogDefinition {
-        name: get_string(hash, "name", "catalogs.definitions")?,
-        catalog_type: get_string(hash, "type", "catalogs.definitions")?,
-        region: opt_string(hash, "region", "catalogs.definitions")?,
-        database: opt_string(hash, "database", "catalogs.definitions")?,
+        name,
+        type_config,
         warehouse_storage: opt_string(hash, "warehouse_storage", "catalogs.definitions")?,
         warehouse_prefix: opt_string(hash, "warehouse_prefix", "catalogs.definitions")?,
     })
+}
+
+fn parse_catalog_type_config(
+    name: &str,
+    catalog_type: &str,
+    hash: &yaml_rust2::yaml::Hash,
+) -> FloeResult<CatalogTypeConfig> {
+    match catalog_type {
+        "glue" => Ok(CatalogTypeConfig::Glue {
+            region: get_string(hash, "region", "catalogs.definitions")?,
+            database: get_string(hash, "database", "catalogs.definitions")?,
+            create_database_if_missing: opt_bool(
+                hash,
+                "create_database_if_missing",
+                "catalogs.definitions",
+            )?
+            .unwrap_or(true),
+            allow_takeover: opt_bool(hash, "allow_takeover", "catalogs.definitions")?
+                .unwrap_or(false),
+        }),
+        other => Err(Box::new(crate::errors::ConfigError(format!(
+            "catalogs.definitions name={name} has unsupported type={other} (supported: glue)"
+        )))),
+    }
 }
 
 fn parse_archive_target(value: &Yaml) -> FloeResult<ArchiveTarget> {

--- a/crates/floe-core/src/config/types.rs
+++ b/crates/floe-core/src/config/types.rs
@@ -328,12 +328,33 @@ pub struct CatalogsConfig {
     pub definitions: Vec<CatalogDefinition>,
 }
 
+/// Type-specific configuration for a catalog definition.
+/// Each variant carries only the fields relevant to that catalog type.
+/// Add a new variant here when supporting a new catalog type.
+#[derive(Debug, Clone)]
+pub enum CatalogTypeConfig {
+    Glue {
+        region: String,
+        database: String,
+        /// Create the Glue database if it does not exist (default: true).
+        create_database_if_missing: bool,
+        /// Allow Floe to take ownership of a Glue table it did not create (default: false).
+        allow_takeover: bool,
+    },
+}
+
+impl CatalogTypeConfig {
+    pub fn catalog_type_str(&self) -> &'static str {
+        match self {
+            Self::Glue { .. } => "glue",
+        }
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct CatalogDefinition {
     pub name: String,
-    pub catalog_type: String,
-    pub region: Option<String>,
-    pub database: Option<String>,
+    pub type_config: CatalogTypeConfig,
     pub warehouse_storage: Option<String>,
     pub warehouse_prefix: Option<String>,
 }

--- a/crates/floe-core/src/config/validate.rs
+++ b/crates/floe-core/src/config/validate.rs
@@ -1,7 +1,8 @@
 use std::collections::HashSet;
 
 use crate::config::{
-    CatalogDefinition, EntityConfig, IncrementalMode, RootConfig, SourceOptions, StorageDefinition,
+    CatalogDefinition, CatalogTypeConfig, EntityConfig, IncrementalMode, RootConfig, SourceOptions,
+    StorageDefinition,
 };
 use crate::io::format;
 use crate::io::read::json_selector::parse_selector;
@@ -15,7 +16,6 @@ const ALLOWED_POLICY_SEVERITIES: &[&str] = &["warn", "reject", "abort"];
 const ALLOWED_MISSING_POLICIES: &[&str] = &["reject_file", "fill_nulls"];
 const ALLOWED_EXTRA_POLICIES: &[&str] = &["reject_file", "ignore"];
 const ALLOWED_STORAGE_TYPES: &[&str] = &["local", "s3", "adls", "gcs"];
-const ALLOWED_CATALOG_TYPES: &[&str] = &["glue"];
 const ALLOWED_ICEBERG_PARTITION_TRANSFORMS: &[&str] = &["identity", "year", "month", "day", "hour"];
 const MIN_SUPPORTED_CONFIG_VERSION: ConfigVersion = ConfigVersion::new(0, 1);
 const MIN_SCHEMA_EVOLUTION_CONFIG_VERSION: ConfigVersion = ConfigVersion::new(0, 2);
@@ -599,9 +599,9 @@ fn validate_iceberg_catalog_binding(
     let accepted_storage_type = storages
         .definition_type(accepted_storage)
         .unwrap_or("local");
-    if accepted_storage_type != "s3" {
+    if accepted_storage_type != "s3" && accepted_storage_type != "gcs" {
         return Err(Box::new(ConfigError(format!(
-            "entity.name={} sink.accepted.iceberg.catalog requires sink.accepted storage type s3 (got {})",
+            "entity.name={} sink.accepted.iceberg.catalog requires sink.accepted storage type s3 or gcs (got {})",
             entity.name, accepted_storage_type
         ))));
     }
@@ -623,12 +623,6 @@ fn validate_iceberg_catalog_binding(
             entity.name, catalog_name
         ))) as Box<dyn std::error::Error + Send + Sync>
     })?;
-    if definition.catalog_type != "glue" {
-        return Err(Box::new(ConfigError(format!(
-            "entity.name={} sink.accepted.iceberg.catalog={} uses unsupported catalog type {} (allowed: glue)",
-            entity.name, catalog_name, definition.catalog_type
-        ))));
-    }
     if let Some(storage_name) = definition.warehouse_storage.as_deref() {
         let storage_type = storages.definition_type(storage_name).ok_or_else(|| {
             Box::new(ConfigError(format!(
@@ -1081,39 +1075,24 @@ impl CatalogRegistry {
 
         let mut definitions = std::collections::HashMap::new();
         for definition in &catalogs.definitions {
-            if !ALLOWED_CATALOG_TYPES.contains(&definition.catalog_type.as_str()) {
-                return Err(Box::new(ConfigError(format!(
-                    "catalogs.definitions name={} type={} is unsupported (allowed: {})",
-                    definition.name,
-                    definition.catalog_type,
-                    ALLOWED_CATALOG_TYPES.join(", ")
-                ))));
-            }
-            if definition.catalog_type == "glue" {
-                if definition.region.is_none() {
-                    return Err(Box::new(ConfigError(format!(
-                        "catalogs.definitions name={} requires region for type glue",
-                        definition.name
-                    ))));
-                }
-                if definition.database.is_none() {
-                    return Err(Box::new(ConfigError(format!(
-                        "catalogs.definitions name={} requires database for type glue",
-                        definition.name
-                    ))));
-                }
-                if let Some(storage_name) = definition.warehouse_storage.as_deref() {
-                    let storage_type = storages.definition_type(storage_name).ok_or_else(|| {
-                        Box::new(ConfigError(format!(
-                            "catalogs.definitions name={} warehouse_storage references unknown storage {}",
-                            definition.name, storage_name
-                        ))) as Box<dyn std::error::Error + Send + Sync>
-                    })?;
-                    if storage_type != "s3" {
-                        return Err(Box::new(ConfigError(format!(
-                            "catalogs.definitions name={} warehouse_storage must reference s3 storage for glue catalog (got {})",
-                            definition.name, storage_type
-                        ))));
+            // catalog type is validated at parse time via CatalogTypeConfig enum
+            match &definition.type_config {
+                CatalogTypeConfig::Glue { .. } => {
+                    if let Some(storage_name) = definition.warehouse_storage.as_deref() {
+                        let storage_type =
+                            storages.definition_type(storage_name).ok_or_else(|| {
+                                Box::new(ConfigError(format!(
+                                    "catalogs.definitions name={} warehouse_storage references unknown storage {}",
+                                    definition.name, storage_name
+                                )))
+                                    as Box<dyn std::error::Error + Send + Sync>
+                            })?;
+                        if storage_type != "s3" {
+                            return Err(Box::new(ConfigError(format!(
+                                "catalogs.definitions name={} warehouse_storage must reference s3 storage for glue catalog (got {})",
+                                definition.name, storage_type
+                            ))));
+                        }
                     }
                 }
             }

--- a/crates/floe-core/src/io/unique_seed/iceberg.rs
+++ b/crates/floe-core/src/io/unique_seed/iceberg.rs
@@ -9,7 +9,8 @@ use crate::io::write::iceberg::metadata::{
     latest_gcs_metadata_location, latest_local_metadata_location, latest_s3_metadata_location,
 };
 use crate::io::write::iceberg::{
-    load_glue_table_state, IcebergCatalogConfig, ICEBERG_CATALOG_NAME, ICEBERG_NAMESPACE,
+    load_glue_table_state, sanitize_table_name, IcebergCatalogConfig, ICEBERG_CATALOG_NAME,
+    ICEBERG_NAMESPACE,
 };
 use crate::{check, config, io, FloeResult};
 
@@ -190,7 +191,7 @@ async fn collect_iceberg_batches(
         catalog.create_namespace(&namespace, HashMap::new()).await?;
     }
 
-    let table_name = iceberg_table_name(entity_name);
+    let table_name = sanitize_table_name(entity_name);
     let table_ident = TableIdent::new(namespace, table_name);
 
     let table = catalog
@@ -203,20 +204,4 @@ async fn collect_iceberg_batches(
         .try_filter(|b| std::future::ready(b.num_rows() > 0))
         .try_collect()
         .await
-}
-
-fn iceberg_table_name(entity_name: &str) -> String {
-    let mut out = String::with_capacity(entity_name.len());
-    for ch in entity_name.chars() {
-        if ch.is_ascii_alphanumeric() || ch == '_' || ch == '-' {
-            out.push(ch);
-        } else {
-            out.push('_');
-        }
-    }
-    if out.is_empty() {
-        "table".to_string()
-    } else {
-        out
-    }
 }

--- a/crates/floe-core/src/io/unique_seed/iceberg.rs
+++ b/crates/floe-core/src/io/unique_seed/iceberg.rs
@@ -9,7 +9,7 @@ use crate::io::write::iceberg::metadata::{
     latest_gcs_metadata_location, latest_local_metadata_location, latest_s3_metadata_location,
 };
 use crate::io::write::iceberg::{
-    load_glue_table_state, GlueIcebergCatalogConfig, ICEBERG_CATALOG_NAME, ICEBERG_NAMESPACE,
+    load_glue_table_state, IcebergCatalogConfig, ICEBERG_CATALOG_NAME, ICEBERG_NAMESPACE,
 };
 use crate::{check, config, io, FloeResult};
 
@@ -33,21 +33,24 @@ impl FormatSeeder for IcebergSeeder<'_> {
         // When a Glue catalog is configured, the writer uses glue_target.table_location as the
         // real table root (not target). Seed from the same location so duplicate detection is
         // consistent with what was actually written.
-        if let Some(glue_target) = self.catalogs.resolve_iceberg_target(
+        if let Some(resolved) = self.catalogs.resolve_iceberg_target(
             self.resolver,
             self.entity,
             &self.entity.sink.accepted,
         )? {
-            if glue_target.catalog_type == "glue" {
-                return seed_from_glue_iceberg(
-                    unique_tracker,
-                    &glue_target,
-                    self.resolver,
-                    self.entity,
-                    scan_cols,
-                    rename_back,
-                );
-            }
+            let catalog_cfg = IcebergCatalogConfig::from_resolved(&resolved)?;
+            let catalog_target = Target::from_resolved(&resolved.table_location)?;
+            let store =
+                object_store::iceberg_store_config(&catalog_target, self.resolver, self.entity)?;
+            return seed_from_catalog(
+                unique_tracker,
+                &catalog_cfg,
+                store.file_io_props,
+                store.warehouse_location,
+                self.entity,
+                scan_cols,
+                rename_back,
+            );
         }
 
         let store = object_store::iceberg_store_config(self.target, self.resolver, self.entity)?;
@@ -95,25 +98,39 @@ impl FormatSeeder for IcebergSeeder<'_> {
     }
 }
 
-fn seed_from_glue_iceberg(
+/// Dispatches to the catalog-type-specific seed implementation.
+/// Add a new arm here when supporting a new catalog type.
+fn seed_from_catalog(
     unique_tracker: &mut check::UniqueTracker,
-    glue_target: &config::ResolvedIcebergCatalogTarget,
-    resolver: &config::StorageResolver,
+    catalog_cfg: &IcebergCatalogConfig,
+    file_io_props: HashMap<String, String>,
+    warehouse_location: String,
     entity: &config::EntityConfig,
     scan_cols: &[String],
     rename_back: &HashMap<String, String>,
 ) -> FloeResult<()> {
-    let catalog_target = Target::from_resolved(&glue_target.table_location)?;
-    let store = object_store::iceberg_store_config(&catalog_target, resolver, entity)?;
+    match catalog_cfg {
+        IcebergCatalogConfig::Glue(glue_cfg) => seed_from_glue(
+            unique_tracker,
+            glue_cfg,
+            file_io_props,
+            warehouse_location,
+            entity,
+            scan_cols,
+            rename_back,
+        ),
+    }
+}
 
-    let glue_cfg = GlueIcebergCatalogConfig {
-        catalog_name: glue_target.catalog_name.clone(),
-        region: glue_target.region.clone(),
-        database: glue_target.database.clone(),
-        namespace: glue_target.namespace.clone(),
-        table: glue_target.table.clone(),
-    };
-
+fn seed_from_glue(
+    unique_tracker: &mut check::UniqueTracker,
+    glue_cfg: &crate::io::write::iceberg::GlueIcebergCatalogConfig,
+    file_io_props: HashMap<String, String>,
+    warehouse_location: String,
+    entity: &config::EntityConfig,
+    scan_cols: &[String],
+    rename_back: &HashMap<String, String>,
+) -> FloeResult<()> {
     let runtime = tokio::runtime::Builder::new_current_thread()
         .enable_all()
         .build()
@@ -124,7 +141,7 @@ fn seed_from_glue_iceberg(
         })?;
 
     let glue_state = runtime
-        .block_on(load_glue_table_state(&glue_cfg))
+        .block_on(load_glue_table_state(glue_cfg))
         .map_err(|err| {
             Box::new(RunError(format!(
                 "glue get_table for iceberg seed failed: {err}"
@@ -138,8 +155,8 @@ fn seed_from_glue_iceberg(
     let batches = runtime
         .block_on(collect_iceberg_batches(
             metadata_location,
-            store.file_io_props,
-            store.warehouse_location,
+            file_io_props,
+            warehouse_location,
             &entity.name,
             scan_cols,
         ))

--- a/crates/floe-core/src/io/write/iceberg.rs
+++ b/crates/floe-core/src/io/write/iceberg.rs
@@ -24,9 +24,8 @@ mod glue;
 pub(crate) mod metadata;
 mod schema;
 
-use self::context::{
-    build_iceberg_write_context, create_table, ensure_namespace, sanitize_table_name,
-};
+pub(crate) use self::context::sanitize_table_name;
+use self::context::{build_iceberg_write_context, create_table, ensure_namespace};
 use self::data_files::{iceberg_small_file_threshold_bytes, write_data_files};
 pub(crate) use self::glue::load_glue_table_state;
 use self::glue::upsert_glue_table;
@@ -94,17 +93,21 @@ impl IcebergCatalogConfig {
     pub(crate) fn from_resolved(
         resolved: &config::ResolvedIcebergCatalogTarget,
     ) -> FloeResult<Self> {
-        match resolved.catalog_type.as_str() {
-            "glue" => Ok(Self::Glue(GlueIcebergCatalogConfig {
+        match &resolved.type_config {
+            config::CatalogTypeConfig::Glue {
+                region,
+                database,
+                create_database_if_missing,
+                allow_takeover,
+            } => Ok(Self::Glue(GlueIcebergCatalogConfig {
                 catalog_name: resolved.catalog_name.clone(),
-                region: resolved.region.clone(),
-                database: resolved.database.clone(),
+                region: region.clone(),
+                database: database.clone(),
                 namespace: resolved.namespace.clone(),
                 table: resolved.table.clone(),
+                create_database_if_missing: *create_database_if_missing,
+                allow_takeover: *allow_takeover,
             })),
-            other => Err(Box::new(RunError(format!(
-                "catalog_type={other} is not yet supported"
-            )))),
         }
     }
 
@@ -140,6 +143,8 @@ pub(crate) struct GlueIcebergCatalogConfig {
     pub(crate) database: String,
     pub(crate) namespace: String,
     pub(crate) table: String,
+    pub(crate) create_database_if_missing: bool,
+    pub(crate) allow_takeover: bool,
 }
 
 impl AcceptedSinkAdapter for IcebergAcceptedAdapter {

--- a/crates/floe-core/src/io/write/iceberg.rs
+++ b/crates/floe-core/src/io/write/iceberg.rs
@@ -77,7 +77,60 @@ struct IcebergWriteContext {
     catalog_name: &'static str,
     catalog_props: HashMap<String, String>,
     metadata_location: Option<String>,
-    glue_catalog: Option<GlueIcebergCatalogConfig>,
+    catalog: Option<IcebergCatalogConfig>,
+}
+
+/// Per-catalog-type configuration used at write and seed time.
+/// Add a new variant here when supporting a new catalog type.
+#[derive(Debug, Clone)]
+pub(crate) enum IcebergCatalogConfig {
+    Glue(GlueIcebergCatalogConfig),
+}
+
+impl IcebergCatalogConfig {
+    /// Constructs the catalog config from a resolved catalog target.
+    /// This is the single dispatch point for catalog_type → variant mapping.
+    /// Add a new arm here when supporting a new catalog type.
+    pub(crate) fn from_resolved(
+        resolved: &config::ResolvedIcebergCatalogTarget,
+    ) -> FloeResult<Self> {
+        match resolved.catalog_type.as_str() {
+            "glue" => Ok(Self::Glue(GlueIcebergCatalogConfig {
+                catalog_name: resolved.catalog_name.clone(),
+                region: resolved.region.clone(),
+                database: resolved.database.clone(),
+                namespace: resolved.namespace.clone(),
+                table: resolved.table.clone(),
+            })),
+            other => Err(Box::new(RunError(format!(
+                "catalog_type={other} is not yet supported"
+            )))),
+        }
+    }
+
+    pub(crate) fn catalog_name(&self) -> &str {
+        match self {
+            Self::Glue(cfg) => &cfg.catalog_name,
+        }
+    }
+
+    pub(crate) fn database(&self) -> Option<&str> {
+        match self {
+            Self::Glue(cfg) => Some(&cfg.database),
+        }
+    }
+
+    pub(crate) fn namespace(&self) -> &str {
+        match self {
+            Self::Glue(cfg) => &cfg.namespace,
+        }
+    }
+
+    pub(crate) fn table(&self) -> &str {
+        match self {
+            Self::Glue(cfg) => &cfg.table,
+        }
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -195,13 +248,13 @@ async fn write_iceberg_table_async(
         catalog_name,
         mut catalog_props,
         mut metadata_location,
-        glue_catalog,
+        catalog: catalog_cfg,
     } = write_ctx;
-    let mut glue_table_state = None;
-    if let Some(glue_cfg) = glue_catalog.as_ref() {
+    let mut glue_state = None;
+    if let Some(IcebergCatalogConfig::Glue(glue_cfg)) = catalog_cfg.as_ref() {
         let state = load_glue_table_state(glue_cfg).await?;
         metadata_location = state.metadata_location.clone();
-        glue_table_state = Some(state);
+        glue_state = Some(state);
     }
     catalog_props.insert(MEMORY_CATALOG_WAREHOUSE.to_string(), table_root_uri.clone());
 
@@ -209,15 +262,15 @@ async fn write_iceberg_table_async(
         .load(catalog_name, catalog_props)
         .await
         .map_err(map_iceberg_err("iceberg catalog init failed"))?;
-    let namespace_name = glue_catalog
+    let namespace_name = catalog_cfg
         .as_ref()
-        .map(|cfg| cfg.namespace.clone())
+        .map(|cfg| cfg.namespace().to_string())
         .unwrap_or_else(|| ICEBERG_NAMESPACE.to_string());
     let namespace = NamespaceIdent::new(namespace_name);
     ensure_namespace(&catalog, &namespace).await?;
-    let table_name = glue_catalog
+    let table_name = catalog_cfg
         .as_ref()
-        .map(|cfg| cfg.table.clone())
+        .map(|cfg| cfg.table().to_string())
         .unwrap_or_else(|| sanitize_table_name(&entity.name));
     let table_ident = TableIdent::new(namespace.clone(), table_name);
 
@@ -346,12 +399,12 @@ async fn write_iceberg_table_async(
             )) as Box<dyn std::error::Error + Send + Sync>
         })?;
 
-    if let Some(glue_cfg) = glue_catalog.as_ref() {
+    if let Some(IcebergCatalogConfig::Glue(glue_cfg)) = catalog_cfg.as_ref() {
         upsert_glue_table(
             glue_cfg,
             &table_root_uri,
             &final_metadata_location,
-            glue_table_state
+            glue_state
                 .as_ref()
                 .and_then(|state| state.version_id.as_deref()),
         )
@@ -372,10 +425,14 @@ async fn write_iceberg_table_async(
         file_paths,
         metrics,
         table_root_uri,
-        iceberg_catalog_name: glue_catalog.as_ref().map(|cfg| cfg.catalog_name.clone()),
-        iceberg_database: glue_catalog.as_ref().map(|cfg| cfg.database.clone()),
-        iceberg_namespace: glue_catalog.as_ref().map(|cfg| cfg.namespace.clone()),
-        iceberg_table: glue_catalog.as_ref().map(|cfg| cfg.table.clone()),
+        iceberg_catalog_name: catalog_cfg
+            .as_ref()
+            .map(|cfg| cfg.catalog_name().to_string()),
+        iceberg_database: catalog_cfg
+            .as_ref()
+            .and_then(|cfg| cfg.database().map(ToOwned::to_owned)),
+        iceberg_namespace: catalog_cfg.as_ref().map(|cfg| cfg.namespace().to_string()),
+        iceberg_table: catalog_cfg.as_ref().map(|cfg| cfg.table().to_string()),
         perf,
     })
 }

--- a/crates/floe-core/src/io/write/iceberg/context.rs
+++ b/crates/floe-core/src/io/write/iceberg/context.rs
@@ -100,6 +100,18 @@ pub(super) fn build_iceberg_write_context(
             bucket,
             base_key,
         } => {
+            if let Some(ctx) = remote.as_mut() {
+                let ctx = &mut **ctx;
+                if let Some(resolved) = ctx.catalogs.resolve_iceberg_target(
+                    ctx.resolver,
+                    entity,
+                    &entity.sink.accepted,
+                )? {
+                    let catalog_cfg = build_catalog_config(ctx, entity, &resolved)?;
+                    return Ok(catalog_cfg);
+                }
+            }
+
             let metadata_location = if matches!(mode, config::WriteMode::Append) {
                 match remote.as_mut() {
                     Some(ctx) => {
@@ -206,7 +218,7 @@ fn build_catalog_config(
     })
 }
 
-pub(super) fn sanitize_table_name(name: &str) -> String {
+pub(crate) fn sanitize_table_name(name: &str) -> String {
     let mut out = String::with_capacity(name.len());
     for ch in name.chars() {
         if ch.is_ascii_alphanumeric() || ch == '_' || ch == '-' {

--- a/crates/floe-core/src/io/write/iceberg/context.rs
+++ b/crates/floe-core/src/io/write/iceberg/context.rs
@@ -12,7 +12,7 @@ use crate::{config, io, FloeResult};
 use super::metadata::{
     latest_gcs_metadata_location, latest_local_metadata_location, latest_s3_metadata_location,
 };
-use super::{map_iceberg_err, GlueIcebergCatalogConfig, IcebergRemoteContext, IcebergWriteContext};
+use super::{map_iceberg_err, IcebergCatalogConfig, IcebergRemoteContext, IcebergWriteContext};
 
 pub(super) fn build_iceberg_write_context(
     target: &Target,
@@ -36,7 +36,7 @@ pub(super) fn build_iceberg_write_context(
                 catalog_name: "floe_iceberg",
                 catalog_props: HashMap::new(),
                 metadata_location,
-                glue_catalog: None,
+                catalog: None,
             })
         }
         Target::S3 {
@@ -47,28 +47,13 @@ pub(super) fn build_iceberg_write_context(
         } => {
             if let Some(ctx) = remote.as_mut() {
                 let ctx = &mut **ctx;
-                if let Some(glue_target) = ctx.catalogs.resolve_iceberg_target(
+                if let Some(resolved) = ctx.catalogs.resolve_iceberg_target(
                     ctx.resolver,
                     entity,
                     &entity.sink.accepted,
                 )? {
-                    if glue_target.catalog_type == "glue" {
-                        let catalog_target = Target::from_resolved(&glue_target.table_location)?;
-                        let store = iceberg_store_config(&catalog_target, ctx.resolver, entity)?;
-                        return Ok(IcebergWriteContext {
-                            table_root_uri: store.warehouse_location,
-                            catalog_name: "floe_iceberg",
-                            catalog_props: store.file_io_props,
-                            metadata_location: None,
-                            glue_catalog: Some(GlueIcebergCatalogConfig {
-                                catalog_name: glue_target.catalog_name,
-                                region: glue_target.region,
-                                database: glue_target.database,
-                                namespace: glue_target.namespace,
-                                table: glue_target.table,
-                            }),
-                        });
-                    }
+                    let catalog_cfg = build_catalog_config(ctx, entity, &resolved)?;
+                    return Ok(catalog_cfg);
                 }
             }
 
@@ -97,7 +82,7 @@ pub(super) fn build_iceberg_write_context(
                         catalog_name: "floe_iceberg",
                         catalog_props: store.file_io_props,
                         metadata_location,
-                        glue_catalog: None,
+                        catalog: None,
                     })
                 }
                 None => Ok(IcebergWriteContext {
@@ -105,7 +90,7 @@ pub(super) fn build_iceberg_write_context(
                     catalog_name: "floe_iceberg",
                     catalog_props: HashMap::new(),
                     metadata_location,
-                    glue_catalog: None,
+                    catalog: None,
                 }),
             }
         }
@@ -140,7 +125,7 @@ pub(super) fn build_iceberg_write_context(
                         catalog_name: "floe_iceberg",
                         catalog_props: store.file_io_props,
                         metadata_location,
-                        glue_catalog: None,
+                        catalog: None,
                     })
                 }
                 None => Ok(IcebergWriteContext {
@@ -148,7 +133,7 @@ pub(super) fn build_iceberg_write_context(
                     catalog_name: "floe_iceberg",
                     catalog_props: HashMap::new(),
                     metadata_location,
-                    glue_catalog: None,
+                    catalog: None,
                 }),
             }
         }
@@ -196,6 +181,29 @@ pub(super) async fn create_table(
         .create_table(namespace, creation)
         .await
         .map_err(map_iceberg_err("iceberg create table failed"))
+}
+
+/// Builds an IcebergWriteContext from a resolved catalog target.
+fn build_catalog_config(
+    ctx: &mut IcebergRemoteContext<'_>,
+    entity: &config::EntityConfig,
+    resolved: &config::ResolvedIcebergCatalogTarget,
+) -> FloeResult<IcebergWriteContext> {
+    let catalog = IcebergCatalogConfig::from_resolved(resolved).map_err(|err| {
+        Box::new(crate::errors::RunError(format!(
+            "entity.name={} catalog config: {err}",
+            entity.name
+        ))) as Box<dyn std::error::Error + Send + Sync>
+    })?;
+    let catalog_target = Target::from_resolved(&resolved.table_location)?;
+    let store = iceberg_store_config(&catalog_target, ctx.resolver, entity)?;
+    Ok(IcebergWriteContext {
+        table_root_uri: store.warehouse_location,
+        catalog_name: "floe_iceberg",
+        catalog_props: store.file_io_props,
+        metadata_location: None,
+        catalog: Some(catalog),
+    })
 }
 
 pub(super) fn sanitize_table_name(name: &str) -> String {

--- a/crates/floe-core/src/io/write/iceberg/glue.rs
+++ b/crates/floe-core/src/io/write/iceberg/glue.rs
@@ -1,14 +1,18 @@
 use aws_config::meta::region::RegionProviderChain;
 use aws_sdk_glue::config::Region as GlueRegion;
 use aws_sdk_glue::types::{
-    StorageDescriptor as GlueStorageDescriptor, TableInput as GlueTableInput,
+    DatabaseInput as GlueDatabaseInput, StorageDescriptor as GlueStorageDescriptor,
+    TableInput as GlueTableInput,
 };
 use aws_sdk_glue::Client as GlueClient;
 
 use crate::errors::RunError;
-use crate::FloeResult;
+use crate::{warnings, FloeResult};
 
 use super::GlueIcebergCatalogConfig;
+
+/// Parameter Floe sets on every table it creates so it can identify ownership.
+const FLOE_MANAGED_PARAM: &str = "floe.managed";
 
 #[derive(Debug, Clone)]
 pub(crate) struct GlueTableState {
@@ -24,6 +28,10 @@ async fn build_glue_client(region: &str) -> FloeResult<GlueClient> {
         .load()
         .await;
     Ok(GlueClient::new(&config))
+}
+
+fn is_access_denied(code: Option<&str>) -> bool {
+    code.is_some_and(|c| c.contains("AccessDenied") || c == "UnauthorizedException")
 }
 
 pub(crate) async fn load_glue_table_state(
@@ -47,16 +55,42 @@ pub(crate) async fn load_glue_table_state(
             let parameters = table.parameters();
             let metadata_location =
                 parameters.and_then(|params| params.get("metadata_location").cloned());
-            let iceberg_param = parameters
+            let is_iceberg = parameters
                 .and_then(|params| params.get("table_type"))
                 .map(|value| value.eq_ignore_ascii_case("ICEBERG"))
                 .unwrap_or(false);
-            if !iceberg_param || metadata_location.is_none() {
+            if !is_iceberg || metadata_location.is_none() {
                 return Err(Box::new(RunError(format!(
-                    "glue table {}.{} exists but is not an Iceberg table managed by Floe (missing Iceberg parameters/metadata_location)",
+                    "glue table {}.{} exists but is not an Iceberg table (missing table_type=ICEBERG or metadata_location)",
                     glue_cfg.database, glue_cfg.table
                 ))));
             }
+
+            // Ownership check: warn or error if the table was not created by Floe.
+            let floe_managed = parameters
+                .and_then(|params| params.get(FLOE_MANAGED_PARAM))
+                .map(|v| v.eq_ignore_ascii_case("true"))
+                .unwrap_or(false);
+            if !floe_managed {
+                if glue_cfg.allow_takeover {
+                    warnings::emit(
+                        "glue",
+                        None,
+                        None,
+                        Some("glue_takeover"),
+                        &format!(
+                            "glue table {}.{} was not created by Floe; taking ownership (allow_takeover=true)",
+                            glue_cfg.database, glue_cfg.table
+                        ),
+                    );
+                } else {
+                    return Err(Box::new(RunError(format!(
+                        "glue table {}.{} was not created by Floe; set allow_takeover=true on the catalog definition to take ownership",
+                        glue_cfg.database, glue_cfg.table
+                    ))));
+                }
+            }
+
             Ok(GlueTableState {
                 metadata_location,
                 version_id: table.version_id().map(ToOwned::to_owned),
@@ -65,12 +99,19 @@ pub(crate) async fn load_glue_table_state(
         Err(err) => {
             if err
                 .as_service_error()
-                .is_some_and(|service_err| service_err.is_entity_not_found_exception())
+                .is_some_and(|e| e.is_entity_not_found_exception())
             {
                 return Ok(GlueTableState {
                     metadata_location: None,
                     version_id: None,
                 });
+            }
+            let code = err.as_service_error().and_then(|e| e.meta().code());
+            if is_access_denied(code) {
+                return Err(Box::new(RunError(format!(
+                    "glue get_table denied for {}.{}: ensure the IAM role/user has glue:GetTable permission: {err}",
+                    glue_cfg.database, glue_cfg.table
+                ))));
             }
             Err(Box::new(RunError(format!(
                 "glue get_table failed for {}.{}: {err}",
@@ -87,6 +128,13 @@ pub(super) async fn upsert_glue_table(
     version_id: Option<&str>,
 ) -> FloeResult<()> {
     let client = build_glue_client(&glue_cfg.region).await?;
+    ensure_glue_database(
+        &client,
+        &glue_cfg.database,
+        glue_cfg.create_database_if_missing,
+    )
+    .await?;
+
     let table_input = build_glue_table_input(glue_cfg, table_root_uri, metadata_location);
 
     let create_result = client
@@ -101,8 +149,15 @@ pub(super) async fn upsert_glue_table(
         Err(err) => {
             if !err
                 .as_service_error()
-                .is_some_and(|service_err| service_err.is_already_exists_exception())
+                .is_some_and(|e| e.is_already_exists_exception())
             {
+                let code = err.as_service_error().and_then(|e| e.meta().code());
+                if is_access_denied(code) {
+                    return Err(Box::new(RunError(format!(
+                        "glue create_table denied for {}.{}: ensure the IAM role/user has glue:CreateTable permission: {err}",
+                        glue_cfg.database, glue_cfg.table
+                    ))));
+                }
                 return Err(Box::new(RunError(format!(
                     "glue create_table failed for {}.{}: {err}",
                     glue_cfg.database, glue_cfg.table
@@ -111,22 +166,96 @@ pub(super) async fn upsert_glue_table(
         }
     }
 
-    let mut update = client
-        .update_table()
-        .database_name(glue_cfg.database.as_str())
-        .name(glue_cfg.table.as_str())
-        .table_input(table_input)
-        .skip_archive(true);
-    if let Some(version_id) = version_id {
-        update = update.version_id(version_id);
+    // Table already exists — update with retry on concurrent modification.
+    const MAX_RETRIES: u32 = 3;
+    let mut attempt = 0_u32;
+    loop {
+        let mut update = client
+            .update_table()
+            .database_name(glue_cfg.database.as_str())
+            .name(glue_cfg.table.as_str())
+            .table_input(table_input.clone())
+            .skip_archive(true);
+        if let Some(vid) = version_id {
+            update = update.version_id(vid);
+        }
+        let result = update.send().await;
+        match result {
+            Ok(_) => return Ok(()),
+            Err(err) => {
+                if attempt < MAX_RETRIES
+                    && err
+                        .as_service_error()
+                        .is_some_and(|e| e.is_concurrent_modification_exception())
+                {
+                    attempt += 1;
+                    tokio::time::sleep(std::time::Duration::from_millis(200 * attempt as u64))
+                        .await;
+                    continue;
+                }
+                let code = err.as_service_error().and_then(|e| e.meta().code());
+                if is_access_denied(code) {
+                    return Err(Box::new(RunError(format!(
+                        "glue update_table denied for {}.{}: ensure the IAM role/user has glue:UpdateTable permission: {err}",
+                        glue_cfg.database, glue_cfg.table
+                    ))));
+                }
+                return Err(Box::new(RunError(format!(
+                    "glue update_table failed for {}.{}: {err}",
+                    glue_cfg.database, glue_cfg.table
+                )))
+                    as Box<dyn std::error::Error + Send + Sync>);
+            }
+        }
     }
-    update.send().await.map_err(|err| {
-        Box::new(RunError(format!(
-            "glue update_table failed for {}.{}: {err}",
-            glue_cfg.database, glue_cfg.table
-        ))) as Box<dyn std::error::Error + Send + Sync>
-    })?;
-    Ok(())
+}
+
+async fn ensure_glue_database(
+    client: &GlueClient,
+    database: &str,
+    create_if_missing: bool,
+) -> FloeResult<()> {
+    let result = client.get_database().name(database).send().await;
+    match result {
+        Ok(_) => Ok(()),
+        Err(err) => {
+            if err
+                .as_service_error()
+                .is_some_and(|e| e.is_entity_not_found_exception())
+            {
+                if !create_if_missing {
+                    return Err(Box::new(RunError(format!(
+                        "glue database {database} does not exist; set create_database_if_missing=true to create it automatically"
+                    ))));
+                }
+                let db_input = GlueDatabaseInput::builder()
+                    .name(database)
+                    .build()
+                    .expect("database input builder validated");
+                client
+                    .create_database()
+                    .database_input(db_input)
+                    .send()
+                    .await
+                    .map_err(|e| {
+                        Box::new(RunError(format!(
+                            "glue create_database failed for {database}: {e}"
+                        ))) as Box<dyn std::error::Error + Send + Sync>
+                    })?;
+                Ok(())
+            } else {
+                let code = err.as_service_error().and_then(|e| e.meta().code());
+                if is_access_denied(code) {
+                    return Err(Box::new(RunError(format!(
+                        "glue get_database denied for {database}: ensure the IAM role/user has glue:GetDatabase permission: {err}"
+                    ))));
+                }
+                Err(Box::new(RunError(format!(
+                    "glue get_database failed for {database}: {err}"
+                ))))
+            }
+        }
+    }
 }
 
 fn build_glue_table_input(
@@ -147,6 +276,7 @@ fn build_glue_table_input(
         .parameters("EXTERNAL", "TRUE")
         .parameters("metadata_location", metadata_location)
         .parameters("floe.iceberg.namespace", glue_cfg.namespace.as_str())
+        .parameters(FLOE_MANAGED_PARAM, "true")
         .build()
         .expect("glue table input builder validated")
 }

--- a/crates/floe-core/tests/unit/config/catalogs.rs
+++ b/crates/floe-core/tests/unit/config/catalogs.rs
@@ -111,7 +111,9 @@ fn catalog_resolver_derives_glue_identity_and_warehouse_location() {
         .expect("glue target");
 
     assert_eq!(resolved.catalog_name, "glue_main");
-    assert!(matches!(resolved.type_config, config::CatalogTypeConfig::Glue { ref database, .. } if database == "lakehouse"));
+    assert!(
+        matches!(resolved.type_config, config::CatalogTypeConfig::Glue { ref database, .. } if database == "lakehouse")
+    );
     assert_eq!(resolved.namespace, "sales_ops");
     assert_eq!(resolved.table, "customer_orders");
     assert_eq!(

--- a/crates/floe-core/tests/unit/config/catalogs.rs
+++ b/crates/floe-core/tests/unit/config/catalogs.rs
@@ -31,9 +31,12 @@ fn base_root() -> config::RootConfig {
             default: Some("glue_main".to_string()),
             definitions: vec![config::CatalogDefinition {
                 name: "glue_main".to_string(),
-                catalog_type: "glue".to_string(),
-                region: Some("us-east-1".to_string()),
-                database: Some("lakehouse".to_string()),
+                type_config: config::CatalogTypeConfig::Glue {
+                    region: "us-east-1".to_string(),
+                    database: "lakehouse".to_string(),
+                    create_database_if_missing: true,
+                    allow_takeover: false,
+                },
                 warehouse_storage: Some("s3_wh".to_string()),
                 warehouse_prefix: Some("iceberg".to_string()),
             }],
@@ -108,8 +111,7 @@ fn catalog_resolver_derives_glue_identity_and_warehouse_location() {
         .expect("glue target");
 
     assert_eq!(resolved.catalog_name, "glue_main");
-    assert_eq!(resolved.catalog_type, "glue");
-    assert_eq!(resolved.database, "lakehouse");
+    assert!(matches!(resolved.type_config, config::CatalogTypeConfig::Glue { ref database, .. } if database == "lakehouse"));
     assert_eq!(resolved.namespace, "sales_ops");
     assert_eq!(resolved.table, "customer_orders");
     assert_eq!(

--- a/crates/floe-core/tests/unit/config/parse.rs
+++ b/crates/floe-core/tests/unit/config/parse.rs
@@ -769,11 +769,10 @@ entities:
     let catalogs = config.catalogs.as_ref().expect("catalogs");
     assert_eq!(catalogs.default.as_deref(), Some("glue_main"));
     assert_eq!(catalogs.definitions.len(), 1);
-    assert_eq!(catalogs.definitions[0].catalog_type, "glue");
-    assert_eq!(
-        catalogs.definitions[0].database.as_deref(),
-        Some("lakehouse")
-    );
+    assert!(matches!(
+        catalogs.definitions[0].type_config,
+        floe_core::config::CatalogTypeConfig::Glue { ref database, .. } if database == "lakehouse"
+    ));
     assert_eq!(
         catalogs.definitions[0].warehouse_prefix.as_deref(),
         Some("iceberg")


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **`CatalogTypeConfig` enum** replaces loose `catalog_type`/`region`/`database` `Option<String>` fields on `CatalogDefinition`; the catalog type is now validated at parse time via `parse_catalog_type_config` — adding a new catalog type is a compiler-enforced change, not a string match
- **`ResolvedIcebergCatalogTarget`** carries `type_config: CatalogTypeConfig` instead of flat string fields; `IcebergCatalogConfig::from_resolved` matches on the enum — single dispatch point for new catalog types
- **`normalize_catalog_ident`** defined once in `catalog.rs` (shared across all types); seeder drops its duplicate `iceberg_table_name` and imports `sanitize_table_name` via `pub(crate)` re-export
- **GCS branch** in `context.rs` now resolves catalog targets identically to the S3 branch (was silently skipped before)
- **`validate.rs`** simplified: redundant `catalog_type != "glue"` check removed (enforced at parse time), iceberg sink now accepts GCS storage in addition to S3

### Glue hardening

- `floe.managed=true` stamped on every table Floe creates; `load_glue_table_state` checks it — errors if the table wasn't created by Floe unless `allow_takeover=true` on the catalog definition
- `ensure_glue_database` creates the Glue database automatically when `create_database_if_missing=true` (default), otherwise gives an actionable error
- `update_table` retries up to 3× with 200 ms backoff on `ConcurrentModificationException`
- IAM access-denied hints on `GetTable`, `CreateTable`, `UpdateTable`, and `GetDatabase` failures

### Adding a new catalog type (e.g. REST, Hive)

1. Add a variant to `CatalogTypeConfig` in `config/types.rs`
2. Add an arm to `parse_catalog_type_config` in `config/parse.rs`
3. Add an arm to `CatalogRegistry::new` match in `config/validate.rs`
4. Add an arm to `IcebergCatalogConfig::from_resolved` in `io/write/iceberg.rs`
5. Add an arm to `seed_from_catalog` in `io/unique_seed/iceberg.rs`
6. Add the implementation file under `io/write/iceberg/`

## Test plan

- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [x] `cargo test -p floe-core --test unit config::` passes (429 config tests)
- [x] `cargo test -p floe-core --test unit io::write::` passes

https://claude.ai/code/session_01XL7X5BrBqLuvYGLY5zeYVR
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XL7X5BrBqLuvYGLY5zeYVR)_