### PR TITLE
chore(release): prepare v0.3.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 All notable changes to Floe are documented in this file.
 
+## v0.3.8
+
+- Delta Lake + Unity Catalog registration:
+  - new `unity` catalog type — after writing a Delta table to cloud storage, Floe
+    optionally registers (or confirms) it as an EXTERNAL DELTA table in Databricks
+    Unity Catalog via the REST API (`POST /api/2.1/unity-catalog/tables`).
+  - existing-table safety: location mismatch and missing `storage_location`
+    (managed table / view collision) are returned as explicit errors.
+  - ADLS: `abfs://` URIs are normalised to `abfss://` before registration.
+  - new `sink.accepted.delta` block: `catalog`, `schema`, `table` overrides.
+  - `create_schema_if_missing` flag on the catalog definition.
+  - Validation: `sink.accepted.delta` rejected on non-delta formats; Unity type
+    rejected for Iceberg sinks; local storage rejected for Unity targets.
+  - Three new report fields: `delta_catalog_name`, `delta_catalog_schema`,
+    `delta_catalog_table`.
+  - `token` supports `${ENV_VAR}` substitution.
+
 ## v0.3.7
 
 - Windows binary now distributed via [Scoop](https://github.com/malon64/scoop-floe): `scoop bucket add floe https://github.com/malon64/scoop-floe` then `scoop install floe`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ All notable changes to Floe are documented in this file.
     rejected for Iceberg sinks; local storage rejected for Unity targets.
   - Three new report fields: `delta_catalog_name`, `delta_catalog_schema`,
     `delta_catalog_table`.
-  - `token` supports `${ENV_VAR}` substitution.
+  - `token` accepts a literal PAT or a single `${ENV_VAR}` reference resolved from the OS environment at run time.
 
 ## v0.3.7
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3380,7 +3380,7 @@ dependencies = [
 
 [[package]]
 name = "floe-cli"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "assert_cmd",
  "clap",
@@ -3393,7 +3393,7 @@ dependencies = [
 
 [[package]]
 name = "floe-core"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "apache-avro 0.16.0",
  "arrow",

--- a/README.md
+++ b/README.md
@@ -2,14 +2,11 @@
 
 # Floe
 
-**Floe** is a single-node, YAML-driven data ingestion framework written in Rust.  
-You describe your data contract in a config file; Floe reads raw files, enforces your schema and quality rules, and writes clean accepted rows to your sink — routing invalid rows to a separate rejected output.
+**Floe** is a single-node, YAML-driven data ingestion framework written in Rust. You describe your data contract in a config file; Floe reads raw files, enforces your schema and quality rules, and writes clean rows to your sink — routing invalid rows to a separate rejected output.
 
-## Architecture
+## How it works
 
 ![Floe architecture](docs/assets/architecture.png)
-
-> Save the architecture diagram as `docs/assets/architecture.png` to render this image.
 
 Each `floe run` executes a four-stage pipeline per entity:
 
@@ -18,64 +15,22 @@ Each `floe run` executes a four-stage pipeline per entity:
 | **1. Resolve inputs** | Discover and download source files from local or cloud storage |
 | **2. File-level checks** | Validate schema structure, file format, and headers |
 | **3. Row-level checks** | Apply type casting and `not_null` checks row by row |
-| **4. Entity-level checks** | Apply `unique` / primary-key checks across all input rows plus existing accepted data (SCD-aware) |
+| **4. Entity-level checks** | Apply `unique` / primary-key checks across all input rows plus existing accepted data |
 
-Rows that pass all checks go to the **accepted** sink. Rows that fail go to the **rejected** sink. The severity policy (`warn` / `reject` / `abort`) controls how failures are handled. A JSON run report is written after every run.
+Rows that pass all checks go to the **accepted** sink. Rows that fail go to the **rejected** sink. A JSON run report is written after every run.
 
-## What Floe solves
+**Inputs:** CSV · TSV · JSON · Parquet · ORC · Avro · XLSX · XML · Fixed-width  
+**Accepted outputs:** Parquet · Delta Lake · Apache Iceberg  
+**Storage:** local · S3 · ADLS · GCS  
+**Catalogs:** AWS Glue · Iceberg REST (Polaris, Nessie, Snowflake) · Databricks Unity Catalog
 
-- **Schema enforcement** — strict or coerce cast modes, column type checking
-- **Data quality** — `not_null`, `unique`, primary-key checks
-- **Clean separation** — accepted and rejected outputs in the same run
-- **Incremental ingestion** — per-entity file-state tracking to skip unchanged files
-- **Auditability** — per-entity and summary JSON reports on every run
-- **Cloud-native paths** — S3, ADLS, GCS sources and sinks via a storage registry
-
-## Minimal config example
-
-```yaml
-version: "0.3"
-report:
-  path: "./reports"
-entities:
-  - name: customer
-    source:
-      format: csv
-      path: ./in/customer
-    sink:
-      accepted:
-        format: parquet
-        path: ./out/accepted/customer
-      rejected:
-        format: csv
-        path: ./out/rejected/customer
-    policy:
-      severity: reject
-    schema:
-      columns:
-        - name: customer_id
-          type: string
-          nullable: false
-          unique: true
-        - name: created_at
-          type: datetime
-          nullable: true
-```
-
-Full example: [example/config.yml](example/config.yml)  
-Config reference: [docs/config.md](docs/config.md)  
-Support matrix: [docs/support-matrix.md](docs/support-matrix.md)
-
-## Quickstart
-
-### Install
+## Install
 
 **macOS / Linux — [Homebrew](https://brew.sh)**
 
 ```bash
 brew tap malon64/floe
 brew install floe
-floe --version
 ```
 
 **Windows — [Scoop](https://scoop.sh)**
@@ -83,141 +38,47 @@ floe --version
 ```bash
 scoop bucket add floe https://github.com/malon64/scoop-floe
 scoop install floe
-floe --version
 ```
 
-Alternatives: download a prebuilt binary from [GitHub Releases](https://github.com/malon64/floe/releases) or `cargo install floe-cli`.
-
-Full installation guide: [docs/installation.md](docs/installation.md)
-
-### Validate a config
-
-```bash
-floe validate -c example/config.yml
-```
-
-### Run
-
-```bash
-floe run -c example/config.yml
-```
-
-### Run with an environment profile
-
-Use a profile to inject environment-specific values (bucket names, paths, etc.) into `{{VAR}}` placeholders in your config without editing the config itself:
-
-```yaml
-# profiles/prod.yaml
-apiVersion: floe/v1
-kind: EnvironmentProfile
-metadata:
-  name: prod
-variables:
-  BUCKET: my-prod-bucket
-  BASE_PATH: /data/prod
-  # Cross-variable references are supported:
-  OUT_PATH: ${BASE_PATH}/accepted
-```
-
-```bash
-floe run -c config.yml --profile profiles/prod.yaml
-```
-
-Variable priority (highest wins): `env.vars` in config → `env.file` → profile variables.
-
-### Run with Docker
+**Docker**
 
 ```bash
 docker pull ghcr.io/malon64/floe:latest
-docker run --rm -v "$PWD:/work" ghcr.io/malon64/floe:latest run -c /work/example/config.yml
+docker run --rm -v "$PWD:/work" ghcr.io/malon64/floe:latest run -c /work/config.yml
 ```
 
-Cloud credentials are passed via environment variables, not baked into the image.
+Or download a prebuilt binary from [GitHub Releases](https://github.com/malon64/floe/releases), or `cargo install floe-cli`.  
+→ [Full installation guide](docs/installation.md)
 
-More CLI details: [docs/cli.md](docs/cli.md)
+## Quick start
 
-## Sample output
-
-```text
-run id: run-20240501-abc123
-report base: ./reports
-==> entity customer (severity=reject, format=csv)
-  REJECTED customers.csv rows=10 accepted=8 rejected=2 elapsed_ms=12
-Totals: files=1 rows=10 accepted=8 rejected=2
-Overall: rejected (exit_code=0)
-Run summary: ./reports/run_run-20240501-abc123/run.summary.json
+```bash
+floe validate -c config.yml   # validate config and schema
+floe run      -c config.yml   # run the pipeline
 ```
 
-## Severity policy
+→ [Config reference](docs/config.md) · [Example config](example/config.yml)
 
-| Policy | Behaviour |
+## Documentation
+
+| Topic | Doc |
 |---|---|
-| `warn` | Keep all rows, surface violations in the report |
-| `reject` | Route violating rows to rejected sink, keep valid rows |
-| `abort` | Fail the entire entity on first violation |
-
-Checks and policy details: [docs/checks.md](docs/checks.md)
-
-## Incremental ingestion
-
-Set `incremental_mode: file` on an entity to enable file-level state tracking. Floe records
-processed file metadata and skips unchanged files on subsequent runs.
-
-```bash
-floe state inspect -c example/config.yml --entity customer
-floe state reset   -c example/config.yml --entity customer --yes
-```
-
-## Supported formats
-
-**Inputs** (local + S3 / ADLS / GCS):  
-CSV · TSV · JSON (array/ndjson) · Parquet · ORC · Avro · XLSX · XML · Fixed-width
-
-**Accepted outputs:**  
-Parquet · Delta Lake (append, overwrite, merge SCD1/SCD2) · Apache Iceberg
-
-**Rejected outputs:** CSV  
-**Reports:** JSON
-
-Sink details: [docs/sinks/options.md](docs/sinks/options.md) · [Delta](docs/sinks/delta.md) · [Iceberg](docs/sinks/iceberg.md)
-
-## Cloud storage
-
-Define a storage in your config and reference it on source/sink:
-
-```yaml
-storages:
-  definitions:
-    - name: s3_raw
-      type: s3
-      bucket: my-bucket
-      region: eu-west-1
-entities:
-  - name: customer
-    source:
-      storage: s3_raw
-      path: raw/customer/
-```
-
-Storage guides: [S3](docs/storages/s3.md) · [ADLS](docs/storages/adls.md) · [GCS](docs/storages/gcs.md)
-
-## Orchestration
-
-`floe manifest generate` produces a JSON manifest that orchestrators can read to schedule
-entities as individual tasks:
-
-```bash
-floe manifest generate -c config.yml --output manifest.json
-```
-
-Connectors: [dagster-floe](https://github.com/malon64/dagster-floe) · [airflow-floe](https://github.com/malon64/airflow-floe)
-
-## More docs
-
-- [How it works](docs/how-it-works.md)
-- [Checks reference](docs/checks.md)
-- [Reports](docs/report.md)
-- [Full summary](docs/summary.md)
+| Configuration reference | [docs/config.md](docs/config.md) |
+| How it works (deep dive) | [docs/how-it-works.md](docs/how-it-works.md) |
+| Checks (not_null, unique, cast) | [docs/checks.md](docs/checks.md) |
+| Delta sink + Unity Catalog | [docs/sinks/delta.md](docs/sinks/delta.md) |
+| Iceberg sink + Glue / REST | [docs/sinks/iceberg.md](docs/sinks/iceberg.md) |
+| Sink options | [docs/sinks/options.md](docs/sinks/options.md) |
+| Write modes | [docs/write_modes.md](docs/write_modes.md) |
+| S3 storage | [docs/storages/s3.md](docs/storages/s3.md) |
+| ADLS storage | [docs/storages/adls.md](docs/storages/adls.md) |
+| GCS storage | [docs/storages/gcs.md](docs/storages/gcs.md) |
+| Incremental ingestion | [docs/profiles.md](docs/profiles.md) |
+| Run reports | [docs/report.md](docs/report.md) |
+| CLI reference | [docs/cli.md](docs/cli.md) |
+| Orchestration (Dagster / Airflow) | [docs/summary.md](docs/summary.md) |
+| Support matrix | [docs/support-matrix.md](docs/support-matrix.md) |
+| Changelog | [CHANGELOG.md](CHANGELOG.md) |
 
 ## License
 

--- a/crates/floe-cli/Cargo.toml
+++ b/crates/floe-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "floe-cli"
-version = "0.3.7"
+version = "0.3.8"
 edition = "2021"
 description = "CLI for Floe, a YAML-driven technical ingestion tool."
 license = "MIT"
@@ -17,7 +17,7 @@ path = "src/main.rs"
 
 [dependencies]
 clap = { version = "4", features = ["derive"] }
-floe-core = { path = "../floe-core", version = "0.3.7" }
+floe-core = { path = "../floe-core", version = "0.3.8" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 

--- a/crates/floe-core/Cargo.toml
+++ b/crates/floe-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "floe-core"
-version = "0.3.7"
+version = "0.3.8"
 edition = "2021"
 description = "Core library for Floe, a YAML-driven technical ingestion tool."
 license = "MIT"

--- a/crates/floe-core/src/io/write/delta/unity.rs
+++ b/crates/floe-core/src/io/write/delta/unity.rs
@@ -38,7 +38,7 @@ impl UnityCatalogConfig {
                 unity_catalog: catalog.clone(),
                 schema: resolved.schema.clone(),
                 table: resolved.table.clone(),
-                token: token.clone(),
+                token: expand_env_token(token, &resolved.catalog_name)?,
                 create_schema_if_missing: *create_schema_if_missing,
             }),
             // The resolved target is guaranteed to be Unity by validate_delta_catalog_binding.
@@ -49,6 +49,25 @@ impl UnityCatalogConfig {
             )))),
         }
     }
+}
+
+/// Expands a single `${VAR_NAME}` reference in the token string using the OS environment.
+/// The token must be either a literal value or a single `${VAR_NAME}` reference; mixing
+/// literal text and references in one string is not supported.
+fn expand_env_token(token: &str, catalog_name: &str) -> FloeResult<String> {
+    let Some(inner) = token.strip_prefix("${").and_then(|s| s.strip_suffix('}')) else {
+        return Ok(token.to_string());
+    };
+    if inner.is_empty() || inner.contains('{') || inner.contains('}') {
+        return Err(Box::new(RunError(format!(
+            "unity catalog {catalog_name} token has invalid syntax: {token}"
+        ))));
+    }
+    std::env::var(inner).map_err(|_| {
+        Box::new(RunError(format!(
+            "unity catalog {catalog_name} token references env var {inner} which is not set"
+        ))) as Box<dyn std::error::Error + Send + Sync>
+    })
 }
 
 // ---------------------------------------------------------------------------

--- a/docs/config.md
+++ b/docs/config.md
@@ -110,7 +110,7 @@ entities:
         - `host` (required): Databricks workspace URL, e.g. `https://my-workspace.azuredatabricks.net`
         - `catalog` (required): Unity catalog name
         - `schema` (required): default schema name
-        - `token` (required): Personal Access Token; supports `${ENV_VAR}` substitution
+        - `token` (required): Personal Access Token; accepts a literal value or a single `${ENV_VAR}` reference resolved from the OS environment at run time
         - `create_schema_if_missing` (optional, default `false`): create the Unity schema if absent
 - `env` (optional)
   - Enables variable templating for string fields using `{{var}}` syntax.

--- a/docs/config.md
+++ b/docs/config.md
@@ -86,17 +86,32 @@ entities:
   - Defines named storage clients for `source.storage` and `sink.*.storage`.
   - If omitted, `local` is assumed.
 - `catalogs` (optional)
-  - Defines named external catalogs for Iceberg sinks.
-  - Current supported type: `glue` (AWS Glue Data Catalog, S3-backed tables).
+  - Defines named external catalogs for Iceberg and Delta sinks.
+  - Supported types: `glue`, `rest`, `unity`.
   - Keys:
-    - `default` (optional): default catalog name used by `sink.accepted.iceberg.catalog` when omitted.
+    - `default` (optional): default catalog name used by `sink.accepted.iceberg.catalog` or `sink.accepted.delta.catalog` when omitted.
     - `definitions` (required): array of catalog definitions.
       - `name` (required)
-      - `type` (required): `glue`
-      - `region` (required for `glue`)
-      - `database` (required for `glue`)
-      - `warehouse_storage` (optional, `glue`): storage name (must resolve to S3)
-      - `warehouse_prefix` (optional, `glue`): prefix used for deterministic table locations
+      - `type` (required): `glue`, `rest`, or `unity`
+      - **`glue`** — AWS Glue Data Catalog (Iceberg, S3-backed):
+        - `region` (required)
+        - `database` (required)
+        - `warehouse_storage` (optional): storage name, must resolve to S3
+        - `warehouse_prefix` (optional): prefix for deterministic table locations
+      - **`rest`** — Iceberg REST catalog (Unity Catalog Iceberg endpoint, Polaris, Nessie, Snowflake Open Catalog, etc.):
+        - `uri` (required): REST catalog base URI
+        - `credential` (optional): `token:<pat>` or `client_credentials:<id>:<secret>`
+        - `warehouse` (optional): warehouse/prefix hint forwarded to the REST catalog
+        - `oauth2_server_uri` (optional): override OAuth2 server URL for client-credentials flow
+        - `scope` (optional): OAuth2 scope
+        - `warehouse_storage` (optional): storage name for table location resolution
+        - `warehouse_prefix` (optional): prefix for deterministic table locations
+      - **`unity`** — Databricks Unity Catalog (Delta Lake external table registration):
+        - `host` (required): Databricks workspace URL, e.g. `https://my-workspace.azuredatabricks.net`
+        - `catalog` (required): Unity catalog name
+        - `schema` (required): default schema name
+        - `token` (required): Personal Access Token; supports `${ENV_VAR}` substitution
+        - `create_schema_if_missing` (optional, default `false`): create the Unity schema if absent
 - `env` (optional)
   - Enables variable templating for string fields using `{{var}}` syntax.
   - `env.file` (optional) loads variables from a YAML file (path relative to the
@@ -232,7 +247,8 @@ is available for templating within that entity.
   - Applies to both accepted and rejected outputs.
 - `accepted` (required)
   - `format`: `parquet`, `delta`, or `iceberg`.
-    - `iceberg`: local/S3/GCS filesystem-catalog sink, with optional AWS Glue catalog registration for S3-backed tables; append/overwrite supported; no schema evolution.
+    - `delta`: Delta Lake transactional sink; optional Unity Catalog registration via `sink.accepted.delta`.
+    - `iceberg`: local/S3/GCS filesystem-catalog sink, with optional AWS Glue or REST catalog registration; append/overwrite supported; no schema evolution.
 - `path`: output directory for accepted records.
   - Supports `{{var}}` templating (see "Templating & domains").
   - `storage` (optional)
@@ -277,18 +293,26 @@ is available for templating within that entity.
   - `iceberg` (optional, `sink.accepted.format: iceberg`)
     - Enables Iceberg catalog-specific options.
     - `catalog` (optional)
-      - Catalog name from `catalogs.definitions`.
+      - Catalog name from `catalogs.definitions` (type `glue` or `rest`).
       - If omitted, `catalogs.default` is used when set.
-      - When set (or defaulted), current implementation uses AWS Glue catalog semantics and requires S3 storage.
     - `namespace` (optional)
       - Iceberg namespace identifier reported with the run.
-      - Defaults to `entity.domain` when present, otherwise the catalog `database`.
+      - Defaults to `entity.domain` when present, otherwise the catalog `database` / REST warehouse value.
     - `table` (optional)
       - Logical table name for the catalog registration.
-      - Defaults to `entity.name` (sanitized/lowercased for Glue compatibility).
+      - Defaults to `entity.name` (normalized).
     - `location` (optional)
       - Overrides the Iceberg table root location.
       - Resolved via `warehouse_storage` when defined, otherwise via the sink storage.
+  - `delta` (optional, `sink.accepted.format: delta`)
+    - Enables Unity Catalog registration after the Delta write.
+    - `catalog` (optional)
+      - Catalog name from `catalogs.definitions` (must be type `unity`).
+      - If omitted, `catalogs.default` is used when set.
+    - `schema` (optional)
+      - Unity schema identifier. Defaults to `entity.domain` (normalized), then the catalog-level `schema`.
+    - `table` (optional)
+      - Unity table name. Defaults to `entity.name` (normalized).
   - Accepted output reports may include file sizing metrics (`files_written`,
     `total_bytes_written`, `avg_file_size_mb`, `small_files_count`) when collected by the writer.
     - Parquet: populated from written parquet files.

--- a/docs/sinks/delta.md
+++ b/docs/sinks/delta.md
@@ -114,9 +114,10 @@ catalogs:
       create_schema_if_missing: false  # create the schema if it does not exist yet
 ```
 
-`token` supports `${ENV_VAR}` substitution via Floe's variable templating. The
-PAT is sent only as a `Bearer` authorization header and is never written to
-reports or logs.
+`token` accepts a literal PAT or a single `${ENV_VAR}` reference (e.g.
+`token: "${DATABRICKS_TOKEN}"`), which is resolved from the OS environment at
+run time. The PAT is sent only as a `Bearer` authorization header and is never
+written to reports or logs.
 
 ### Entity config
 

--- a/docs/sinks/delta.md
+++ b/docs/sinks/delta.md
@@ -94,6 +94,81 @@ GCS notes:
 - Authentication uses Application Default Credentials via
   `GOOGLE_APPLICATION_CREDENTIALS`.
 
+## Unity Catalog registration (Databricks)
+
+After writing a Delta table to cloud storage, Floe can register (or confirm) it
+as an EXTERNAL DELTA table in Databricks Unity Catalog via the REST API.
+
+### Catalog definition
+
+```yaml
+catalogs:
+  default: "databricks"          # optional — omit if using per-entity override
+  definitions:
+    - name: "databricks"
+      type: "unity"
+      host: "https://my-workspace.azuredatabricks.net"
+      catalog: "my_catalog"      # Unity catalog name
+      schema: "my_schema"        # default schema (overridable per entity)
+      token: "${DATABRICKS_TOKEN}"
+      create_schema_if_missing: false  # create the schema if it does not exist yet
+```
+
+`token` supports `${ENV_VAR}` substitution via Floe's variable templating. The
+PAT is sent only as a `Bearer` authorization header and is never written to
+reports or logs.
+
+### Entity config
+
+```yaml
+entities:
+  - name: orders
+    domain: "sales"
+    sink:
+      write_mode: append
+      accepted:
+        format: delta
+        storage: s3_out
+        path: warehouse/orders
+        delta:
+          catalog: "databricks"  # optional if catalogs.default is set
+          schema: "sales_ops"    # optional; defaults to entity.domain → catalog schema
+          table: "orders_v2"     # optional; defaults to entity.name (normalized)
+```
+
+### Registration logic
+
+1. `GET /api/2.1/unity-catalog/tables/<catalog>.<schema>.<table>` — if the
+   table already exists its `storage_location` is compared to the current write
+   target. A location mismatch (stale config or name collision) is returned as
+   an error. An absent `storage_location` (managed table / view collision) is
+   also an error.
+2. `404` → optionally create the schema (`create_schema_if_missing: true`), then
+   `POST /api/2.1/unity-catalog/tables` with `table_type: EXTERNAL` and
+   `data_source_format: DELTA`.
+3. Any other HTTP status is propagated as a run error.
+
+### ADLS note
+
+Floe normalises `abfs://` storage URIs to `abfss://` before passing them to
+Unity Catalog, matching the secure scheme Databricks external locations expect.
+
+### Validation
+
+- `sink.accepted.delta` is rejected unless `sink.accepted.format: delta`.
+- Only `unity` catalog type is accepted for `sink.accepted.delta.catalog`
+  (Glue and REST catalog types are for Iceberg only).
+- Unity Catalog registration requires cloud-backed storage (S3, GCS, or ADLS);
+  local storage raises a validation error.
+
+### Report fields
+
+Successful registration populates three additional fields in the entity report
+`accepted_output`:
+- `delta_catalog_name` — catalog definition name (e.g. `"databricks"`)
+- `delta_catalog_schema` — resolved schema identifier
+- `delta_catalog_table` — resolved table identifier
+
 Operational note:
 - Floe writes data and reports write-time metrics. Table optimization/maintenance
   (for example `OPTIMIZE`/compaction and `VACUUM`) should run as separate jobs.


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Bump `floe-core` and `floe-cli` from `0.3.7` → `0.3.8` and update `Cargo.lock`
- Add v0.3.8 entry to `CHANGELOG.md` (Unity Catalog registration for Delta Lake)
- **docs/config.md**: expand `catalogs` section with `rest` and `unity` types; add `sink.accepted.delta` block reference; update `format: delta` description
- **docs/sinks/delta.md**: new Unity Catalog section covering catalog definition, entity config YAML, registration logic, ADLS `abfss://` note, validation rules, and report fields
- **README**: trimmed to architecture overview + install + doc index — detail moved to `docs/` pages

## Merging + releasing

After merging, push the tag to trigger the release pipeline:

```bash
git tag v0.3.8 <merge-commit-sha>
git push origin v0.3.8
```

## Test plan

- [ ] CI passes (clippy + tests)
- [ ] `cargo install floe-cli` from the published crate resolves `0.3.8`
- [ ] GitHub Release created with binaries for all platforms
- [ ] Homebrew formula and Scoop manifest updated automatically by the release workflow

https://claude.ai/code/session_014HWTzh9ZVUBToR1YegqgUQ
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_014HWTzh9ZVUBToR1YegqgUQ)_