### PR TITLE
feat(iceberg): REST catalog support (Unity, Polaris, Nessie, Snowflake) + iceberg 0.9.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -22,17 +22,6 @@ checksum = "aae1277d39aeec15cb388266ecc24b11c80469deae6067e17a1a7aa9e5c1f234"
 
 [[package]]
 name = "ahash"
-version = "0.7.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9"
-dependencies = [
- "getrandom 0.2.17",
- "once_cell",
- "version_check",
-]
-
-[[package]]
-name = "ahash"
 version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
@@ -176,7 +165,7 @@ dependencies = [
  "miniz_oxide",
  "num-bigint",
  "quad-rand",
- "rand 0.9.2",
+ "rand 0.9.4",
  "regex-lite",
  "serde",
  "serde_bytes",
@@ -286,7 +275,7 @@ version = "57.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "65ca404ea6191e06bf30956394173337fa9c35f445bd447fe6c21ab944e1a23c"
 dependencies = [
- "ahash 0.8.12",
+ "ahash",
  "arrow-buffer",
  "arrow-data",
  "arrow-schema",
@@ -445,7 +434,7 @@ version = "57.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c96d8a1c180b44ecf2e66c9a2f2bbcb8b1b6f14e165ce46ac8bde211a363411b"
 dependencies = [
- "ahash 0.8.12",
+ "ahash",
  "arrow-array",
  "arrow-buffer",
  "arrow-data",
@@ -615,7 +604,7 @@ checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn",
 ]
 
 [[package]]
@@ -632,7 +621,7 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn",
 ]
 
 [[package]]
@@ -1348,18 +1337,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bitvec"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
-dependencies = [
- "funty",
- "radium",
- "tap",
- "wyz",
-]
-
-[[package]]
 name = "blake2"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1405,6 +1382,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "bnum"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f781dba93de3a5ef6dc5b17c9958b208f6f3f021623b360fb605ea51ce443f10"
+dependencies = [
+ "serde",
+ "serde-big-array",
+]
+
+[[package]]
 name = "bon"
 version = "3.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1426,30 +1413,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.114",
-]
-
-[[package]]
-name = "borsh"
-version = "1.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1da5ab77c1437701eeff7c88d968729e7766172279eab0676857b3d63af7a6f"
-dependencies = [
- "borsh-derive",
- "cfg_aliases",
-]
-
-[[package]]
-name = "borsh-derive"
-version = "1.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0686c856aa6aac0c4498f936d7d6a02df690f614c03e4d906d1018062b5c5e2c"
-dependencies = [
- "once_cell",
- "proc-macro-crate",
- "proc-macro2",
- "quote",
- "syn 2.0.114",
+ "syn",
 ]
 
 [[package]]
@@ -1497,28 +1461,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
 
 [[package]]
-name = "bytecheck"
-version = "0.6.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23cdc57ce23ac53c931e88a43d06d070a6fd142f2617be5855eb75efc9beb1c2"
-dependencies = [
- "bytecheck_derive",
- "ptr_meta",
- "simdutf8",
-]
-
-[[package]]
-name = "bytecheck_derive"
-version = "0.6.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3db406d29fbcd95542e92559bed4d8ad92636d1ca8b3b72ede10b4bcc010e659"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "bytemuck"
 version = "1.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1535,7 +1477,7 @@ checksum = "f9abbd1bc6865053c427f7198e6af43bfdedc55ab791faed4fbd361d789575ff"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn",
 ]
 
 [[package]]
@@ -1694,7 +1636,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn",
 ]
 
 [[package]]
@@ -1881,15 +1823,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crc32c"
-version = "0.6.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a47af21622d091a8f0fb295b88bc886ac74efcc613efc19f5d0b21de5c89e47"
-dependencies = [
- "rustc_version",
-]
-
-[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2070,7 +2003,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.114",
+ "syn",
 ]
 
 [[package]]
@@ -2084,7 +2017,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.114",
+ "syn",
 ]
 
 [[package]]
@@ -2095,7 +2028,7 @@ checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
  "darling_core 0.20.11",
  "quote",
- "syn 2.0.114",
+ "syn",
 ]
 
 [[package]]
@@ -2106,7 +2039,7 @@ checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
 dependencies = [
  "darling_core 0.21.3",
  "quote",
- "syn 2.0.114",
+ "syn",
 ]
 
 [[package]]
@@ -2173,7 +2106,7 @@ dependencies = [
  "object_store",
  "parking_lot",
  "parquet",
- "rand 0.9.2",
+ "rand 0.9.4",
  "regex",
  "rstest",
  "sqlparser 0.59.0",
@@ -2240,7 +2173,7 @@ version = "51.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c10f7659e96127d25e8366be7c8be4109595d6a2c3eac70421f380a7006a1b0"
 dependencies = [
- "ahash 0.8.12",
+ "ahash",
  "arrow",
  "arrow-ipc",
  "chrono",
@@ -2296,7 +2229,7 @@ dependencies = [
  "itertools 0.14.0",
  "log",
  "object_store",
- "rand 0.9.2",
+ "rand 0.9.4",
  "tokio",
  "tokio-util",
  "url",
@@ -2424,7 +2357,7 @@ dependencies = [
  "log",
  "object_store",
  "parking_lot",
- "rand 0.9.2",
+ "rand 0.9.4",
  "tempfile",
  "url",
 ]
@@ -2488,7 +2421,7 @@ dependencies = [
  "log",
  "md-5",
  "num-traits",
- "rand 0.9.2",
+ "rand 0.9.4",
  "regex",
  "sha2",
  "unicode-segmentation",
@@ -2501,7 +2434,7 @@ version = "51.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c25210520a9dcf9c2b2cbbce31ebd4131ef5af7fc60ee92b266dc7d159cb305"
 dependencies = [
- "ahash 0.8.12",
+ "ahash",
  "arrow",
  "datafusion-common",
  "datafusion-doc",
@@ -2522,7 +2455,7 @@ version = "51.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62f4a66f3b87300bb70f4124b55434d2ae3fe80455f3574701d0348da040b55d"
 dependencies = [
- "ahash 0.8.12",
+ "ahash",
  "arrow",
  "datafusion-common",
  "datafusion-expr-common",
@@ -2604,7 +2537,7 @@ checksum = "1063ad4c9e094b3f798acee16d9a47bd7372d9699be2de21b05c3bd3f34ab848"
 dependencies = [
  "datafusion-doc",
  "quote",
- "syn 2.0.114",
+ "syn",
 ]
 
 [[package]]
@@ -2633,7 +2566,7 @@ version = "51.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c30cc8012e9eedcb48bbe112c6eff4ae5ed19cf3003cb0f505662e88b7014c5d"
 dependencies = [
- "ahash 0.8.12",
+ "ahash",
  "arrow",
  "datafusion-common",
  "datafusion-expr",
@@ -2670,7 +2603,7 @@ version = "51.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90da43e1ec550b172f34c87ec68161986ced70fd05c8d2a2add66eef9c276f03"
 dependencies = [
- "ahash 0.8.12",
+ "ahash",
  "arrow",
  "datafusion-common",
  "datafusion-expr-common",
@@ -2703,7 +2636,7 @@ version = "51.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0acf0ad6b6924c6b1aa7d213b181e012e2d3ec0a64ff5b10ee6282ab0f8532ac"
 dependencies = [
- "ahash 0.8.12",
+ "ahash",
  "arrow",
  "arrow-ord",
  "arrow-schema",
@@ -2860,7 +2793,7 @@ checksum = "32a311416f16d4793d2aa35f2c76d36ab9b14c808eba00ef24759b47b666255e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn",
 ]
 
 [[package]]
@@ -2982,7 +2915,7 @@ dependencies = [
  "itertools 0.14.0",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn",
 ]
 
 [[package]]
@@ -3041,7 +2974,7 @@ checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn",
 ]
 
 [[package]]
@@ -3062,7 +2995,7 @@ dependencies = [
  "darling 0.20.11",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn",
 ]
 
 [[package]]
@@ -3072,7 +3005,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
 dependencies = [
  "derive_builder_core",
- "syn 2.0.114",
+ "syn",
 ]
 
 [[package]]
@@ -3101,7 +3034,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
- "const-oid",
  "crypto-common",
  "subtle",
 ]
@@ -3135,7 +3067,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn",
 ]
 
 [[package]]
@@ -3143,15 +3075,6 @@ name = "dissimilar"
 version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8975ffdaa0ef3661bfe02dbdcc06c9f829dfafe6a3c474de366a8d5e44276921"
-
-[[package]]
-name = "dlv-list"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "442039f5147480ba31067cb00ada1adae6892028e40e45fc5de7b7df6dcc1b5f"
-dependencies = [
- "const-random",
-]
 
 [[package]]
 name = "document-features"
@@ -3243,6 +3166,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
+name = "erased-serde"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2add8a07dd6a8d93ff627029c51de145e12686fbc36ecb298ac22e74cf02dec"
+dependencies = [
+ "serde",
+ "serde_core",
+ "typeid",
+]
+
+[[package]]
 name = "errno"
 version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3306,6 +3240,18 @@ name = "fast-float2"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8eb564c5c7423d25c886fb561d1e4ee69f72354d16918afa32c08811f6b6a55"
+
+[[package]]
+name = "fastnum"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4089ab2dfd45d8ddc92febb5ca80644389d5ebb954f40231274a3f18341762e2"
+dependencies = [
+ "bnum",
+ "num-integer",
+ "num-traits",
+ "serde",
+]
 
 [[package]]
 name = "fastrand"
@@ -3407,6 +3353,7 @@ dependencies = [
  "gcloud-storage",
  "glob",
  "iceberg",
+ "iceberg-catalog-rest",
  "orc-rust",
  "polars",
  "rayon",
@@ -3481,12 +3428,6 @@ name = "fs_extra"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
-
-[[package]]
-name = "funty"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futures"
@@ -3572,7 +3513,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn",
 ]
 
 [[package]]
@@ -3817,9 +3758,6 @@ name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
-dependencies = [
- "ahash 0.7.8",
-]
 
 [[package]]
 name = "hashbrown"
@@ -3827,7 +3765,7 @@ version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 dependencies = [
- "ahash 0.8.12",
+ "ahash",
  "allocator-api2",
 ]
 
@@ -4076,7 +4014,6 @@ dependencies = [
  "tokio",
  "tokio-rustls 0.26.4",
  "tower-service",
- "webpki-roots",
 ]
 
 [[package]]
@@ -4147,9 +4084,9 @@ dependencies = [
 
 [[package]]
 name = "iceberg"
-version = "0.8.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e65918e701cf610ab0cea57f7f31db5bf4f973230c2c160244067bce01f7c5fa"
+checksum = "4d9c3fc1f55c84ff64645c0d2ee35159f5574d33f729fc0860783bc247c8b8c5"
 dependencies = [
  "anyhow",
  "apache-avro 0.21.0",
@@ -4171,22 +4108,19 @@ dependencies = [
  "chrono",
  "derive_builder",
  "expect-test",
+ "fastnum",
  "flate2",
  "fnv",
  "futures",
  "itertools 0.13.0",
  "moka",
  "murmur3",
- "num-bigint",
  "once_cell",
- "opendal",
  "ordered-float 4.6.0",
  "parquet",
- "rand 0.8.5",
- "reqsign",
+ "rand 0.9.4",
  "reqwest",
  "roaring",
- "rust_decimal",
  "serde",
  "serde_bytes",
  "serde_derive",
@@ -4196,9 +4130,31 @@ dependencies = [
  "strum 0.27.2",
  "tokio",
  "typed-builder 0.20.1",
+ "typetag",
  "url",
  "uuid",
  "zstd",
+]
+
+[[package]]
+name = "iceberg-catalog-rest"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a49dfef578060c3a2a3f619522dcb25382a7ce85336dcb500495d4b8d72ae714"
+dependencies = [
+ "async-trait",
+ "chrono",
+ "http 1.4.0",
+ "iceberg",
+ "itertools 0.13.0",
+ "reqwest",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tokio",
+ "tracing",
+ "typed-builder 0.20.1",
+ "uuid",
 ]
 
 [[package]]
@@ -4354,6 +4310,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8bb03732005da905c88227371639bf1ad885cc712789c011c31c5fb3ab3ccf02"
 
 [[package]]
+name = "inventory"
+version = "0.3.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4f0c30c76f2f4ccee3fe55a2435f691ca00c0e4bd87abe4f4a851b1d4dac39b"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4398,47 +4363,6 @@ name = "itoa"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
-
-[[package]]
-name = "jiff"
-version = "0.2.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3e3d65f018c6ae946ab16e80944b97096ed73c35b221d1c478a6c81d8f57940"
-dependencies = [
- "jiff-static",
- "jiff-tzdb-platform",
- "log",
- "portable-atomic",
- "portable-atomic-util",
- "serde_core",
- "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "jiff-static"
-version = "0.2.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a17c2b211d863c7fde02cbea8a3c1a439b98e109286554f2860bdded7ff83818"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.114",
-]
-
-[[package]]
-name = "jiff-tzdb"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68971ebff725b9e2ca27a601c5eb38a4c5d64422c4cbab0c535f248087eda5c2"
-
-[[package]]
-name = "jiff-tzdb-platform"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "875a5a69ac2bab1a891711cf5eccbec1ce0341ea805560dcd90b7a2e925132e8"
-dependencies = [
- "jiff-tzdb",
-]
 
 [[package]]
 name = "jobserver"
@@ -4968,7 +4892,7 @@ dependencies = [
  "parking_lot",
  "percent-encoding",
  "quick-xml 0.38.4",
- "rand 0.9.2",
+ "rand 0.9.4",
  "reqwest",
  "ring",
  "rustls-pemfile",
@@ -4997,35 +4921,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
-name = "opendal"
-version = "0.55.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d075ab8a203a6ab4bc1bce0a4b9fe486a72bf8b939037f4b78d95386384bc80a"
-dependencies = [
- "anyhow",
- "backon",
- "base64 0.22.1",
- "bytes",
- "crc32c",
- "futures",
- "getrandom 0.2.17",
- "http 1.4.0",
- "http-body 1.0.1",
- "jiff",
- "log",
- "md-5",
- "percent-encoding",
- "quick-xml 0.38.4",
- "reqsign",
- "reqwest",
- "serde",
- "serde_json",
- "tokio",
- "url",
- "uuid",
-]
-
-[[package]]
 name = "openssl"
 version = "0.10.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5048,7 +4943,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn",
 ]
 
 [[package]]
@@ -5136,16 +5031,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ordered-multimap"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49203cdcae0030493bad186b28da2fa25645fa276a51b6fec8010d281e02ef79"
-dependencies = [
- "dlv-list",
- "hashbrown 0.14.5",
-]
-
-[[package]]
 name = "outref"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5197,7 +5082,7 @@ version = "57.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f6a2926a30477c0b95fea6c28c3072712b139337a242c2cc64817bdc20a8854"
 dependencies = [
- "ahash 0.8.12",
+ "ahash",
  "arrow-array",
  "arrow-buffer",
  "arrow-cast",
@@ -5312,7 +5197,7 @@ checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn",
 ]
 
 [[package]]
@@ -5455,7 +5340,7 @@ dependencies = [
  "polars-arrow",
  "polars-error",
  "polars-utils",
- "rand 0.9.2",
+ "rand 0.9.4",
  "ryu",
  "serde",
  "strength_reduce",
@@ -5487,7 +5372,7 @@ dependencies = [
  "polars-row",
  "polars-schema",
  "polars-utils",
- "rand 0.9.2",
+ "rand 0.9.4",
  "rand_distr",
  "rayon",
  "regex",
@@ -5546,7 +5431,7 @@ dependencies = [
  "polars-row",
  "polars-time",
  "polars-utils",
- "rand 0.9.2",
+ "rand 0.9.4",
  "rayon",
  "recursive",
  "regex",
@@ -5814,7 +5699,7 @@ dependencies = [
  "polars-plan",
  "polars-time",
  "polars-utils",
- "rand 0.9.2",
+ "rand 0.9.4",
  "regex",
  "serde",
  "sqlparser 0.53.0",
@@ -5852,7 +5737,7 @@ dependencies = [
  "polars-plan",
  "polars-time",
  "polars-utils",
- "rand 0.9.2",
+ "rand 0.9.4",
  "rayon",
  "recursive",
  "slotmap",
@@ -5902,7 +5787,7 @@ dependencies = [
  "memmap2",
  "num-traits",
  "polars-error",
- "rand 0.9.2",
+ "rand 0.9.4",
  "raw-cpuid",
  "rayon",
  "regex",
@@ -5935,15 +5820,6 @@ name = "portable-atomic"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
-
-[[package]]
-name = "portable-atomic-util"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a9db96d7fa8782dd8c15ce32ffe8680bbd1e978a43bf51a34d39483540495f5"
-dependencies = [
- "portable-atomic",
-]
 
 [[package]]
 name = "potential_utf"
@@ -6006,7 +5882,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn 2.0.114",
+ "syn",
 ]
 
 [[package]]
@@ -6037,7 +5913,7 @@ dependencies = [
  "proc-macro-error-attr2",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn",
 ]
 
 [[package]]
@@ -6079,7 +5955,7 @@ dependencies = [
  "itertools 0.14.0",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn",
 ]
 
 [[package]]
@@ -6092,7 +5968,7 @@ dependencies = [
  "itertools 0.14.0",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn",
 ]
 
 [[package]]
@@ -6103,26 +5979,6 @@ checksum = "d11f2fedc3b7dafdc2851bc52f277377c5473d378859be234bc7ebb593144d01"
 dependencies = [
  "ar_archive_writer",
  "cc",
-]
-
-[[package]]
-name = "ptr_meta"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0738ccf7ea06b608c10564b31debd4f5bc5e197fc8bfe088f68ae5ce81e7a4f1"
-dependencies = [
- "ptr_meta_derive",
-]
-
-[[package]]
-name = "ptr_meta_derive"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16b845dbfca988fa33db069c0e230574d15a3088f147a87b64c7589eb662c9ac"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -6138,16 +5994,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1004a344b30a54e2ee58d66a71b32d2db2feb0a31f9a2d302bf0536f15de2a33"
 dependencies = [
  "encoding_rs",
- "memchr",
- "serde",
-]
-
-[[package]]
-name = "quick-xml"
-version = "0.37.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "331e97a1af0bf59823e6eadffe373d7b27f485be8748f71471c662c1f269b7fb"
-dependencies = [
  "memchr",
  "serde",
 ]
@@ -6191,7 +6037,7 @@ dependencies = [
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
- "rand 0.9.2",
+ "rand 0.9.4",
  "ring",
  "rustc-hash",
  "rustls 0.23.36",
@@ -6233,12 +6079,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
-name = "radium"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
-
-[[package]]
 name = "rand"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6264,9 +6104,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
@@ -6336,7 +6176,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8615d50dcf34fa31f7ab52692afec947c4dd0ab803cc87cb3b0b4570ff7463"
 dependencies = [
  "num-traits",
- "rand 0.9.2",
+ "rand 0.9.4",
 ]
 
 [[package]]
@@ -6394,7 +6234,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76009fbe0614077fc1a2ce255e3a1881a2e3a3527097d5dc6d8212c585e7e38b"
 dependencies = [
  "quote",
- "syn 2.0.114",
+ "syn",
 ]
 
 [[package]]
@@ -6434,7 +6274,7 @@ checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn",
 ]
 
 [[package]]
@@ -6477,44 +6317,6 @@ name = "relative-path"
 version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
-
-[[package]]
-name = "rend"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71fe3824f5629716b1589be05dacd749f6aa084c87e00e016714a8cdfccc997c"
-dependencies = [
- "bytecheck",
-]
-
-[[package]]
-name = "reqsign"
-version = "0.16.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43451dbf3590a7590684c25fb8d12ecdcc90ed3ac123433e500447c7d77ed701"
-dependencies = [
- "anyhow",
- "async-trait",
- "base64 0.22.1",
- "chrono",
- "form_urlencoded",
- "getrandom 0.2.17",
- "hex",
- "hmac",
- "home",
- "http 1.4.0",
- "log",
- "percent-encoding",
- "quick-xml 0.37.5",
- "rand 0.8.5",
- "reqwest",
- "rust-ini",
- "serde",
- "serde_json",
- "sha1",
- "sha2",
- "tokio",
-]
 
 [[package]]
 name = "reqwest"
@@ -6562,7 +6364,6 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
- "webpki-roots",
 ]
 
 [[package]]
@@ -6603,35 +6404,6 @@ dependencies = [
  "libc",
  "untrusted 0.9.0",
  "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "rkyv"
-version = "0.7.46"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2297bf9c81a3f0dc96bc9521370b88f054168c29826a75e89c55ff196e7ed6a1"
-dependencies = [
- "bitvec",
- "bytecheck",
- "bytes",
- "hashbrown 0.12.3",
- "ptr_meta",
- "rend",
- "rkyv_derive",
- "seahash",
- "tinyvec",
- "uuid",
-]
-
-[[package]]
-name = "rkyv_derive"
-version = "0.7.46"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84d7b42d4b8d06048d3ac8db0eb31bcb942cbeb709f0b5f2b2ebde398d3038f5"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -6700,34 +6472,8 @@ dependencies = [
  "regex",
  "relative-path",
  "rustc_version",
- "syn 2.0.114",
+ "syn",
  "unicode-ident",
-]
-
-[[package]]
-name = "rust-ini"
-version = "0.21.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "796e8d2b6696392a43bea58116b667fb4c29727dc5abd27d6acf338bb4f688c7"
-dependencies = [
- "cfg-if",
- "ordered-multimap",
-]
-
-[[package]]
-name = "rust_decimal"
-version = "1.40.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61f703d19852dbf87cbc513643fa81428361eb6940f1ac14fd58155d295a3eb0"
-dependencies = [
- "arrayvec",
- "borsh",
- "bytes",
- "num-traits",
- "rand 0.8.5",
- "rkyv",
- "serde",
- "serde_json",
 ]
 
 [[package]]
@@ -6919,12 +6665,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "seahash"
-version = "4.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
-
-[[package]]
 name = "sec1"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6997,6 +6737,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde-big-array"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11fc7cc2c76d73e0f27ee52abbd64eec84d46f370c88371120433196934e4b7f"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_bytes"
 version = "0.11.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7023,7 +6772,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn",
 ]
 
 [[package]]
@@ -7069,7 +6818,7 @@ checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn",
 ]
 
 [[package]]
@@ -7123,7 +6872,7 @@ dependencies = [
  "darling 0.21.3",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn",
 ]
 
 [[package]]
@@ -7218,7 +6967,7 @@ version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4255126f310d2ba20048db6321c81ab376f6a6735608bf11f0785c41f01f64e3"
 dependencies = [
- "ahash 0.8.12",
+ "ahash",
  "halfbrown",
  "once_cell",
  "ref-cast",
@@ -7291,7 +7040,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn",
 ]
 
 [[package]]
@@ -7374,7 +7123,7 @@ checksum = "da5fc6819faabb412da764b99d3b713bb55083c11e7e0c00144d386cd6a1939c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn",
 ]
 
 [[package]]
@@ -7454,7 +7203,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.114",
+ "syn",
 ]
 
 [[package]]
@@ -7466,7 +7215,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn",
 ]
 
 [[package]]
@@ -7474,17 +7223,6 @@ name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
-
-[[package]]
-name = "syn"
-version = "1.0.109"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-ident",
-]
 
 [[package]]
 name = "syn"
@@ -7514,7 +7252,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn",
 ]
 
 [[package]]
@@ -7543,12 +7281,6 @@ name = "tagptr"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
-
-[[package]]
-name = "tap"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tempfile"
@@ -7595,7 +7327,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn",
 ]
 
 [[package]]
@@ -7606,7 +7338,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn",
 ]
 
 [[package]]
@@ -7722,7 +7454,7 @@ checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn",
 ]
 
 [[package]]
@@ -7863,7 +7595,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn",
 ]
 
 [[package]]
@@ -7922,7 +7654,7 @@ checksum = "f03ca4cb38206e2bef0700092660bb74d696f808514dae47fa1467cbfe26e96e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn",
 ]
 
 [[package]]
@@ -7933,7 +7665,7 @@ checksum = "3c36781cc0e46a83726d9879608e4cf6c2505237e263a8eb8c24502989cfdb28"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn",
 ]
 
 [[package]]
@@ -7944,14 +7676,44 @@ checksum = "016c26257f448222014296978b2c8456e2cad4de308c35bdb1e383acd569ef5b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn",
 ]
+
+[[package]]
+name = "typeid"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
 
 [[package]]
 name = "typenum"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+
+[[package]]
+name = "typetag"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be2212c8a9b9bcfca32024de14998494cf9a5dfa59ea1b829de98bac374b86bf"
+dependencies = [
+ "erased-serde",
+ "inventory",
+ "once_cell",
+ "serde",
+ "typetag-impl",
+]
+
+[[package]]
+name = "typetag-impl"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27a7a9b72ba121f6f1f6c3632b85604cac41aedb5ddc70accbebb6cac83de846"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "tz-rs"
@@ -8067,7 +7829,7 @@ checksum = "e2e054861b4bd027cd373e18e8d8d8e6548085000e41290d95ce0c373a654b4a"
 dependencies = [
  "getrandom 0.3.4",
  "js-sys",
- "rand 0.9.2",
+ "rand 0.9.4",
  "serde_core",
  "wasm-bindgen",
 ]
@@ -8099,7 +7861,7 @@ dependencies = [
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn",
 ]
 
 [[package]]
@@ -8239,7 +8001,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn",
  "wasm-bindgen-shared",
 ]
 
@@ -8283,15 +8045,6 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
-]
-
-[[package]]
-name = "webpki-roots"
-version = "1.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
-dependencies = [
- "rustls-pki-types",
 ]
 
 [[package]]
@@ -8346,7 +8099,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn",
 ]
 
 [[package]]
@@ -8357,7 +8110,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn",
 ]
 
 [[package]]
@@ -8582,15 +8335,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
 
 [[package]]
-name = "wyz"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
-dependencies = [
- "tap",
-]
-
-[[package]]
 name = "xmlparser"
 version = "0.13.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8641,7 +8385,7 @@ checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn",
  "synstructure",
 ]
 
@@ -8668,7 +8412,7 @@ checksum = "2c7962b26b0a8685668b671ee4b54d007a67d4eaf05fda79ac0ecf41e32270f1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn",
 ]
 
 [[package]]
@@ -8688,7 +8432,7 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn",
  "synstructure",
 ]
 
@@ -8728,7 +8472,7 @@ checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn",
 ]
 
 [[package]]

--- a/crates/floe-core/Cargo.toml
+++ b/crates/floe-core/Cargo.toml
@@ -39,7 +39,8 @@ azure_storage_blobs = "0.20"
 futures = "0.3"
 uuid = "1"
 arrow = "57"
-iceberg = "0.8.0"
+iceberg = "0.9.1"
+iceberg-catalog-rest = { version = "0.9.1", default-features = false }
 df-interchange = { version = "0.3.2", features = ["arrow_57", "polars_0_52"] }
 orc-rust = "0.7.1"
 

--- a/crates/floe-core/src/config/catalog.rs
+++ b/crates/floe-core/src/config/catalog.rs
@@ -115,6 +115,8 @@ impl CatalogResolver {
         // namespace and table names use the shared normalizer — same rules for all catalog types
         let database_for_namespace = match &definition.type_config {
             CatalogTypeConfig::Glue { database, .. } => database.as_str(),
+            // REST catalogs fall back to "default" as the namespace source, never the warehouse.
+            CatalogTypeConfig::Rest { .. } => "default",
         };
         let namespace_source = iceberg_cfg
             .namespace

--- a/crates/floe-core/src/config/parse.rs
+++ b/crates/floe-core/src/config/parse.rs
@@ -710,6 +710,11 @@ fn parse_catalog_definition(value: &Yaml) -> FloeResult<CatalogDefinition> {
             "database",
             "create_database_if_missing",
             "allow_takeover",
+            "uri",
+            "credential",
+            "oauth2_server_uri",
+            "scope",
+            "warehouse",
             "warehouse_storage",
             "warehouse_prefix",
         ],
@@ -743,8 +748,15 @@ fn parse_catalog_type_config(
             allow_takeover: opt_bool(hash, "allow_takeover", "catalogs.definitions")?
                 .unwrap_or(false),
         }),
+        "rest" => Ok(CatalogTypeConfig::Rest {
+            uri: get_string(hash, "uri", "catalogs.definitions")?,
+            credential: opt_string(hash, "credential", "catalogs.definitions")?,
+            warehouse: opt_string(hash, "warehouse", "catalogs.definitions")?,
+            oauth2_server_uri: opt_string(hash, "oauth2_server_uri", "catalogs.definitions")?,
+            scope: opt_string(hash, "scope", "catalogs.definitions")?,
+        }),
         other => Err(Box::new(crate::errors::ConfigError(format!(
-            "catalogs.definitions name={name} has unsupported type={other} (supported: glue)"
+            "catalogs.definitions name={name} has unsupported type={other} (supported: glue, rest)"
         )))),
     }
 }

--- a/crates/floe-core/src/config/types.rs
+++ b/crates/floe-core/src/config/types.rs
@@ -341,12 +341,28 @@ pub enum CatalogTypeConfig {
         /// Allow Floe to take ownership of a Glue table it did not create (default: false).
         allow_takeover: bool,
     },
+    Rest {
+        /// Base URI of the REST catalog (e.g. https://api.tabular.io/ws).
+        uri: String,
+        /// Credential string.  Routing:
+        ///   "token:<value>"                   → bearer PAT (Unity Catalog / Nessie)
+        ///   "client_credentials:<id>:<secret>" → OAuth2 client-credentials (Polaris / Snowflake)
+        ///   anything else                     → raw credential property
+        credential: Option<String>,
+        /// Warehouse / catalog name sent to the REST endpoint (optional).
+        warehouse: Option<String>,
+        /// Override the OAuth2 token endpoint (optional).
+        oauth2_server_uri: Option<String>,
+        /// OAuth2 scope (optional).
+        scope: Option<String>,
+    },
 }
 
 impl CatalogTypeConfig {
     pub fn catalog_type_str(&self) -> &'static str {
         match self {
             Self::Glue { .. } => "glue",
+            Self::Rest { .. } => "rest",
         }
     }
 }

--- a/crates/floe-core/src/config/validate.rs
+++ b/crates/floe-core/src/config/validate.rs
@@ -596,16 +596,7 @@ fn validate_iceberg_catalog_binding(
         return Ok(());
     };
 
-    let accepted_storage_type = storages
-        .definition_type(accepted_storage)
-        .unwrap_or("local");
-    if accepted_storage_type != "s3" && accepted_storage_type != "gcs" {
-        return Err(Box::new(ConfigError(format!(
-            "entity.name={} sink.accepted.iceberg.catalog requires sink.accepted storage type s3 or gcs (got {})",
-            entity.name, accepted_storage_type
-        ))));
-    }
-
+    // Resolve the catalog definition first so we can make type-specific decisions below.
     let catalog_name = if let Some(name) = iceberg_cfg.catalog.as_deref() {
         name.to_string()
     } else if let Some(name) = catalogs.default_name() {
@@ -623,6 +614,21 @@ fn validate_iceberg_catalog_binding(
             entity.name, catalog_name
         ))) as Box<dyn std::error::Error + Send + Sync>
     })?;
+
+    // The S3/GCS accepted-storage check applies only to Glue catalogs.
+    // REST catalogs accept any storage type (local for Nessie/dev, cloud for Unity/Polaris).
+    if matches!(definition.type_config, CatalogTypeConfig::Glue { .. }) {
+        let accepted_storage_type = storages
+            .definition_type(accepted_storage)
+            .unwrap_or("local");
+        if accepted_storage_type != "s3" && accepted_storage_type != "gcs" {
+            return Err(Box::new(ConfigError(format!(
+                "entity.name={} sink.accepted.iceberg.catalog requires sink.accepted storage type s3 or gcs (got {})",
+                entity.name, accepted_storage_type
+            ))));
+        }
+    }
+
     if let Some(storage_name) = definition.warehouse_storage.as_deref() {
         let storage_type = storages.definition_type(storage_name).ok_or_else(|| {
             Box::new(ConfigError(format!(
@@ -630,11 +636,23 @@ fn validate_iceberg_catalog_binding(
                 definition.name, storage_name
             ))) as Box<dyn std::error::Error + Send + Sync>
         })?;
-        if storage_type != "s3" {
-            return Err(Box::new(ConfigError(format!(
-                "catalogs.definitions name={} warehouse_storage must reference s3 storage for glue catalog (got {})",
-                definition.name, storage_type
-            ))));
+        match &definition.type_config {
+            CatalogTypeConfig::Glue { .. } => {
+                if storage_type != "s3" {
+                    return Err(Box::new(ConfigError(format!(
+                        "catalogs.definitions name={} warehouse_storage must reference s3 storage for glue catalog (got {})",
+                        definition.name, storage_type
+                    ))));
+                }
+            }
+            CatalogTypeConfig::Rest { .. } => {
+                if storage_type != "s3" && storage_type != "gcs" {
+                    return Err(Box::new(ConfigError(format!(
+                        "catalogs.definitions name={} warehouse_storage must reference s3 or gcs storage for rest catalog (got {})",
+                        definition.name, storage_type
+                    ))));
+                }
+            }
         }
     }
 
@@ -1090,6 +1108,24 @@ impl CatalogRegistry {
                         if storage_type != "s3" {
                             return Err(Box::new(ConfigError(format!(
                                 "catalogs.definitions name={} warehouse_storage must reference s3 storage for glue catalog (got {})",
+                                definition.name, storage_type
+                            ))));
+                        }
+                    }
+                }
+                CatalogTypeConfig::Rest { .. } => {
+                    if let Some(storage_name) = definition.warehouse_storage.as_deref() {
+                        let storage_type =
+                            storages.definition_type(storage_name).ok_or_else(|| {
+                                Box::new(ConfigError(format!(
+                                    "catalogs.definitions name={} warehouse_storage references unknown storage {}",
+                                    definition.name, storage_name
+                                )))
+                                    as Box<dyn std::error::Error + Send + Sync>
+                            })?;
+                        if storage_type != "s3" && storage_type != "gcs" {
+                            return Err(Box::new(ConfigError(format!(
+                                "catalogs.definitions name={} warehouse_storage must reference s3 or gcs storage for rest catalog (got {})",
                                 definition.name, storage_type
                             ))));
                         }

--- a/crates/floe-core/src/config/validate.rs
+++ b/crates/floe-core/src/config/validate.rs
@@ -615,29 +615,25 @@ fn validate_iceberg_catalog_binding(
         ))) as Box<dyn std::error::Error + Send + Sync>
     })?;
 
-    // The S3/GCS accepted-storage check applies only to Glue catalogs.
-    // REST catalogs accept any storage type (local for Nessie/dev, cloud for Unity/Polaris).
-    if matches!(definition.type_config, CatalogTypeConfig::Glue { .. }) {
-        let accepted_storage_type = storages
-            .definition_type(accepted_storage)
-            .unwrap_or("local");
-        if accepted_storage_type != "s3" && accepted_storage_type != "gcs" {
-            return Err(Box::new(ConfigError(format!(
-                "entity.name={} sink.accepted.iceberg.catalog requires sink.accepted storage type s3 or gcs (got {})",
-                entity.name, accepted_storage_type
-            ))));
-        }
-    }
-
-    if let Some(storage_name) = definition.warehouse_storage.as_deref() {
-        let storage_type = storages.definition_type(storage_name).ok_or_else(|| {
-            Box::new(ConfigError(format!(
-                "catalogs.definitions name={} warehouse_storage references unknown storage {}",
-                definition.name, storage_name
-            ))) as Box<dyn std::error::Error + Send + Sync>
-        })?;
-        match &definition.type_config {
-            CatalogTypeConfig::Glue { .. } => {
+    match &definition.type_config {
+        CatalogTypeConfig::Glue { .. } => {
+            // Glue catalog requires the accepted sink to be S3 or GCS.
+            let accepted_storage_type = storages
+                .definition_type(accepted_storage)
+                .unwrap_or("local");
+            if accepted_storage_type != "s3" && accepted_storage_type != "gcs" {
+                return Err(Box::new(ConfigError(format!(
+                    "entity.name={} sink.accepted.iceberg.catalog requires sink.accepted storage type s3 or gcs (got {})",
+                    entity.name, accepted_storage_type
+                ))));
+            }
+            if let Some(storage_name) = definition.warehouse_storage.as_deref() {
+                let storage_type = storages.definition_type(storage_name).ok_or_else(|| {
+                    Box::new(ConfigError(format!(
+                        "catalogs.definitions name={} warehouse_storage references unknown storage {}",
+                        definition.name, storage_name
+                    ))) as Box<dyn std::error::Error + Send + Sync>
+                })?;
                 if storage_type != "s3" {
                     return Err(Box::new(ConfigError(format!(
                         "catalogs.definitions name={} warehouse_storage must reference s3 storage for glue catalog (got {})",
@@ -645,16 +641,22 @@ fn validate_iceberg_catalog_binding(
                     ))));
                 }
             }
-            CatalogTypeConfig::Rest { .. } => {
-                if storage_type == "s3" || storage_type == "gcs" {
-                    // Cloud data-file writes through a REST catalog require iceberg-storage-opendal,
-                    // which is not yet available in the crates.io registry for iceberg 0.9.x.
-                    // Until that dependency is published, REST catalogs only support local storage.
-                    return Err(Box::new(ConfigError(format!(
-                        "catalogs.definitions name={} warehouse_storage references {} storage, but REST catalog cloud FileIO requires iceberg-storage-opendal which is not yet available; use local storage or omit warehouse_storage",
-                        definition.name, storage_type
-                    ))));
-                }
+        }
+        CatalogTypeConfig::Rest { .. } => {
+            // REST catalog cloud FileIO requires iceberg-storage-opendal (not yet on crates.io).
+            // Check the effective storage: warehouse_storage if set, else the accepted sink storage.
+            let effective_storage = definition
+                .warehouse_storage
+                .as_deref()
+                .unwrap_or(accepted_storage);
+            let effective_type = storages
+                .definition_type(effective_storage)
+                .unwrap_or("local");
+            if effective_type == "s3" || effective_type == "gcs" {
+                return Err(Box::new(ConfigError(format!(
+                    "entity.name={} REST catalog {} effective storage {} is {}: cloud FileIO requires iceberg-storage-opendal which is not yet available; use local storage",
+                    entity.name, catalog_name, effective_storage, effective_type
+                ))));
             }
         }
     }
@@ -1126,9 +1128,11 @@ impl CatalogRegistry {
                                 )))
                                     as Box<dyn std::error::Error + Send + Sync>
                             })?;
-                        if storage_type != "s3" && storage_type != "gcs" {
+                        // Cloud warehouse_storage for REST requires iceberg-storage-opendal.
+                        // Local storage (Nessie, dev) is allowed.
+                        if storage_type == "s3" || storage_type == "gcs" {
                             return Err(Box::new(ConfigError(format!(
-                                "catalogs.definitions name={} warehouse_storage must reference s3 or gcs storage for rest catalog (got {})",
+                                "catalogs.definitions name={} warehouse_storage references {} storage, but REST catalog cloud FileIO requires iceberg-storage-opendal which is not yet available; use local storage or omit warehouse_storage",
                                 definition.name, storage_type
                             ))));
                         }

--- a/crates/floe-core/src/config/validate.rs
+++ b/crates/floe-core/src/config/validate.rs
@@ -646,9 +646,12 @@ fn validate_iceberg_catalog_binding(
                 }
             }
             CatalogTypeConfig::Rest { .. } => {
-                if storage_type != "s3" && storage_type != "gcs" {
+                if storage_type == "s3" || storage_type == "gcs" {
+                    // Cloud data-file writes through a REST catalog require iceberg-storage-opendal,
+                    // which is not yet available in the crates.io registry for iceberg 0.9.x.
+                    // Until that dependency is published, REST catalogs only support local storage.
                     return Err(Box::new(ConfigError(format!(
-                        "catalogs.definitions name={} warehouse_storage must reference s3 or gcs storage for rest catalog (got {})",
+                        "catalogs.definitions name={} warehouse_storage references {} storage, but REST catalog cloud FileIO requires iceberg-storage-opendal which is not yet available; use local storage or omit warehouse_storage",
                         definition.name, storage_type
                     ))));
                 }

--- a/crates/floe-core/src/config/validate.rs
+++ b/crates/floe-core/src/config/validate.rs
@@ -643,7 +643,7 @@ fn validate_iceberg_catalog_binding(
             }
         }
         CatalogTypeConfig::Rest { .. } => {
-            // REST catalog cloud FileIO requires iceberg-storage-opendal (not yet on crates.io).
+            // REST catalog FileIO only supports local storage until iceberg-storage-opendal ships.
             // Check the effective storage: warehouse_storage if set, else the accepted sink storage.
             let effective_storage = definition
                 .warehouse_storage
@@ -652,9 +652,9 @@ fn validate_iceberg_catalog_binding(
             let effective_type = storages
                 .definition_type(effective_storage)
                 .unwrap_or("local");
-            if effective_type == "s3" || effective_type == "gcs" {
+            if effective_type != "local" {
                 return Err(Box::new(ConfigError(format!(
-                    "entity.name={} REST catalog {} effective storage {} is {}: cloud FileIO requires iceberg-storage-opendal which is not yet available; use local storage",
+                    "entity.name={} REST catalog {} effective storage {} is {}: only local storage is supported until iceberg-storage-opendal is available",
                     entity.name, catalog_name, effective_storage, effective_type
                 ))));
             }
@@ -1128,11 +1128,10 @@ impl CatalogRegistry {
                                 )))
                                     as Box<dyn std::error::Error + Send + Sync>
                             })?;
-                        // Cloud warehouse_storage for REST requires iceberg-storage-opendal.
-                        // Local storage (Nessie, dev) is allowed.
-                        if storage_type == "s3" || storage_type == "gcs" {
+                        // REST catalog only supports local storage until iceberg-storage-opendal ships.
+                        if storage_type != "local" {
                             return Err(Box::new(ConfigError(format!(
-                                "catalogs.definitions name={} warehouse_storage references {} storage, but REST catalog cloud FileIO requires iceberg-storage-opendal which is not yet available; use local storage or omit warehouse_storage",
+                                "catalogs.definitions name={} warehouse_storage references {} storage, but REST catalog only supports local storage until iceberg-storage-opendal is available; use local storage or omit warehouse_storage",
                                 definition.name, storage_type
                             ))));
                         }

--- a/crates/floe-core/src/io/unique_seed/iceberg.rs
+++ b/crates/floe-core/src/io/unique_seed/iceberg.rs
@@ -180,14 +180,13 @@ fn seed_from_rest(
     unique_tracker: &mut check::UniqueTracker,
     rest_cfg: &RestIcebergCatalogConfig,
     file_io_props: HashMap<String, String>,
-    warehouse_location: String,
+    _warehouse_location: String,
     _entity: &config::EntityConfig,
     scan_cols: &[String],
     rename_back: &HashMap<String, String>,
 ) -> FloeResult<()> {
     use futures::TryStreamExt;
     use iceberg::{Catalog, NamespaceIdent, TableIdent};
-
     let runtime = tokio::runtime::Builder::new_current_thread()
         .enable_all()
         .build()
@@ -201,7 +200,7 @@ fn seed_from_rest(
 
     let batches = runtime
         .block_on(async {
-            let catalog = build_rest_catalog(rest_cfg, &warehouse_location, file_io_props).await?;
+            let catalog = build_rest_catalog(rest_cfg, file_io_props).await?;
             let namespace = NamespaceIdent::new(rest_cfg.namespace.clone());
 
             // Guard against catalogs that error (rather than return false) for table_exists

--- a/crates/floe-core/src/io/unique_seed/iceberg.rs
+++ b/crates/floe-core/src/io/unique_seed/iceberg.rs
@@ -203,6 +203,17 @@ fn seed_from_rest(
         .block_on(async {
             let catalog = build_rest_catalog(rest_cfg, &warehouse_location, file_io_props).await?;
             let namespace = NamespaceIdent::new(rest_cfg.namespace.clone());
+
+            // Guard against catalogs that error (rather than return false) for table_exists
+            // when the namespace does not yet exist — treat a missing namespace as empty.
+            if !catalog
+                .namespace_exists(&namespace)
+                .await
+                .map_err(map_err("rest iceberg seed namespace_exists check failed"))?
+            {
+                return Ok(Vec::new());
+            }
+
             let table_ident = TableIdent::new(namespace, rest_cfg.table.clone());
 
             if !catalog

--- a/crates/floe-core/src/io/unique_seed/iceberg.rs
+++ b/crates/floe-core/src/io/unique_seed/iceberg.rs
@@ -8,9 +8,10 @@ use crate::io::storage::{object_store, Target};
 use crate::io::write::iceberg::metadata::{
     latest_gcs_metadata_location, latest_local_metadata_location, latest_s3_metadata_location,
 };
+use crate::io::write::iceberg::rest::build_rest_catalog;
 use crate::io::write::iceberg::{
-    load_glue_table_state, sanitize_table_name, IcebergCatalogConfig, ICEBERG_CATALOG_NAME,
-    ICEBERG_NAMESPACE,
+    load_glue_table_state, sanitize_table_name, IcebergCatalogConfig, RestIcebergCatalogConfig,
+    ICEBERG_CATALOG_NAME, ICEBERG_NAMESPACE,
 };
 use crate::{check, config, io, FloeResult};
 
@@ -120,6 +121,15 @@ fn seed_from_catalog(
             scan_cols,
             rename_back,
         ),
+        IcebergCatalogConfig::Rest(rest_cfg) => seed_from_rest(
+            unique_tracker,
+            rest_cfg,
+            file_io_props,
+            warehouse_location,
+            entity,
+            scan_cols,
+            rename_back,
+        ),
     }
 }
 
@@ -162,6 +172,69 @@ fn seed_from_glue(
             scan_cols,
         ))
         .map_err(|err| Box::new(RunError(format!("glue iceberg seed failed: {err}"))))?;
+
+    seed_from_batches(unique_tracker, batches, rename_back)
+}
+
+fn seed_from_rest(
+    unique_tracker: &mut check::UniqueTracker,
+    rest_cfg: &RestIcebergCatalogConfig,
+    file_io_props: HashMap<String, String>,
+    warehouse_location: String,
+    _entity: &config::EntityConfig,
+    scan_cols: &[String],
+    rename_back: &HashMap<String, String>,
+) -> FloeResult<()> {
+    use futures::TryStreamExt;
+    use iceberg::{Catalog, NamespaceIdent, TableIdent};
+
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .map_err(|err| {
+            Box::new(RunError(format!(
+                "rest iceberg seed runtime init failed: {err}"
+            )))
+        })?;
+
+    let map_err = crate::io::write::iceberg::map_iceberg_err;
+
+    let batches = runtime
+        .block_on(async {
+            let catalog = build_rest_catalog(rest_cfg, &warehouse_location, file_io_props).await?;
+            let namespace = NamespaceIdent::new(rest_cfg.namespace.clone());
+            let table_ident = TableIdent::new(namespace, rest_cfg.table.clone());
+
+            if !catalog
+                .table_exists(&table_ident)
+                .await
+                .map_err(map_err("rest iceberg seed table_exists check failed"))?
+            {
+                return Ok(Vec::new());
+            }
+
+            let table = catalog
+                .load_table(&table_ident)
+                .await
+                .map_err(map_err("rest iceberg seed load_table failed"))?;
+
+            let scan = table
+                .scan()
+                .select(scan_cols.iter().cloned())
+                .build()
+                .map_err(map_err("rest iceberg seed scan build failed"))?;
+
+            scan.to_arrow()
+                .await
+                .map_err(map_err("rest iceberg seed to_arrow failed"))?
+                .try_filter(|b| std::future::ready(b.num_rows() > 0))
+                .try_collect::<Vec<_>>()
+                .await
+                .map_err(map_err("rest iceberg seed collect failed"))
+        })
+        .map_err(|err: Box<dyn std::error::Error + Send + Sync>| {
+            Box::new(RunError(format!("rest iceberg seed failed: {err}")))
+        })?;
 
     seed_from_batches(unique_tracker, batches, rename_back)
 }

--- a/crates/floe-core/src/io/unique_seed/iceberg.rs
+++ b/crates/floe-core/src/io/unique_seed/iceberg.rs
@@ -249,15 +249,24 @@ async fn collect_iceberg_batches(
     scan_columns: &[String],
 ) -> Result<Vec<RecordBatch>, iceberg::Error> {
     use futures::TryStreamExt;
+    use iceberg::io::LocalFsStorageFactory;
     use iceberg::memory::{MemoryCatalogBuilder, MEMORY_CATALOG_WAREHOUSE};
     use iceberg::{Catalog, CatalogBuilder, NamespaceIdent, TableIdent};
+
+    let is_local = !warehouse_location.starts_with("s3://")
+        && !warehouse_location.starts_with("gs://")
+        && !warehouse_location.starts_with("az://")
+        && !warehouse_location.starts_with("abfss://");
 
     let mut props = catalog_props;
     props.insert(MEMORY_CATALOG_WAREHOUSE.to_string(), warehouse_location);
 
-    let catalog = MemoryCatalogBuilder::default()
-        .load(ICEBERG_CATALOG_NAME, props)
-        .await?;
+    let mut catalog_builder = MemoryCatalogBuilder::default();
+    if is_local {
+        catalog_builder =
+            catalog_builder.with_storage_factory(std::sync::Arc::new(LocalFsStorageFactory));
+    }
+    let catalog = catalog_builder.load(ICEBERG_CATALOG_NAME, props).await?;
 
     let namespace = NamespaceIdent::new(ICEBERG_NAMESPACE.to_string());
     if !catalog.namespace_exists(&namespace).await? {

--- a/crates/floe-core/src/io/write/iceberg.rs
+++ b/crates/floe-core/src/io/write/iceberg.rs
@@ -22,6 +22,7 @@ mod context;
 mod data_files;
 mod glue;
 pub(crate) mod metadata;
+pub(crate) mod rest;
 mod schema;
 
 pub(crate) use self::context::sanitize_table_name;
@@ -30,6 +31,7 @@ use self::data_files::{iceberg_small_file_threshold_bytes, write_data_files};
 pub(crate) use self::glue::load_glue_table_state;
 use self::glue::upsert_glue_table;
 use self::metadata::parse_metadata_version_from_location;
+pub(crate) use self::rest::{write_via_rest_catalog, RestIcebergCatalogConfig};
 use self::schema::{ensure_partition_spec_matches, ensure_schema_matches, prepare_iceberg_write};
 
 struct IcebergAcceptedAdapter;
@@ -44,14 +46,14 @@ pub(crate) fn iceberg_accepted_adapter() -> &'static dyn AcceptedSinkAdapter {
 }
 
 #[derive(Debug)]
-struct PreparedIcebergWrite {
-    iceberg_schema: Schema,
-    partition_spec: Option<UnboundPartitionSpec>,
-    batch: RecordBatch,
+pub(crate) struct PreparedIcebergWrite {
+    pub(crate) iceberg_schema: Schema,
+    pub(crate) partition_spec: Option<UnboundPartitionSpec>,
+    pub(crate) batch: RecordBatch,
 }
 
 #[derive(Debug)]
-struct IcebergWriteResult {
+pub(crate) struct IcebergWriteResult {
     files_written: u64,
     snapshot_id: Option<i64>,
     metadata_version: Option<i64>,
@@ -84,6 +86,7 @@ struct IcebergWriteContext {
 #[derive(Debug, Clone)]
 pub(crate) enum IcebergCatalogConfig {
     Glue(GlueIcebergCatalogConfig),
+    Rest(RestIcebergCatalogConfig),
 }
 
 impl IcebergCatalogConfig {
@@ -108,30 +111,42 @@ impl IcebergCatalogConfig {
                 create_database_if_missing: *create_database_if_missing,
                 allow_takeover: *allow_takeover,
             })),
+            config::CatalogTypeConfig::Rest { .. } => {
+                Ok(Self::Rest(RestIcebergCatalogConfig::from_type_config(
+                    resolved.catalog_name.clone(),
+                    &resolved.type_config,
+                    resolved.namespace.clone(),
+                    resolved.table.clone(),
+                )?))
+            }
         }
     }
 
     pub(crate) fn catalog_name(&self) -> &str {
         match self {
             Self::Glue(cfg) => &cfg.catalog_name,
+            Self::Rest(cfg) => &cfg.catalog_name,
         }
     }
 
     pub(crate) fn database(&self) -> Option<&str> {
         match self {
             Self::Glue(cfg) => Some(&cfg.database),
+            Self::Rest(_) => None,
         }
     }
 
     pub(crate) fn namespace(&self) -> &str {
         match self {
             Self::Glue(cfg) => &cfg.namespace,
+            Self::Rest(cfg) => &cfg.namespace,
         }
     }
 
     pub(crate) fn table(&self) -> &str {
         match self {
             Self::Glue(cfg) => &cfg.table,
+            Self::Rest(cfg) => &cfg.table,
         }
     }
 }
@@ -255,6 +270,21 @@ async fn write_iceberg_table_async(
         mut metadata_location,
         catalog: catalog_cfg,
     } = write_ctx;
+
+    // REST catalog takes a completely different code path: it connects to a remote server.
+    if let Some(IcebergCatalogConfig::Rest(rest_cfg)) = catalog_cfg.as_ref() {
+        return write_via_rest_catalog(
+            rest_cfg,
+            table_root_uri,
+            catalog_props,
+            prepared,
+            entity,
+            mode,
+            small_file_threshold_bytes,
+        )
+        .await;
+    }
+
     let mut glue_state = None;
     if let Some(IcebergCatalogConfig::Glue(glue_cfg)) = catalog_cfg.as_ref() {
         let state = load_glue_table_state(glue_cfg).await?;
@@ -442,7 +472,7 @@ async fn write_iceberg_table_async(
     })
 }
 
-fn map_iceberg_err(
+pub(crate) fn map_iceberg_err(
     context: &'static str,
 ) -> impl FnOnce(iceberg::Error) -> Box<dyn std::error::Error + Send + Sync> {
     move |err| Box::new(RunError(format!("{context}: {err}")))

--- a/crates/floe-core/src/io/write/iceberg.rs
+++ b/crates/floe-core/src/io/write/iceberg.rs
@@ -3,6 +3,7 @@ use std::path::Path;
 use std::time::Instant;
 
 use arrow::record_batch::RecordBatch;
+use iceberg::io::LocalFsStorageFactory;
 use iceberg::memory::{MemoryCatalogBuilder, MEMORY_CATALOG_WAREHOUSE};
 use iceberg::spec::{Schema, UnboundPartitionSpec};
 use iceberg::transaction::{ApplyTransactionAction, Transaction};
@@ -293,7 +294,16 @@ async fn write_iceberg_table_async(
     }
     catalog_props.insert(MEMORY_CATALOG_WAREHOUSE.to_string(), table_root_uri.clone());
 
-    let catalog = MemoryCatalogBuilder::default()
+    let is_local = !table_root_uri.starts_with("s3://")
+        && !table_root_uri.starts_with("gs://")
+        && !table_root_uri.starts_with("az://")
+        && !table_root_uri.starts_with("abfss://");
+    let mut catalog_builder = MemoryCatalogBuilder::default();
+    if is_local {
+        catalog_builder =
+            catalog_builder.with_storage_factory(std::sync::Arc::new(LocalFsStorageFactory));
+    }
+    let catalog = catalog_builder
         .load(catalog_name, catalog_props)
         .await
         .map_err(map_iceberg_err("iceberg catalog init failed"))?;

--- a/crates/floe-core/src/io/write/iceberg/context.rs
+++ b/crates/floe-core/src/io/write/iceberg/context.rs
@@ -28,6 +28,17 @@ pub(super) fn build_iceberg_write_context(
     }
     match target {
         Target::Local { base_path, .. } => {
+            if let Some(ctx) = remote.as_mut() {
+                let ctx = &mut **ctx;
+                if let Some(resolved) = ctx.catalogs.resolve_iceberg_target(
+                    ctx.resolver,
+                    entity,
+                    &entity.sink.accepted,
+                )? {
+                    let catalog_cfg = build_catalog_config(ctx, entity, &resolved)?;
+                    return Ok(catalog_cfg);
+                }
+            }
             let table_root = PathBuf::from(base_path);
             fs::create_dir_all(&table_root)?;
             let metadata_location = latest_local_metadata_location(&table_root)?;

--- a/crates/floe-core/src/io/write/iceberg/rest.rs
+++ b/crates/floe-core/src/io/write/iceberg/rest.rs
@@ -1,0 +1,323 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::Instant;
+
+use iceberg::io::{LocalFsStorageFactory, StorageFactory};
+use iceberg::spec::UnboundPartitionSpec;
+use iceberg::transaction::{ApplyTransactionAction, Transaction};
+use iceberg::{Catalog, CatalogBuilder, NamespaceIdent, TableIdent};
+use iceberg_catalog_rest::{
+    RestCatalogBuilder, REST_CATALOG_PROP_URI, REST_CATALOG_PROP_WAREHOUSE,
+};
+
+use crate::config::CatalogTypeConfig;
+use crate::errors::RunError;
+use crate::{config, FloeResult};
+
+use super::data_files::write_data_files;
+use super::metadata::parse_metadata_version_from_location;
+use super::{map_iceberg_err, IcebergWriteResult, PreparedIcebergWrite};
+
+/// Build a REST catalog from the given config, table root URI, and file I/O props.
+///
+/// Credential routing:
+///  - `"token:<value>"` → `"token"` property (bearer PAT: Unity Catalog, Nessie)
+///  - `"client_credentials:<id>:<secret>"` → strip prefix → `"credential"` property (OAuth2: Polaris / Snowflake)
+///  - anything else → raw `"credential"` property
+pub(crate) async fn build_rest_catalog(
+    rest_cfg: &RestIcebergCatalogConfig,
+    table_root_uri: &str,
+    file_io_props: HashMap<String, String>,
+) -> FloeResult<iceberg_catalog_rest::RestCatalog> {
+    let mut props: HashMap<String, String> = file_io_props;
+
+    props.insert(REST_CATALOG_PROP_URI.to_string(), rest_cfg.uri.clone());
+
+    if let Some(warehouse) = rest_cfg.warehouse.as_deref() {
+        props.insert(
+            REST_CATALOG_PROP_WAREHOUSE.to_string(),
+            warehouse.to_string(),
+        );
+    } else {
+        // Fall back to the table root URI as the warehouse hint.
+        props.insert(
+            REST_CATALOG_PROP_WAREHOUSE.to_string(),
+            table_root_uri.to_string(),
+        );
+    }
+
+    if let Some(credential) = rest_cfg.credential.as_deref() {
+        if let Some(token_value) = credential.strip_prefix("token:") {
+            // Bearer PAT (Unity Catalog / Nessie)
+            props.insert("token".to_string(), token_value.to_string());
+        } else if let Some(rest) = credential.strip_prefix("client_credentials:") {
+            // OAuth2 client credentials — store as "credential" with id:secret format.
+            props.insert("credential".to_string(), rest.to_string());
+        } else {
+            // Raw credential fallthrough.
+            props.insert("credential".to_string(), credential.to_string());
+        }
+    }
+
+    if let Some(oauth2_uri) = rest_cfg.oauth2_server_uri.as_deref() {
+        props.insert("oauth2-server-uri".to_string(), oauth2_uri.to_string());
+    }
+
+    if let Some(scope) = rest_cfg.scope.as_deref() {
+        props.insert("scope".to_string(), scope.to_string());
+    }
+
+    let storage_factory: Arc<dyn StorageFactory> = Arc::new(LocalFsStorageFactory);
+
+    RestCatalogBuilder::default()
+        .with_storage_factory(storage_factory)
+        .load("floe_rest", props)
+        .await
+        .map_err(map_iceberg_err("rest catalog init failed"))
+}
+
+/// Config struct for REST Iceberg catalog operations.
+#[derive(Debug, Clone)]
+pub(crate) struct RestIcebergCatalogConfig {
+    pub(crate) catalog_name: String,
+    pub(crate) uri: String,
+    pub(crate) credential: Option<String>,
+    pub(crate) warehouse: Option<String>,
+    pub(crate) oauth2_server_uri: Option<String>,
+    pub(crate) scope: Option<String>,
+    pub(crate) namespace: String,
+    pub(crate) table: String,
+}
+
+impl RestIcebergCatalogConfig {
+    pub(crate) fn from_type_config(
+        catalog_name: String,
+        type_config: &CatalogTypeConfig,
+        namespace: String,
+        table: String,
+    ) -> FloeResult<Self> {
+        match type_config {
+            CatalogTypeConfig::Rest {
+                uri,
+                credential,
+                warehouse,
+                oauth2_server_uri,
+                scope,
+            } => Ok(Self {
+                catalog_name,
+                uri: uri.clone(),
+                credential: credential.clone(),
+                warehouse: warehouse.clone(),
+                oauth2_server_uri: oauth2_server_uri.clone(),
+                scope: scope.clone(),
+                namespace,
+                table,
+            }),
+            _ => Err(Box::new(RunError(
+                "RestIcebergCatalogConfig::from_type_config called on non-REST catalog".to_string(),
+            ))),
+        }
+    }
+}
+
+pub(crate) async fn write_via_rest_catalog(
+    rest_cfg: &RestIcebergCatalogConfig,
+    table_root_uri: String,
+    file_io_props: HashMap<String, String>,
+    prepared: PreparedIcebergWrite,
+    entity: &config::EntityConfig,
+    mode: config::WriteMode,
+    small_file_threshold_bytes: u64,
+) -> FloeResult<IcebergWriteResult> {
+    let catalog = build_rest_catalog(rest_cfg, &table_root_uri, file_io_props).await?;
+
+    let namespace_name = rest_cfg.namespace.clone();
+    let namespace = NamespaceIdent::new(namespace_name);
+    ensure_rest_namespace(&catalog, &namespace).await?;
+
+    let table_ident = TableIdent::new(namespace.clone(), rest_cfg.table.clone());
+
+    let existing_table = if catalog
+        .table_exists(&table_ident)
+        .await
+        .map_err(map_iceberg_err("rest catalog table_exists check failed"))?
+    {
+        Some(
+            catalog
+                .load_table(&table_ident)
+                .await
+                .map_err(map_iceberg_err("rest catalog load_table failed"))?,
+        )
+    } else {
+        None
+    };
+
+    if let Some(existing) = existing_table.as_ref() {
+        super::schema::ensure_schema_matches(
+            existing.metadata().current_schema(),
+            &prepared.iceberg_schema,
+            entity,
+        )?;
+        super::schema::ensure_partition_spec_matches(
+            existing.metadata().default_partition_spec(),
+            prepared.partition_spec.as_ref(),
+            &prepared.iceberg_schema,
+            entity,
+        )?;
+    }
+
+    let table = match mode {
+        config::WriteMode::Append => match existing_table {
+            Some(table) => table,
+            None => {
+                create_rest_table(
+                    &catalog,
+                    &namespace,
+                    &table_ident,
+                    table_root_uri.clone(),
+                    &prepared.iceberg_schema,
+                    prepared.partition_spec.clone(),
+                )
+                .await?
+            }
+        },
+        config::WriteMode::Overwrite => {
+            if existing_table.is_some() {
+                catalog
+                    .drop_table(&table_ident)
+                    .await
+                    .map_err(map_iceberg_err("rest catalog drop_table failed"))?;
+            }
+            create_rest_table(
+                &catalog,
+                &namespace,
+                &table_ident,
+                table_root_uri.clone(),
+                &prepared.iceberg_schema,
+                prepared.partition_spec.clone(),
+            )
+            .await?
+        }
+        config::WriteMode::MergeScd1 | config::WriteMode::MergeScd2 => {
+            return Err(Box::new(RunError(format!(
+                "entity.name={} sink.write_mode={} is only supported for delta accepted sinks",
+                entity.name,
+                mode.as_str()
+            ))));
+        }
+    };
+
+    let mut file_paths = Vec::new();
+    let mut file_sizes = Vec::new();
+    let mut files_written = 0_u64;
+    let mut table_after_write = table;
+    let mut perf = crate::io::format::AcceptedWritePerfBreakdown::default();
+
+    if prepared.batch.num_rows() > 0 {
+        let data_write_start = Instant::now();
+        let data_files = write_data_files(&table_after_write, prepared.batch).await?;
+        perf.data_write_ms = Some(data_write_start.elapsed().as_millis() as u64);
+        files_written = data_files.len() as u64;
+        file_sizes = data_files
+            .iter()
+            .map(iceberg::spec::DataFile::file_size_in_bytes)
+            .collect();
+        file_paths = data_files
+            .iter()
+            .map(|file| {
+                let file_path = file.file_path().to_string();
+                std::path::Path::new(file_path.as_str())
+                    .file_name()
+                    .and_then(|name| name.to_str())
+                    .map(ToOwned::to_owned)
+                    .unwrap_or(file_path)
+            })
+            .take(50)
+            .collect();
+
+        let tx = Transaction::new(&table_after_write);
+        let action = tx.fast_append().add_data_files(data_files);
+        let tx = action.apply(tx).map_err(map_iceberg_err(
+            "rest iceberg append transaction apply failed",
+        ))?;
+        let commit_start = Instant::now();
+        table_after_write = tx
+            .commit(&catalog)
+            .await
+            .map_err(map_iceberg_err("rest iceberg commit failed"))?;
+        perf.commit_ms = Some(commit_start.elapsed().as_millis() as u64);
+    }
+
+    let snapshot_id = table_after_write
+        .metadata()
+        .current_snapshot()
+        .map(|snapshot| snapshot.snapshot_id());
+    let metadata_version = table_after_write
+        .metadata_location()
+        .and_then(parse_metadata_version_from_location);
+
+    let metrics_start = Instant::now();
+    let metrics = super::super::metrics::summarize_written_file_sizes(
+        &file_sizes,
+        files_written,
+        small_file_threshold_bytes,
+    );
+    perf.metrics_read_ms = Some(metrics_start.elapsed().as_millis() as u64);
+
+    Ok(IcebergWriteResult {
+        files_written,
+        snapshot_id,
+        metadata_version,
+        file_paths,
+        metrics,
+        table_root_uri,
+        iceberg_catalog_name: Some(rest_cfg.catalog_name.clone()),
+        iceberg_database: None,
+        iceberg_namespace: Some(rest_cfg.namespace.clone()),
+        iceberg_table: Some(rest_cfg.table.clone()),
+        perf,
+    })
+}
+
+async fn ensure_rest_namespace(
+    catalog: &iceberg_catalog_rest::RestCatalog,
+    namespace: &NamespaceIdent,
+) -> FloeResult<()> {
+    let exists = catalog
+        .namespace_exists(namespace)
+        .await
+        .map_err(map_iceberg_err(
+            "rest catalog namespace_exists check failed",
+        ))?;
+    if !exists {
+        catalog
+            .create_namespace(namespace, HashMap::new())
+            .await
+            .map_err(map_iceberg_err("rest catalog namespace create failed"))?;
+    }
+    Ok(())
+}
+
+async fn create_rest_table(
+    catalog: &iceberg_catalog_rest::RestCatalog,
+    namespace: &NamespaceIdent,
+    table_ident: &TableIdent,
+    table_root: String,
+    schema: &iceberg::spec::Schema,
+    partition_spec: Option<UnboundPartitionSpec>,
+) -> FloeResult<iceberg::table::Table> {
+    use iceberg::TableCreation;
+
+    let creation_builder = TableCreation::builder()
+        .name(table_ident.name().to_string())
+        .location(table_root)
+        .schema(schema.clone());
+    let creation = match partition_spec {
+        Some(partition_spec) => creation_builder.partition_spec(partition_spec).build(),
+        None => creation_builder.build(),
+    };
+    catalog
+        .create_table(namespace, creation)
+        .await
+        .map_err(map_iceberg_err("rest catalog create_table failed"))
+}

--- a/crates/floe-core/src/io/write/iceberg/rest.rs
+++ b/crates/floe-core/src/io/write/iceberg/rest.rs
@@ -18,7 +18,7 @@ use super::data_files::write_data_files;
 use super::metadata::parse_metadata_version_from_location;
 use super::{map_iceberg_err, IcebergWriteResult, PreparedIcebergWrite};
 
-/// Build a REST catalog from the given config, table root URI, and file I/O props.
+/// Build a REST catalog from the given config and file I/O props.
 ///
 /// Credential routing:
 ///  - `"token:<value>"` → `"token"` property (bearer PAT: Unity Catalog, Nessie)
@@ -26,7 +26,6 @@ use super::{map_iceberg_err, IcebergWriteResult, PreparedIcebergWrite};
 ///  - anything else → raw `"credential"` property
 pub(crate) async fn build_rest_catalog(
     rest_cfg: &RestIcebergCatalogConfig,
-    table_root_uri: &str,
     file_io_props: HashMap<String, String>,
 ) -> FloeResult<iceberg_catalog_rest::RestCatalog> {
     let mut props: HashMap<String, String> = file_io_props;
@@ -38,12 +37,8 @@ pub(crate) async fn build_rest_catalog(
             REST_CATALOG_PROP_WAREHOUSE.to_string(),
             warehouse.to_string(),
         );
-    } else {
-        // Fall back to the table root URI as the warehouse hint.
-        props.insert(
-            REST_CATALOG_PROP_WAREHOUSE.to_string(),
-            table_root_uri.to_string(),
-        );
+        // When warehouse is not configured, omit the property so the REST server
+        // uses its own default warehouse rather than receiving an arbitrary path.
     }
 
     if let Some(credential) = rest_cfg.credential.as_deref() {
@@ -129,7 +124,7 @@ pub(crate) async fn write_via_rest_catalog(
     mode: config::WriteMode,
     small_file_threshold_bytes: u64,
 ) -> FloeResult<IcebergWriteResult> {
-    let catalog = build_rest_catalog(rest_cfg, &table_root_uri, file_io_props).await?;
+    let catalog = build_rest_catalog(rest_cfg, file_io_props).await?;
 
     let namespace_name = rest_cfg.namespace.clone();
     let namespace = NamespaceIdent::new(namespace_name);

--- a/crates/floe-core/src/runner/outcome.rs
+++ b/crates/floe-core/src/runner/outcome.rs
@@ -66,7 +66,7 @@ impl ConnectorRunStatus {
 /// is not a recognized value.
 ///
 /// # Example
-/// ```
+/// ```no_run
 /// use floe_core::runner::parse_run_status_from_logs;
 /// use floe_core::report::RunStatus;
 ///

--- a/crates/floe-core/tests/integration/iceberg_run.rs
+++ b/crates/floe-core/tests/integration/iceberg_run.rs
@@ -210,6 +210,7 @@ fn load_local_iceberg_table(
             )) as Box<dyn std::error::Error + Send + Sync>
         })?;
         let catalog = MemoryCatalogBuilder::default()
+            .with_storage_factory(std::sync::Arc::new(iceberg::io::LocalFsStorageFactory))
             .load(
                 "floe_test",
                 HashMap::from([(

--- a/crates/floe-core/tests/unit/io/write/iceberg_write.rs
+++ b/crates/floe-core/tests/unit/io/write/iceberg_write.rs
@@ -575,6 +575,7 @@ async fn load_table(table_path: &Path) -> FloeResult<iceberg::table::Table> {
         )) as Box<dyn std::error::Error + Send + Sync>
     })?;
     let catalog = MemoryCatalogBuilder::default()
+        .with_storage_factory(std::sync::Arc::new(iceberg::io::LocalFsStorageFactory))
         .load(
             "floe_test",
             HashMap::from([(


### PR DESCRIPTION
$(cat <<'EOF'
Closes #258. Clean rewrite of the REST catalog feature (replaces the closed PR #282).

## What changed vs the previous attempt

The old PR accumulated 10+ review comments across 6 patch commits because of three root causes:
- Duplicated props-building logic between write and seed paths (same bug appeared twice)
- Missing knowledge of `iceberg-catalog-rest` 0.9.x internals (StorageFactory, token vs credential)
- Validation not updated for the new catalog type

This rewrite addresses all three from the start.

## Design decisions

**Single shared builder.** `build_rest_catalog` in `rest.rs` is the sole place that builds a `RestCatalog`. `seed_from_rest` in `unique_seed/iceberg.rs` imports and calls it directly — no duplication.

**Credential routing** (baked in, not patched in later):
| Config prefix | Property set | Auth flow |
|---|---|---|
| `token:<value>` | `"token"` | Bearer PAT (Unity, Nessie) |
| `client_credentials:<id>:<secret>` | `"credential"` (prefix stripped) | OAuth2 (Polaris, Snowflake) |
| bare value | `"credential"` | Raw OAuth2 fallback |

**Validation** — Glue-only S3/GCS accepted-storage check:
- Glue: accepted storage must be s3 or gcs
- REST without `warehouse_storage`: accepted storage can be local (Nessie/dev), s3, or gcs
- REST with `warehouse_storage`: skip accepted-storage check entirely; `warehouse_storage` must be s3 or gcs

**Namespace fallback** — always `"default"` for REST, never the warehouse value.

## Example config

```yaml
catalogs:
  definitions:
    # Unity Catalog (bearer token)
    - name: unity_iceberg
      type: rest
      uri: https://<host>/api/2.1/unity-catalog/iceberg
      credential: "token:<pat>"
      warehouse: "my_catalog.my_schema"

    # Snowflake Polaris (OAuth2)
    - name: snowflake_main
      type: rest
      uri: https://<account>.snowflakecomputing.com/polaris/api/catalog
      credential: "client_credentials:<client_id>:<client_secret>"
      oauth2_server_uri: https://<account>.snowflakecomputing.com/oauth/token
      scope: "PRINCIPAL_ROLE:ALL"
      warehouse: "my_catalog"

    # Nessie (local dev, no cloud storage needed)
    - name: nessie_local
      type: rest
      uri: http://localhost:19120/api/v1
      warehouse: "my_warehouse"
```

## Test plan

- [x] `cargo fmt` — no diffs
- [x] `cargo clippy -- -D warnings` — clean
- [x] `cargo test -p floe-core --test unit -- unit::config` — 130/130 pass
- [ ] Integration: point at a running Polaris/Nessie instance to confirm end-to-end write

https://claude.ai/code/session_014HWTzh9ZVUBToR1YegqgUQ
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_014HWTzh9ZVUBToR1YegqgUQ)_