### PR TITLE
feat(lineage): OpenLineage integration (#262)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6620,6 +6620,7 @@ dependencies = [
  "base64 0.22.1",
  "bytes",
  "encoding_rs",
+ "futures-channel",
  "futures-core",
  "futures-util",
  "h2 0.4.13",

--- a/crates/floe-cli/src/logging.rs
+++ b/crates/floe-cli/src/logging.rs
@@ -1,5 +1,5 @@
 use clap::ValueEnum;
-use floe_core::{set_observer, RunEvent, RunObserver};
+use floe_core::{RunEvent, RunObserver};
 use std::io::Write;
 use std::sync::Arc;
 
@@ -10,14 +10,14 @@ pub enum LogFormat {
     Json,
 }
 
-pub fn install_observer(format: LogFormat) {
+pub fn build_log_observer(format: LogFormat) -> Option<Arc<dyn RunObserver>> {
     if matches!(format, LogFormat::Off) {
-        return;
+        return None;
     }
-    let _ = set_observer(Arc::new(CliObserver {
+    Some(Arc::new(CliObserver {
         format,
         lock: std::sync::Mutex::new(()),
-    }));
+    }))
 }
 
 struct CliObserver {

--- a/crates/floe-cli/src/logging.rs
+++ b/crates/floe-cli/src/logging.rs
@@ -70,7 +70,14 @@ fn now_ms() -> u128 {
 }
 
 pub fn emit_failed_run_events(run_id: &str, err: &(dyn std::error::Error + 'static)) {
-    let observer = floe_core::run::events::default_observer();
+    emit_failed_run_events_to(floe_core::run::events::default_observer(), run_id, err);
+}
+
+pub fn emit_failed_run_events_to(
+    observer: &dyn floe_core::RunObserver,
+    run_id: &str,
+    err: &(dyn std::error::Error + 'static),
+) {
     observer.on_event(RunEvent::Log {
         run_id: run_id.to_string(),
         log_level: "error".to_string(),

--- a/crates/floe-cli/src/logging.rs
+++ b/crates/floe-cli/src/logging.rs
@@ -20,6 +20,30 @@ pub fn build_log_observer(format: LogFormat) -> Option<Arc<dyn RunObserver>> {
     }))
 }
 
+/// A minimal observer that forwards warn/error Log events to stderr.
+/// Used when a lineage observer is active but no log observer is configured,
+/// so that lineage HTTP errors (401, timeouts) are not silently dropped.
+struct StderrWarnObserver;
+
+impl RunObserver for StderrWarnObserver {
+    fn on_event(&self, event: RunEvent) {
+        if let RunEvent::Log {
+            log_level,
+            message,
+            ..
+        } = event
+        {
+            if log_level == "warn" || log_level == "error" {
+                eprintln!("{log_level}: {message}");
+            }
+        }
+    }
+}
+
+pub fn build_warn_sink() -> Arc<dyn RunObserver> {
+    Arc::new(StderrWarnObserver)
+}
+
 struct CliObserver {
     format: LogFormat,
     lock: std::sync::Mutex<()>,

--- a/crates/floe-cli/src/logging.rs
+++ b/crates/floe-cli/src/logging.rs
@@ -69,15 +69,7 @@ fn now_ms() -> u128 {
         .unwrap_or(0)
 }
 
-pub fn emit_failed_run_events(
-    run_id: &str,
-    err: &(dyn std::error::Error + 'static),
-    log_format: &LogFormat,
-) {
-    if matches!(log_format, LogFormat::Off) {
-        return;
-    }
-
+pub fn emit_failed_run_events(run_id: &str, err: &(dyn std::error::Error + 'static)) {
     let observer = floe_core::run::events::default_observer();
     observer.on_event(RunEvent::Log {
         run_id: run_id.to_string(),

--- a/crates/floe-cli/src/logging.rs
+++ b/crates/floe-cli/src/logging.rs
@@ -28,9 +28,7 @@ struct StderrWarnObserver;
 impl RunObserver for StderrWarnObserver {
     fn on_event(&self, event: RunEvent) {
         if let RunEvent::Log {
-            log_level,
-            message,
-            ..
+            log_level, message, ..
         } = event
         {
             if log_level == "warn" || log_level == "error" {

--- a/crates/floe-cli/src/main.rs
+++ b/crates/floe-cli/src/main.rs
@@ -1,9 +1,9 @@
 use clap::{Parser, Subcommand, ValueEnum};
 use floe_core::{
-    add_entity_to_config, build_common_manifest_json, inspect_entity_state_with_base,
+    add_entity_to_config, build_common_manifest_json, inspect_entity_state_with_base, load_config,
     load_config_with_profile_overrides, parse_profile, reset_entity_state_with_base,
-    resolve_config_location, run_with_base, validate_profile, validate_with_base, AddEntityOptions,
-    FloeResult, RunOptions, ValidateOptions,
+    resolve_config_location, run_with_base, set_observer, validate_profile, validate_with_base,
+    AddEntityOptions, FloeResult, MultiObserver, RunOptions, ValidateOptions,
 };
 use std::io::Write;
 
@@ -423,7 +423,6 @@ fn main() -> FloeResult<()> {
                 dry_run,
                 profile: profile_config,
             };
-            logging::install_observer(log_format.clone());
 
             let config_location = match resolve_config_location(&config) {
                 Ok(location) => location,
@@ -435,6 +434,34 @@ fn main() -> FloeResult<()> {
                     std::process::exit(1);
                 }
             };
+
+            // Load config early to check for lineage block so we can install
+            // a composed observer before run_with_base.
+            let early_config = load_config(&config_location.path);
+            let lineage_observer = early_config
+                .as_ref()
+                .ok()
+                .and_then(|c| c.lineage.as_ref())
+                .and_then(
+                    |lineage_cfg| match floe_core::lineage::build_observer(lineage_cfg) {
+                        Ok(obs) => Some(obs),
+                        Err(err) => {
+                            eprintln!("Warning: lineage observer disabled: {err}");
+                            None
+                        }
+                    },
+                );
+
+            let mut obs_vec = Vec::new();
+            if let Some(log_obs) = logging::build_log_observer(log_format.clone()) {
+                obs_vec.push(log_obs);
+            }
+            if let Some(lin_obs) = lineage_observer {
+                obs_vec.push(lin_obs);
+            }
+            if !obs_vec.is_empty() {
+                let _ = set_observer(std::sync::Arc::new(MultiObserver::new(obs_vec)));
+            }
 
             let outcome =
                 match run_with_base(&config_location.path, config_location.base.clone(), options) {

--- a/crates/floe-cli/src/main.rs
+++ b/crates/floe-cli/src/main.rs
@@ -483,11 +483,19 @@ fn main() -> FloeResult<()> {
 
             // Install the combined observer exactly once.
             let mut obs_vec = Vec::new();
+            let has_log_obs = log_obs.is_some();
             if let Some(log) = log_obs {
                 obs_vec.push(log);
             }
             if let Some(lin) = lineage_observer {
                 obs_vec.push(lin);
+            }
+            // When lineage is active but no log observer (e.g. --log-format off),
+            // the global observer is set to the lineage observer, which ignores
+            // RunEvent::Log. Add a stderr warn sink so that lineage HTTP errors
+            // (401, timeouts) emitted via warnings::emit are not silently dropped.
+            if !has_log_obs && !obs_vec.is_empty() {
+                obs_vec.push(logging::build_warn_sink());
             }
             if !obs_vec.is_empty() {
                 let _ = set_observer(std::sync::Arc::new(MultiObserver::new(obs_vec)));

--- a/crates/floe-cli/src/main.rs
+++ b/crates/floe-cli/src/main.rs
@@ -1,9 +1,10 @@
 use clap::{Parser, Subcommand, ValueEnum};
 use floe_core::{
-    add_entity_to_config, build_common_manifest_json, inspect_entity_state_with_base, load_config,
-    load_config_with_profile_overrides, parse_profile, reset_entity_state_with_base,
-    resolve_config_location, run_with_base, set_observer, validate_profile, validate_with_base,
-    AddEntityOptions, FloeResult, MultiObserver, RunOptions, ValidateOptions,
+    add_entity_to_config, build_common_manifest_json, inspect_entity_state_with_base,
+    load_config_with_profile_overrides, load_config_with_profile_vars, parse_profile,
+    reset_entity_state_with_base, resolve_config_location, run_with_base, set_observer,
+    validate_profile, validate_with_base, AddEntityOptions, FloeResult, MultiObserver, RunOptions,
+    ValidateOptions,
 };
 use std::io::Write;
 
@@ -417,6 +418,12 @@ fn main() -> FloeResult<()> {
                 None
             };
 
+            // Extract profile vars before moving profile_config into RunOptions.
+            let profile_vars_for_lineage = profile_config
+                .as_ref()
+                .map(|p| p.variables.clone())
+                .unwrap_or_default();
+
             let options = RunOptions {
                 run_id: Some(computed_run_id.clone()),
                 entities,
@@ -436,21 +443,23 @@ fn main() -> FloeResult<()> {
             };
 
             // Load config early to check for lineage block so we can install
-            // a composed observer before run_with_base.
-            let early_config = load_config(&config_location.path);
+            // a composed observer before run_with_base. Apply profile vars so
+            // that {{VAR}} placeholders in lineage.url / lineage.api_key are expanded.
+            let early_config =
+                load_config_with_profile_vars(&config_location.path, &profile_vars_for_lineage);
             let lineage_observer = early_config
                 .as_ref()
                 .ok()
-                .and_then(|c| c.lineage.as_ref())
-                .and_then(
-                    |lineage_cfg| match floe_core::lineage::build_observer(lineage_cfg) {
+                .and_then(|c| c.lineage.as_ref().map(|l| (l, c.entities.as_slice())))
+                .and_then(|(lineage_cfg, entities)| {
+                    match floe_core::lineage::build_observer(lineage_cfg, entities) {
                         Ok(obs) => Some(obs),
                         Err(err) => {
                             eprintln!("Warning: lineage observer disabled: {err}");
                             None
                         }
-                    },
-                );
+                    }
+                });
 
             let mut obs_vec = Vec::new();
             if let Some(log_obs) = logging::build_log_observer(log_format.clone()) {

--- a/crates/floe-cli/src/main.rs
+++ b/crates/floe-cli/src/main.rs
@@ -420,6 +420,14 @@ fn main() -> FloeResult<()> {
                 .map(|p| p.variables.clone())
                 .unwrap_or_default();
 
+            // Install the log observer immediately so that any failure before
+            // the lineage observer is built (e.g. config resolution error) still
+            // emits structured events for --log-format json/text.
+            let log_obs = logging::build_log_observer(log_format.clone());
+            if let Some(ref obs) = log_obs {
+                let _ = set_observer(obs.clone());
+            }
+
             let options = RunOptions {
                 run_id: Some(computed_run_id.clone()),
                 entities,
@@ -470,14 +478,14 @@ fn main() -> FloeResult<()> {
                     }
                 });
 
-            let mut obs_vec = Vec::new();
-            if let Some(log_obs) = logging::build_log_observer(log_format.clone()) {
-                obs_vec.push(log_obs);
-            }
+            // If lineage is present, upgrade to a MultiObserver combining both.
+            // Otherwise log_obs is already installed (or noop if --log-format off).
             if let Some(lin_obs) = lineage_observer {
+                let mut obs_vec = Vec::new();
+                if let Some(log) = log_obs {
+                    obs_vec.push(log);
+                }
                 obs_vec.push(lin_obs);
-            }
-            if !obs_vec.is_empty() {
                 let _ = set_observer(std::sync::Arc::new(MultiObserver::new(obs_vec)));
             }
 

--- a/crates/floe-cli/src/main.rs
+++ b/crates/floe-cli/src/main.rs
@@ -3,8 +3,8 @@ use floe_core::{
     add_entity_to_config, build_common_manifest_json, inspect_entity_state_with_base,
     load_config_with_profile_overrides, load_config_with_profile_vars, parse_profile,
     reset_entity_state_with_base, resolve_config_location, run_with_base, set_observer,
-    validate_profile, validate_with_base, AddEntityOptions, FloeResult, MultiObserver, RunOptions,
-    ValidateOptions,
+    validate_profile, validate_with_base, AddEntityOptions, FloeResult, MultiObserver, RunEvent,
+    RunOptions, ValidateOptions,
 };
 use std::io::Write;
 
@@ -505,6 +505,16 @@ fn main() -> FloeResult<()> {
                 match run_with_base(&config_location.path, config_location.base.clone(), options) {
                     Ok(outcome) => outcome,
                     Err(err) => {
+                        // run_with_base may fail before run_with_runtime emits RunStarted
+                        // (e.g. validate_with_base, RunContext construction, validate_entities).
+                        // Emit a paired START so lineage consumers always see a complete
+                        // lifecycle rather than an orphaned FAIL event.
+                        floe_core::run::events::default_observer().on_event(RunEvent::RunStarted {
+                            run_id: computed_run_id.clone(),
+                            config: config_location.path.display().to_string(),
+                            report_base: None,
+                            ts_ms: floe_core::run::events::event_time_ms(),
+                        });
                         logging::emit_failed_run_events(&computed_run_id, err.as_ref());
                         let mut err_out = std::io::stderr().lock();
                         let _ = writeln!(err_out, "Error: {err}");

--- a/crates/floe-cli/src/main.rs
+++ b/crates/floe-cli/src/main.rs
@@ -395,11 +395,7 @@ fn main() -> FloeResult<()> {
                 let parsed = match parse_profile(path) {
                     Ok(p) => p,
                     Err(err) => {
-                        logging::emit_failed_run_events(
-                            &computed_run_id,
-                            err.as_ref(),
-                            &log_format,
-                        );
+                        logging::emit_failed_run_events(&computed_run_id, err.as_ref());
                         let mut err_out = std::io::stderr().lock();
                         let _ = writeln!(err_out, "Error: {err}");
                         let _ = err_out.flush();
@@ -407,7 +403,7 @@ fn main() -> FloeResult<()> {
                     }
                 };
                 if let Err(err) = validate_profile(&parsed) {
-                    logging::emit_failed_run_events(&computed_run_id, err.as_ref(), &log_format);
+                    logging::emit_failed_run_events(&computed_run_id, err.as_ref());
                     let mut err_out = std::io::stderr().lock();
                     let _ = writeln!(err_out, "Error: {err}");
                     let _ = err_out.flush();
@@ -434,7 +430,7 @@ fn main() -> FloeResult<()> {
             let config_location = match resolve_config_location(&config) {
                 Ok(location) => location,
                 Err(err) => {
-                    logging::emit_failed_run_events(&computed_run_id, err.as_ref(), &log_format);
+                    logging::emit_failed_run_events(&computed_run_id, err.as_ref());
                     let mut err_out = std::io::stderr().lock();
                     let _ = writeln!(err_out, "Error: {err}");
                     let _ = err_out.flush();
@@ -476,11 +472,7 @@ fn main() -> FloeResult<()> {
                 match run_with_base(&config_location.path, config_location.base.clone(), options) {
                     Ok(outcome) => outcome,
                     Err(err) => {
-                        logging::emit_failed_run_events(
-                            &computed_run_id,
-                            err.as_ref(),
-                            &log_format,
-                        );
+                        logging::emit_failed_run_events(&computed_run_id, err.as_ref());
                         let mut err_out = std::io::stderr().lock();
                         let _ = writeln!(err_out, "Error: {err}");
                         let _ = err_out.flush();

--- a/crates/floe-cli/src/main.rs
+++ b/crates/floe-cli/src/main.rs
@@ -505,16 +505,21 @@ fn main() -> FloeResult<()> {
                 match run_with_base(&config_location.path, config_location.base.clone(), options) {
                     Ok(outcome) => outcome,
                     Err(err) => {
-                        // run_with_base may fail before run_with_runtime emits RunStarted
-                        // (e.g. validate_with_base, RunContext construction, validate_entities).
-                        // Emit a paired START so lineage consumers always see a complete
-                        // lifecycle rather than an orphaned FAIL event.
-                        floe_core::run::events::default_observer().on_event(RunEvent::RunStarted {
-                            run_id: computed_run_id.clone(),
-                            config: config_location.path.display().to_string(),
-                            report_base: None,
-                            ts_ms: floe_core::run::events::event_time_ms(),
-                        });
+                        // Only emit RunStarted if run_with_runtime did not already emit it
+                        // (e.g. failures during validate_with_base, RunContext construction,
+                        // or validate_entities happen before the core runner reaches that point).
+                        // Errors after RunStarted — such as resolve_entity_plans — must not
+                        // produce a duplicate START for the same run id.
+                        if !floe_core::run::events::is_run_started() {
+                            floe_core::run::events::default_observer().on_event(
+                                RunEvent::RunStarted {
+                                    run_id: computed_run_id.clone(),
+                                    config: config_location.path.display().to_string(),
+                                    report_base: None,
+                                    ts_ms: floe_core::run::events::event_time_ms(),
+                                },
+                            );
+                        }
                         logging::emit_failed_run_events(&computed_run_id, err.as_ref());
                         let mut err_out = std::io::stderr().lock();
                         let _ = writeln!(err_out, "Error: {err}");

--- a/crates/floe-cli/src/main.rs
+++ b/crates/floe-cli/src/main.rs
@@ -420,13 +420,9 @@ fn main() -> FloeResult<()> {
                 .map(|p| p.variables.clone())
                 .unwrap_or_default();
 
-            // Install the log observer immediately so that any failure before
-            // the lineage observer is built (e.g. config resolution error) still
-            // emits structured events for --log-format json/text.
+            // Build log observer early (before set_observer) so early failure
+            // paths can emit directly to it without going through the global observer.
             let log_obs = logging::build_log_observer(log_format.clone());
-            if let Some(ref obs) = log_obs {
-                let _ = set_observer(obs.clone());
-            }
 
             let options = RunOptions {
                 run_id: Some(computed_run_id.clone()),
@@ -438,7 +434,14 @@ fn main() -> FloeResult<()> {
             let config_location = match resolve_config_location(&config) {
                 Ok(location) => location,
                 Err(err) => {
-                    logging::emit_failed_run_events(&computed_run_id, err.as_ref());
+                    // set_observer not called yet; emit directly to log_obs.
+                    if let Some(ref obs) = log_obs {
+                        logging::emit_failed_run_events_to(
+                            obs.as_ref(),
+                            &computed_run_id,
+                            err.as_ref(),
+                        );
+                    }
                     let mut err_out = std::io::stderr().lock();
                     let _ = writeln!(err_out, "Error: {err}");
                     let _ = err_out.flush();
@@ -478,14 +481,15 @@ fn main() -> FloeResult<()> {
                     }
                 });
 
-            // If lineage is present, upgrade to a MultiObserver combining both.
-            // Otherwise log_obs is already installed (or noop if --log-format off).
-            if let Some(lin_obs) = lineage_observer {
-                let mut obs_vec = Vec::new();
-                if let Some(log) = log_obs {
-                    obs_vec.push(log);
-                }
-                obs_vec.push(lin_obs);
+            // Install the combined observer exactly once.
+            let mut obs_vec = Vec::new();
+            if let Some(log) = log_obs {
+                obs_vec.push(log);
+            }
+            if let Some(lin) = lineage_observer {
+                obs_vec.push(lin);
+            }
+            if !obs_vec.is_empty() {
                 let _ = set_observer(std::sync::Arc::new(MultiObserver::new(obs_vec)));
             }
 

--- a/crates/floe-cli/src/main.rs
+++ b/crates/floe-cli/src/main.rs
@@ -438,6 +438,19 @@ fn main() -> FloeResult<()> {
                 }
             };
 
+            // Resolve inter-variable references (e.g. "${HOST}/api") using the
+            // same resolve_vars path the runner uses, now that we have config_location.
+            let profile_vars_for_lineage = {
+                let config_env_vars =
+                    floe_core::extract_config_env_vars(&config_location.path).unwrap_or_default();
+                floe_core::resolve_vars(floe_core::VarSources {
+                    profile: &profile_vars_for_lineage,
+                    cli: &std::collections::HashMap::new(),
+                    config: &config_env_vars,
+                })
+                .unwrap_or(profile_vars_for_lineage)
+            };
+
             // Load config early to check for lineage block so we can install
             // a composed observer before run_with_base. Apply profile vars so
             // that {{VAR}} placeholders in lineage.url / lineage.api_key are expanded.

--- a/crates/floe-core/Cargo.toml
+++ b/crates/floe-core/Cargo.toml
@@ -45,7 +45,7 @@ iceberg-storage-opendal = { version = "0.9.1", features = ["opendal-gcs"] }
 df-interchange = { version = "0.3.2", features = ["arrow_57", "polars_0_52"] }
 orc-rust = "0.7.1"
 
-reqwest = { version = "0.12", default-features = true, features = ["native-tls-vendored", "json"] }
+reqwest = { version = "0.12", default-features = true, features = ["native-tls-vendored", "json", "blocking"] }
 sha2 = "0.10"
 hex = "0.4"
 

--- a/crates/floe-core/src/config/parse.rs
+++ b/crates/floe-core/src/config/parse.rs
@@ -13,9 +13,10 @@ use crate::config::yaml_decode::{
 use crate::config::{
     ArchiveTarget, CatalogDefinition, CatalogTypeConfig, CatalogsConfig, ColumnConfig,
     DomainConfig, EntityConfig, EntityMetadata, EntityStateConfig, EnvConfig,
-    IcebergPartitionFieldConfig, IcebergSinkTargetConfig, IncrementalMode, MergeOptionsConfig,
-    MergeScd2OptionsConfig, NormalizeColumnsConfig, PiiColumnConfig, PiiConfig, PiiStrategy,
-    PolicyConfig, ProjectMetadata, ReportConfig, RootConfig, SchemaConfig, SchemaEvolutionConfig,
+    IcebergPartitionFieldConfig, IcebergSinkTargetConfig, IncrementalMode, LineageConfig,
+    MergeOptionsConfig, MergeScd2OptionsConfig, NormalizeColumnsConfig, PiiColumnConfig,
+    PiiConfig, PiiStrategy, PolicyConfig, ProjectMetadata, ReportConfig, RootConfig, SchemaConfig,
+    SchemaEvolutionConfig,
     SchemaEvolutionIncompatibleAction, SchemaEvolutionMode, SchemaMismatchConfig, SinkConfig,
     SinkOptions, SinkTarget, SourceConfig, SourceOptions, StorageDefinition, StoragesConfig,
     WriteMode,
@@ -116,6 +117,7 @@ fn parse_root(doc: &Yaml) -> FloeResult<RootConfig> {
             "env",
             "domains",
             "report",
+            "lineage",
             "entities",
         ],
     )?;
@@ -159,6 +161,10 @@ fn parse_root(doc: &Yaml) -> FloeResult<RootConfig> {
             storage: None,
         }),
     };
+    let lineage = match hash_get(root, "lineage") {
+        Some(value) => Some(parse_lineage_config(value)?),
+        None => None,
+    };
     let entities_yaml = get_array(root, "entities", "root")?;
     let mut entities = Vec::with_capacity(entities_yaml.len());
     for (index, entity_yaml) in entities_yaml.iter().enumerate() {
@@ -181,6 +187,7 @@ fn parse_root(doc: &Yaml) -> FloeResult<RootConfig> {
         env,
         domains,
         report,
+        lineage,
         entities,
     })
 }
@@ -1097,5 +1104,21 @@ fn parse_pii_column(value: &Yaml) -> FloeResult<PiiColumnConfig> {
         strategy,
         mask_pattern: opt_string(hash, "mask_pattern", "pii.columns")?,
         redact_value: opt_string(hash, "redact_value", "pii.columns")?,
+    })
+}
+
+fn parse_lineage_config(value: &Yaml) -> FloeResult<LineageConfig> {
+    let hash = yaml_hash(value, "lineage")?;
+    validate_known_keys(
+        hash,
+        "lineage",
+        &["url", "api_key", "timeout_secs", "namespace", "producer"],
+    )?;
+    Ok(LineageConfig {
+        url: get_string(hash, "url", "lineage")?,
+        api_key: opt_string(hash, "api_key", "lineage")?,
+        timeout_secs: opt_u64(hash, "timeout_secs", "lineage")?,
+        namespace: get_string(hash, "namespace", "lineage")?,
+        producer: opt_string(hash, "producer", "lineage")?,
     })
 }

--- a/crates/floe-core/src/config/parse.rs
+++ b/crates/floe-core/src/config/parse.rs
@@ -14,12 +14,11 @@ use crate::config::{
     ArchiveTarget, CatalogDefinition, CatalogTypeConfig, CatalogsConfig, ColumnConfig,
     DomainConfig, EntityConfig, EntityMetadata, EntityStateConfig, EnvConfig,
     IcebergPartitionFieldConfig, IcebergSinkTargetConfig, IncrementalMode, LineageConfig,
-    MergeOptionsConfig, MergeScd2OptionsConfig, NormalizeColumnsConfig, PiiColumnConfig,
-    PiiConfig, PiiStrategy, PolicyConfig, ProjectMetadata, ReportConfig, RootConfig, SchemaConfig,
-    SchemaEvolutionConfig,
-    SchemaEvolutionIncompatibleAction, SchemaEvolutionMode, SchemaMismatchConfig, SinkConfig,
-    SinkOptions, SinkTarget, SourceConfig, SourceOptions, StorageDefinition, StoragesConfig,
-    WriteMode,
+    MergeOptionsConfig, MergeScd2OptionsConfig, NormalizeColumnsConfig, PiiColumnConfig, PiiConfig,
+    PiiStrategy, PolicyConfig, ProjectMetadata, ReportConfig, RootConfig, SchemaConfig,
+    SchemaEvolutionConfig, SchemaEvolutionIncompatibleAction, SchemaEvolutionMode,
+    SchemaMismatchConfig, SinkConfig, SinkOptions, SinkTarget, SourceConfig, SourceOptions,
+    StorageDefinition, StoragesConfig, WriteMode,
 };
 use crate::{ConfigError, FloeResult};
 

--- a/crates/floe-core/src/config/template.rs
+++ b/crates/floe-core/src/config/template.rs
@@ -34,6 +34,13 @@ pub fn apply_templates_with_vars(
         report.path = replace_placeholders(&report.path, &vars, "report.path", None)?;
     }
 
+    if let Some(lineage) = config.lineage.as_mut() {
+        lineage.url = replace_placeholders(&lineage.url, &vars, "lineage.url", None)?;
+        if let Some(api_key) = lineage.api_key.as_mut() {
+            *api_key = replace_placeholders(api_key, &vars, "lineage.api_key", None)?;
+        }
+    }
+
     if let Some(storages) = config.storages.as_mut() {
         for definition in storages.definitions.iter_mut() {
             if let Some(prefix) = definition.prefix.as_mut() {

--- a/crates/floe-core/src/config/types.rs
+++ b/crates/floe-core/src/config/types.rs
@@ -17,7 +17,17 @@ pub struct RootConfig {
     pub env: Option<EnvConfig>,
     pub domains: Vec<DomainConfig>,
     pub report: Option<ReportConfig>,
+    pub lineage: Option<LineageConfig>,
     pub entities: Vec<EntityConfig>,
+}
+
+#[derive(Debug, Clone)]
+pub struct LineageConfig {
+    pub url: String,
+    pub api_key: Option<String>,
+    pub timeout_secs: Option<u64>,
+    pub namespace: String,
+    pub producer: Option<String>,
 }
 
 #[derive(Debug)]

--- a/crates/floe-core/src/config/validate.rs
+++ b/crates/floe-core/src/config/validate.rs
@@ -74,6 +74,9 @@ pub(crate) fn validate_config(config: &RootConfig) -> FloeResult<()> {
     if let Some(report) = &config.report {
         validate_report(report, &storage_registry)?;
     }
+    if let Some(lineage) = &config.lineage {
+        validate_lineage(lineage)?;
+    }
 
     let mut names = HashSet::new();
     for entity in &config.entities {
@@ -86,6 +89,20 @@ pub(crate) fn validate_config(config: &RootConfig) -> FloeResult<()> {
         }
     }
 
+    Ok(())
+}
+
+fn validate_lineage(lineage: &crate::config::LineageConfig) -> FloeResult<()> {
+    if lineage.url.trim().is_empty() {
+        return Err(Box::new(ConfigError(
+            "lineage.url must not be empty".to_string(),
+        )));
+    }
+    if lineage.namespace.trim().is_empty() {
+        return Err(Box::new(ConfigError(
+            "lineage.namespace must not be empty".to_string(),
+        )));
+    }
     Ok(())
 }
 

--- a/crates/floe-core/src/lib.rs
+++ b/crates/floe-core/src/lib.rs
@@ -5,6 +5,7 @@ pub mod checks;
 pub mod config;
 pub mod errors;
 pub mod io;
+pub mod lineage;
 pub(crate) mod log;
 pub mod manifest;
 pub mod profile;
@@ -26,7 +27,7 @@ pub use profile::{
     detect_malformed_placeholder, detect_unresolved_placeholders, parse_profile,
     parse_profile_from_str, validate_merged_vars, validate_profile, ProfileConfig,
 };
-pub use run::events::{set_observer, RunEvent, RunObserver};
+pub use run::events::{set_observer, MultiObserver, RunEvent, RunObserver};
 pub use run::{run, run_with_base, DryRunEntityPreview, EntityOutcome, RunOutcome};
 pub use runner::{parse_run_status_from_logs, ConnectorRunStatus};
 pub use runtime::{DefaultRuntime, Runtime};

--- a/crates/floe-core/src/lib.rs
+++ b/crates/floe-core/src/lib.rs
@@ -75,6 +75,13 @@ pub fn load_config(config_path: &Path) -> FloeResult<config::RootConfig> {
     config::parse_config(config_path)
 }
 
+pub fn load_config_with_profile_vars(
+    config_path: &Path,
+    profile_vars: &std::collections::HashMap<String, String>,
+) -> FloeResult<config::RootConfig> {
+    config::parse_config_with_vars(config_path, profile_vars)
+}
+
 pub fn load_config_with_profile_overrides(
     config_path: &Path,
     profile_vars: &std::collections::HashMap<String, String>,

--- a/crates/floe-core/src/lineage/mod.rs
+++ b/crates/floe-core/src/lineage/mod.rs
@@ -232,10 +232,29 @@ fn ms_to_iso8601(ms: u128) -> String {
 impl RunObserver for OpenLineageObserver {
     fn on_event(&self, event: RunEvent) {
         match event {
-            RunEvent::RunStarted { ts_ms, .. } => {
+            RunEvent::RunStarted { run_id, ts_ms, .. } => {
                 if let Ok(mut guard) = self.run_start_ms.lock() {
                     *guard = Some(ts_ms);
                 }
+                let event_time = ms_to_iso8601(ts_ms);
+                let body = json!({
+                    "eventType": "START",
+                    "eventTime": event_time,
+                    "run": {
+                        "runId": run_id,
+                        "facets": {}
+                    },
+                    "job": {
+                        "namespace": self.config.namespace,
+                        "name": run_id,
+                        "facets": {}
+                    },
+                    "inputs": [],
+                    "outputs": [],
+                    "producer": self.producer(),
+                    "schemaURL": "https://openlineage.io/spec/1-0-5/OpenLineage.json#/$defs/RunEvent"
+                });
+                self.post_event(body);
             }
             RunEvent::EntityStarted {
                 run_id,

--- a/crates/floe-core/src/lineage/mod.rs
+++ b/crates/floe-core/src/lineage/mod.rs
@@ -4,18 +4,20 @@ use std::time::Duration;
 
 use serde_json::{json, Value};
 
-use crate::config::LineageConfig;
+use crate::config::{EntityConfig, LineageConfig};
 use crate::run::events::{RunEvent, RunObserver};
 
 pub struct OpenLineageObserver {
     client: reqwest::blocking::Client,
     config: LineageConfig,
     entity_start_ms: Mutex<HashMap<String, u128>>,
+    entity_run_ids: Mutex<HashMap<String, String>>,
     run_start_ms: Mutex<Option<u128>>,
+    entity_schemas: HashMap<String, Vec<(String, String)>>,
 }
 
 impl OpenLineageObserver {
-    pub fn new(config: &LineageConfig) -> crate::FloeResult<Self> {
+    pub fn new(config: &LineageConfig, entities: &[EntityConfig]) -> crate::FloeResult<Self> {
         let timeout = Duration::from_secs(config.timeout_secs.unwrap_or(5));
         let client = reqwest::blocking::Client::builder()
             .timeout(timeout)
@@ -25,11 +27,27 @@ impl OpenLineageObserver {
                     "lineage: failed to build HTTP client: {e}"
                 ))) as Box<dyn std::error::Error + Send + Sync>
             })?;
+
+        let entity_schemas = entities
+            .iter()
+            .map(|e| {
+                let fields: Vec<(String, String)> = e
+                    .schema
+                    .columns
+                    .iter()
+                    .map(|c| (c.name.clone(), c.column_type.clone()))
+                    .collect();
+                (e.name.clone(), fields)
+            })
+            .collect();
+
         Ok(Self {
             client,
             config: config.clone(),
             entity_start_ms: Mutex::new(HashMap::new()),
+            entity_run_ids: Mutex::new(HashMap::new()),
             run_start_ms: Mutex::new(None),
+            entity_schemas,
         })
     }
 
@@ -39,14 +57,27 @@ impl OpenLineageObserver {
         if let Some(api_key) = self.config.api_key.as_deref() {
             req = req.bearer_auth(api_key);
         }
-        if let Err(e) = req.send() {
-            crate::warnings::emit(
-                "",
-                None,
-                None,
-                Some("lineage_http_error"),
-                &format!("lineage: POST {url} failed: {e}"),
-            );
+        match req.send() {
+            Err(e) => {
+                crate::warnings::emit(
+                    "",
+                    None,
+                    None,
+                    Some("lineage_http_error"),
+                    &format!("lineage: POST {url} failed: {e}"),
+                );
+            }
+            Ok(resp) => {
+                if let Err(e) = resp.error_for_status() {
+                    crate::warnings::emit(
+                        "",
+                        None,
+                        None,
+                        Some("lineage_http_error"),
+                        &format!("lineage: POST {url} returned error status: {e}"),
+                    );
+                }
+            }
         }
     }
 
@@ -93,35 +124,42 @@ impl OpenLineageObserver {
 
     fn emit_entity_run_event(
         &self,
-        run_id: &str,
+        entity_run_id: &str,
         name: &str,
         event_type: &str,
         ts_ms: u128,
         stats: Option<EntityStats>,
     ) {
         let event_time = ms_to_iso8601(ts_ms);
-        let job_name = format!("{}.{}", run_id, name);
+        let job_name = format!("{}.{name}", self.config.namespace);
 
         let mut run_facets = json!({});
         if let Some(parent) = self.parent_run_facet() {
             run_facets["parent"] = parent;
         }
 
-        let mut facets = json!({});
-        if let Some(ref s) = stats {
-            facets["dataQualityMetrics"] = json!({
+        // Build inputs with all facets for COMPLETE events; empty for START.
+        let inputs = if let Some(ref s) = stats {
+            let rejection_rate = if s.rows > 0 {
+                s.rejected as f64 / s.rows as f64
+            } else {
+                0.0
+            };
+            let schema_facet = json!({
+                "fields": s.schema_fields.iter().map(|(col_name, col_type)| {
+                    json!({ "name": col_name, "type": col_type })
+                }).collect::<Vec<_>>(),
+                "_producer": self.producer(),
+                "_schemaURL": "https://openlineage.io/spec/facets/1-1-1/SchemaDatasetFacet.json"
+            });
+            let dq_facet = json!({
                 "rowCount": s.rows,
                 "validCount": s.accepted,
                 "invalidCount": s.rejected,
                 "_producer": self.producer(),
                 "_schemaURL": "https://openlineage.io/spec/facets/1-0-2/DataQualityMetricsInputDatasetFacet.json"
             });
-            let rejection_rate = if s.rows > 0 {
-                s.rejected as f64 / s.rows as f64
-            } else {
-                0.0
-            };
-            facets["floeQualityRun"] = json!({
+            let floe_facet = json!({
                 "entity": name,
                 "rejectionRate": rejection_rate,
                 "files": s.files,
@@ -133,13 +171,24 @@ impl OpenLineageObserver {
                 "_producer": self.producer(),
                 "_schemaURL": "https://github.com/malon64/floe/schemas/FloeQualityRunFacet.json"
             });
-        }
+            json!([{
+                "namespace": self.config.namespace,
+                "name": name,
+                "facets": {
+                    "schema": schema_facet,
+                    "dataQualityMetrics": dq_facet,
+                    "floeQualityRun": floe_facet
+                }
+            }])
+        } else {
+            json!([])
+        };
 
         let body = json!({
             "eventType": event_type,
             "eventTime": event_time,
             "run": {
-                "runId": run_id,
+                "runId": entity_run_id,
                 "facets": run_facets
             },
             "job": {
@@ -147,50 +196,12 @@ impl OpenLineageObserver {
                 "name": job_name,
                 "facets": {}
             },
-            "inputs": [],
+            "inputs": inputs,
             "outputs": [],
             "producer": self.producer(),
             "schemaURL": "https://openlineage.io/spec/1-0-5/OpenLineage.json#/$defs/RunEvent"
         });
         self.post_event(body);
-
-        if event_type == "COMPLETE" {
-            if let Some(ref s) = stats {
-                let schema_facet = json!({
-                    "fields": s.schema_fields.iter().map(|(col_name, col_type)| {
-                        json!({ "name": col_name, "type": col_type })
-                    }).collect::<Vec<_>>(),
-                    "_producer": self.producer(),
-                    "_schemaURL": "https://openlineage.io/spec/facets/1-1-1/SchemaDatasetFacet.json"
-                });
-                let complete_body = json!({
-                    "eventType": "COMPLETE",
-                    "eventTime": event_time,
-                    "run": {
-                        "runId": run_id,
-                        "facets": run_facets
-                    },
-                    "job": {
-                        "namespace": self.config.namespace,
-                        "name": job_name,
-                        "facets": {}
-                    },
-                    "inputs": [{
-                        "namespace": self.config.namespace,
-                        "name": name,
-                        "facets": {
-                            "schema": schema_facet,
-                            "dataQualityMetrics": facets.get("dataQualityMetrics").cloned().unwrap_or(json!(null)),
-                            "floeQualityRun": facets.get("floeQualityRun").cloned().unwrap_or(json!(null))
-                        }
-                    }],
-                    "outputs": [],
-                    "producer": self.producer(),
-                    "schemaURL": "https://openlineage.io/spec/1-0-5/OpenLineage.json#/$defs/RunEvent"
-                });
-                self.post_event(complete_body);
-            }
-        }
     }
 }
 
@@ -226,12 +237,21 @@ impl RunObserver for OpenLineageObserver {
                     *guard = Some(ts_ms);
                 }
             }
-            RunEvent::EntityStarted { name, ts_ms, .. } => {
+            RunEvent::EntityStarted {
+                run_id,
+                name,
+                ts_ms,
+            } => {
+                // Use a per-entity run_id (overall_run_id.entity.name) so that
+                // the START and COMPLETE events for the same entity share the same run_id.
+                let entity_run_id = format!("{run_id}.entity.{name}");
                 if let Ok(mut guard) = self.entity_start_ms.lock() {
                     guard.insert(name.clone(), ts_ms);
                 }
-                // emit START event
-                self.emit_entity_run_event(&format!("entity-{name}"), &name, "START", ts_ms, None);
+                if let Ok(mut guard) = self.entity_run_ids.lock() {
+                    guard.insert(name.clone(), entity_run_id.clone());
+                }
+                self.emit_entity_run_event(&entity_run_id, &name, "START", ts_ms, None);
             }
             RunEvent::EntityFinished {
                 run_id,
@@ -245,6 +265,13 @@ impl RunObserver for OpenLineageObserver {
                 ts_ms,
                 ..
             } => {
+                let entity_run_id = self
+                    .entity_run_ids
+                    .lock()
+                    .ok()
+                    .and_then(|g| g.get(&name).cloned())
+                    .unwrap_or_else(|| format!("{run_id}.entity.{name}"));
+                let schema_fields = self.entity_schemas.get(&name).cloned().unwrap_or_default();
                 let stats = EntityStats {
                     files,
                     rows,
@@ -252,9 +279,9 @@ impl RunObserver for OpenLineageObserver {
                     rejected,
                     warnings,
                     errors,
-                    schema_fields: vec![],
+                    schema_fields,
                 };
-                self.emit_entity_run_event(&run_id, &name, "COMPLETE", ts_ms, Some(stats));
+                self.emit_entity_run_event(&entity_run_id, &name, "COMPLETE", ts_ms, Some(stats));
             }
             RunEvent::RunFinished {
                 run_id,
@@ -292,7 +319,10 @@ impl RunObserver for OpenLineageObserver {
     }
 }
 
-pub fn build_observer(config: &LineageConfig) -> crate::FloeResult<Arc<dyn RunObserver>> {
-    let obs = OpenLineageObserver::new(config)?;
+pub fn build_observer(
+    config: &LineageConfig,
+    entities: &[EntityConfig],
+) -> crate::FloeResult<Arc<dyn RunObserver>> {
+    let obs = OpenLineageObserver::new(config, entities)?;
     Ok(Arc::new(obs))
 }

--- a/crates/floe-core/src/lineage/mod.rs
+++ b/crates/floe-core/src/lineage/mod.rs
@@ -256,6 +256,7 @@ impl RunObserver for OpenLineageObserver {
             RunEvent::EntityFinished {
                 run_id,
                 name,
+                status,
                 files,
                 rows,
                 accepted,
@@ -263,7 +264,6 @@ impl RunObserver for OpenLineageObserver {
                 warnings,
                 errors,
                 ts_ms,
-                ..
             } => {
                 let entity_run_id = self
                     .entity_run_ids
@@ -271,6 +271,11 @@ impl RunObserver for OpenLineageObserver {
                     .ok()
                     .and_then(|g| g.get(&name).cloned())
                     .unwrap_or_else(|| format!("{run_id}.entity.{name}"));
+                let event_type = if status == "failed" || status == "aborted" {
+                    "FAIL"
+                } else {
+                    "COMPLETE"
+                };
                 let schema_fields = self.entity_schemas.get(&name).cloned().unwrap_or_default();
                 let stats = EntityStats {
                     files,
@@ -281,7 +286,7 @@ impl RunObserver for OpenLineageObserver {
                     errors,
                     schema_fields,
                 };
-                self.emit_entity_run_event(&entity_run_id, &name, "COMPLETE", ts_ms, Some(stats));
+                self.emit_entity_run_event(&entity_run_id, &name, event_type, ts_ms, Some(stats));
             }
             RunEvent::RunFinished {
                 run_id,

--- a/crates/floe-core/src/lineage/mod.rs
+++ b/crates/floe-core/src/lineage/mod.rs
@@ -1,0 +1,298 @@
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use serde_json::{json, Value};
+
+use crate::config::LineageConfig;
+use crate::run::events::{RunEvent, RunObserver};
+
+pub struct OpenLineageObserver {
+    client: reqwest::blocking::Client,
+    config: LineageConfig,
+    entity_start_ms: Mutex<HashMap<String, u128>>,
+    run_start_ms: Mutex<Option<u128>>,
+}
+
+impl OpenLineageObserver {
+    pub fn new(config: &LineageConfig) -> crate::FloeResult<Self> {
+        let timeout = Duration::from_secs(config.timeout_secs.unwrap_or(5));
+        let client = reqwest::blocking::Client::builder()
+            .timeout(timeout)
+            .build()
+            .map_err(|e| {
+                Box::new(crate::errors::ConfigError(format!(
+                    "lineage: failed to build HTTP client: {e}"
+                ))) as Box<dyn std::error::Error + Send + Sync>
+            })?;
+        Ok(Self {
+            client,
+            config: config.clone(),
+            entity_start_ms: Mutex::new(HashMap::new()),
+            run_start_ms: Mutex::new(None),
+        })
+    }
+
+    fn post_event(&self, body: Value) {
+        let url = format!("{}/api/v1/lineage", self.config.url.trim_end_matches('/'));
+        let mut req = self.client.post(&url).json(&body);
+        if let Some(api_key) = self.config.api_key.as_deref() {
+            req = req.bearer_auth(api_key);
+        }
+        if let Err(e) = req.send() {
+            crate::warnings::emit(
+                "",
+                None,
+                None,
+                Some("lineage_http_error"),
+                &format!("lineage: POST {url} failed: {e}"),
+            );
+        }
+    }
+
+    fn producer(&self) -> &str {
+        self.config
+            .producer
+            .as_deref()
+            .unwrap_or("https://github.com/malon64/floe")
+    }
+
+    fn parent_run_facet(&self) -> Option<Value> {
+        if let Ok(run_id) = std::env::var("AIRFLOW_CTX_DAG_RUN_ID") {
+            let dag = std::env::var("AIRFLOW_CTX_DAG_ID").unwrap_or_default();
+            let task = std::env::var("AIRFLOW_CTX_TASK_ID").unwrap_or_default();
+            let job_name = if task.is_empty() {
+                dag.clone()
+            } else {
+                format!("{dag}.{task}")
+            };
+            return Some(json!({
+                "run": { "runId": run_id },
+                "job": {
+                    "namespace": self.config.namespace,
+                    "name": job_name
+                },
+                "_producer": self.producer(),
+                "_schemaURL": "https://openlineage.io/spec/facets/1-0-0/ParentRunFacet.json"
+            }));
+        }
+        if let Ok(run_id) = std::env::var("DAGSTER_RUN_ID") {
+            let job = std::env::var("DAGSTER_JOB_NAME").unwrap_or_default();
+            return Some(json!({
+                "run": { "runId": run_id },
+                "job": {
+                    "namespace": self.config.namespace,
+                    "name": job
+                },
+                "_producer": self.producer(),
+                "_schemaURL": "https://openlineage.io/spec/facets/1-0-0/ParentRunFacet.json"
+            }));
+        }
+        None
+    }
+
+    fn emit_entity_run_event(
+        &self,
+        run_id: &str,
+        name: &str,
+        event_type: &str,
+        ts_ms: u128,
+        stats: Option<EntityStats>,
+    ) {
+        let event_time = ms_to_iso8601(ts_ms);
+        let job_name = format!("{}.{}", run_id, name);
+
+        let mut run_facets = json!({});
+        if let Some(parent) = self.parent_run_facet() {
+            run_facets["parent"] = parent;
+        }
+
+        let mut facets = json!({});
+        if let Some(ref s) = stats {
+            facets["dataQualityMetrics"] = json!({
+                "rowCount": s.rows,
+                "validCount": s.accepted,
+                "invalidCount": s.rejected,
+                "_producer": self.producer(),
+                "_schemaURL": "https://openlineage.io/spec/facets/1-0-2/DataQualityMetricsInputDatasetFacet.json"
+            });
+            let rejection_rate = if s.rows > 0 {
+                s.rejected as f64 / s.rows as f64
+            } else {
+                0.0
+            };
+            facets["floeQualityRun"] = json!({
+                "entity": name,
+                "rejectionRate": rejection_rate,
+                "files": s.files,
+                "rows": s.rows,
+                "accepted": s.accepted,
+                "rejected": s.rejected,
+                "warnings": s.warnings,
+                "errors": s.errors,
+                "_producer": self.producer(),
+                "_schemaURL": "https://github.com/malon64/floe/schemas/FloeQualityRunFacet.json"
+            });
+        }
+
+        let body = json!({
+            "eventType": event_type,
+            "eventTime": event_time,
+            "run": {
+                "runId": run_id,
+                "facets": run_facets
+            },
+            "job": {
+                "namespace": self.config.namespace,
+                "name": job_name,
+                "facets": {}
+            },
+            "inputs": [],
+            "outputs": [],
+            "producer": self.producer(),
+            "schemaURL": "https://openlineage.io/spec/1-0-5/OpenLineage.json#/$defs/RunEvent"
+        });
+        self.post_event(body);
+
+        if event_type == "COMPLETE" {
+            if let Some(ref s) = stats {
+                let schema_facet = json!({
+                    "fields": s.schema_fields.iter().map(|(col_name, col_type)| {
+                        json!({ "name": col_name, "type": col_type })
+                    }).collect::<Vec<_>>(),
+                    "_producer": self.producer(),
+                    "_schemaURL": "https://openlineage.io/spec/facets/1-1-1/SchemaDatasetFacet.json"
+                });
+                let complete_body = json!({
+                    "eventType": "COMPLETE",
+                    "eventTime": event_time,
+                    "run": {
+                        "runId": run_id,
+                        "facets": run_facets
+                    },
+                    "job": {
+                        "namespace": self.config.namespace,
+                        "name": job_name,
+                        "facets": {}
+                    },
+                    "inputs": [{
+                        "namespace": self.config.namespace,
+                        "name": name,
+                        "facets": {
+                            "schema": schema_facet,
+                            "dataQualityMetrics": facets.get("dataQualityMetrics").cloned().unwrap_or(json!(null)),
+                            "floeQualityRun": facets.get("floeQualityRun").cloned().unwrap_or(json!(null))
+                        }
+                    }],
+                    "outputs": [],
+                    "producer": self.producer(),
+                    "schemaURL": "https://openlineage.io/spec/1-0-5/OpenLineage.json#/$defs/RunEvent"
+                });
+                self.post_event(complete_body);
+            }
+        }
+    }
+}
+
+struct EntityStats {
+    files: u64,
+    rows: u64,
+    accepted: u64,
+    rejected: u64,
+    warnings: u64,
+    errors: u64,
+    schema_fields: Vec<(String, String)>,
+}
+
+fn ms_to_iso8601(ms: u128) -> String {
+    let secs = (ms / 1000) as i64;
+    let nanos = ((ms % 1000) * 1_000_000) as i64;
+    match time::OffsetDateTime::from_unix_timestamp(secs) {
+        Ok(dt) => {
+            let ns = time::Duration::nanoseconds(nanos);
+            let dt = dt.saturating_add(ns);
+            dt.format(&time::format_description::well_known::Rfc3339)
+                .unwrap_or_else(|_| ms.to_string())
+        }
+        Err(_) => ms.to_string(),
+    }
+}
+
+impl RunObserver for OpenLineageObserver {
+    fn on_event(&self, event: RunEvent) {
+        match event {
+            RunEvent::RunStarted { ts_ms, .. } => {
+                if let Ok(mut guard) = self.run_start_ms.lock() {
+                    *guard = Some(ts_ms);
+                }
+            }
+            RunEvent::EntityStarted { name, ts_ms, .. } => {
+                if let Ok(mut guard) = self.entity_start_ms.lock() {
+                    guard.insert(name.clone(), ts_ms);
+                }
+                // emit START event
+                self.emit_entity_run_event(&format!("entity-{name}"), &name, "START", ts_ms, None);
+            }
+            RunEvent::EntityFinished {
+                run_id,
+                name,
+                files,
+                rows,
+                accepted,
+                rejected,
+                warnings,
+                errors,
+                ts_ms,
+                ..
+            } => {
+                let stats = EntityStats {
+                    files,
+                    rows,
+                    accepted,
+                    rejected,
+                    warnings,
+                    errors,
+                    schema_fields: vec![],
+                };
+                self.emit_entity_run_event(&run_id, &name, "COMPLETE", ts_ms, Some(stats));
+            }
+            RunEvent::RunFinished {
+                run_id,
+                status,
+                ts_ms,
+                ..
+            } => {
+                let event_type = if status == "failed" || status == "aborted" {
+                    "FAIL"
+                } else {
+                    "COMPLETE"
+                };
+                let event_time = ms_to_iso8601(ts_ms);
+                let body = json!({
+                    "eventType": event_type,
+                    "eventTime": event_time,
+                    "run": {
+                        "runId": run_id,
+                        "facets": {}
+                    },
+                    "job": {
+                        "namespace": self.config.namespace,
+                        "name": run_id,
+                        "facets": {}
+                    },
+                    "inputs": [],
+                    "outputs": [],
+                    "producer": self.producer(),
+                    "schemaURL": "https://openlineage.io/spec/1-0-5/OpenLineage.json#/$defs/RunEvent"
+                });
+                self.post_event(body);
+            }
+            _ => {}
+        }
+    }
+}
+
+pub fn build_observer(config: &LineageConfig) -> crate::FloeResult<Arc<dyn RunObserver>> {
+    let obs = OpenLineageObserver::new(config)?;
+    Ok(Arc::new(obs))
+}

--- a/crates/floe-core/src/run/events.rs
+++ b/crates/floe-core/src/run/events.rs
@@ -1,3 +1,4 @@
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, OnceLock};
 
 use serde::Serialize;
@@ -108,6 +109,16 @@ impl RunObserver for MultiObserver {
 static NOOP_OBSERVER: NoopObserver = NoopObserver;
 
 static OBSERVER: OnceLock<Arc<dyn RunObserver>> = OnceLock::new();
+
+static RUN_STARTED_EMITTED: AtomicBool = AtomicBool::new(false);
+
+pub fn mark_run_started() {
+    RUN_STARTED_EMITTED.store(true, Ordering::Relaxed);
+}
+
+pub fn is_run_started() -> bool {
+    RUN_STARTED_EMITTED.load(Ordering::Relaxed)
+}
 
 pub fn set_observer(observer: Arc<dyn RunObserver>) -> bool {
     OBSERVER.set(observer).is_ok()

--- a/crates/floe-core/src/run/events.rs
+++ b/crates/floe-core/src/run/events.rs
@@ -87,6 +87,24 @@ impl RunObserver for NoopObserver {
     fn on_event(&self, _event: RunEvent) {}
 }
 
+pub struct MultiObserver {
+    observers: Vec<Arc<dyn RunObserver>>,
+}
+
+impl MultiObserver {
+    pub fn new(observers: Vec<Arc<dyn RunObserver>>) -> Self {
+        Self { observers }
+    }
+}
+
+impl RunObserver for MultiObserver {
+    fn on_event(&self, event: RunEvent) {
+        for obs in &self.observers {
+            obs.on_event(event.clone());
+        }
+    }
+}
+
 static NOOP_OBSERVER: NoopObserver = NoopObserver;
 
 static OBSERVER: OnceLock<Arc<dyn RunObserver>> = OnceLock::new();

--- a/crates/floe-core/src/run/mod.rs
+++ b/crates/floe-core/src/run/mod.rs
@@ -142,6 +142,7 @@ pub fn run_with_runtime(
             report_base: context.report_base_path.clone(),
             ts_ms: event_time_ms(),
         });
+        crate::run::events::mark_run_started();
     }
     let resolve_start = perf_enabled.then(Instant::now);
     let plans = resolve_entity_plans(&context, runtime, &selected_entities, resolution_mode)?;

--- a/crates/floe-core/src/run/mod.rs
+++ b/crates/floe-core/src/run/mod.rs
@@ -170,15 +170,32 @@ pub fn run_with_runtime(
     let mut abort_run = false;
 
     for plan in plans {
+        let entity_name = plan.entity.name.clone();
         observer.on_event(RunEvent::EntityStarted {
             run_id: context.run_id.clone(),
-            name: plan.entity.name.clone(),
+            name: entity_name.clone(),
             ts_ms: event_time_ms(),
         });
+        let entity_result = run_entity(&context, runtime, observer, plan);
+        if let Err(err) = entity_result {
+            observer.on_event(RunEvent::EntityFinished {
+                run_id: context.run_id.clone(),
+                name: entity_name,
+                status: "failed".to_string(),
+                files: 0,
+                rows: 0,
+                accepted: 0,
+                rejected: 0,
+                warnings: 0,
+                errors: 0,
+                ts_ms: event_time_ms(),
+            });
+            return Err(err);
+        }
         let EntityRunResult {
             outcome,
             abort_run: aborted,
-        } = run_entity(&context, runtime, observer, plan)?;
+        } = entity_result.unwrap();
         let report = &outcome.report;
         let (mut status, _) = report::compute_run_outcome(
             &report

--- a/crates/floe-core/tests/unit/config/adls_storage.rs
+++ b/crates/floe-core/tests/unit/config/adls_storage.rs
@@ -11,6 +11,7 @@ fn base_root() -> config::RootConfig {
         env: None,
         domains: Vec::new(),
         report: None,
+        lineage: None,
         entities: Vec::new(),
     }
 }

--- a/crates/floe-core/tests/unit/config/adls_validation.rs
+++ b/crates/floe-core/tests/unit/config/adls_validation.rs
@@ -67,6 +67,7 @@ fn adls_missing_required_fields_errors() {
         env: None,
         domains: Vec::new(),
         report: None,
+        lineage: None,
         entities: vec![base_entity()],
     };
 
@@ -99,6 +100,7 @@ fn adls_referenced_errors_until_implemented() {
         env: None,
         domains: Vec::new(),
         report: None,
+        lineage: None,
         entities: vec![base_entity()],
     };
 

--- a/crates/floe-core/tests/unit/config/catalogs.rs
+++ b/crates/floe-core/tests/unit/config/catalogs.rs
@@ -44,6 +44,7 @@ fn base_root() -> config::RootConfig {
         env: None,
         domains: Vec::new(),
         report: None,
+        lineage: None,
         entities: Vec::new(),
     }
 }
@@ -279,6 +280,7 @@ fn unity_root() -> config::RootConfig {
         env: None,
         domains: Vec::new(),
         report: None,
+        lineage: None,
         entities: Vec::new(),
     }
 }

--- a/crates/floe-core/tests/unit/config/lineage_validation.rs
+++ b/crates/floe-core/tests/unit/config/lineage_validation.rs
@@ -1,0 +1,97 @@
+use floe_core::{validate, ValidateOptions};
+
+use super::super::common::write_temp_config;
+
+fn assert_validation_error(contents: &str, expected_parts: &[&str]) {
+    let path = write_temp_config(contents);
+    let err = validate(&path, ValidateOptions::default()).expect_err("expected error");
+    let message = err.to_string();
+    for part in expected_parts {
+        assert!(
+            message.contains(part),
+            "expected error to contain {part:?}, got: {message}"
+        );
+    }
+}
+
+#[test]
+fn lineage_url_required() {
+    let config = r#"version: "0.1"
+report:
+  path: "/tmp/reports"
+lineage:
+  namespace: "my-ns"
+entities:
+  - name: "orders"
+    source:
+      format: "csv"
+      path: "/tmp/input"
+    sink:
+      accepted:
+        format: "parquet"
+        path: "/tmp/out"
+    policy:
+      severity: "warn"
+    schema:
+      columns:
+        - name: "id"
+          type: "string"
+"#;
+    assert_validation_error(config, &["url"]);
+}
+
+#[test]
+fn lineage_namespace_required() {
+    let config = r#"version: "0.1"
+report:
+  path: "/tmp/reports"
+lineage:
+  url: "http://marquez:5000"
+entities:
+  - name: "orders"
+    source:
+      format: "csv"
+      path: "/tmp/input"
+    sink:
+      accepted:
+        format: "parquet"
+        path: "/tmp/out"
+    policy:
+      severity: "warn"
+    schema:
+      columns:
+        - name: "id"
+          type: "string"
+"#;
+    assert_validation_error(config, &["namespace"]);
+}
+
+#[test]
+fn lineage_valid_config_parses() {
+    let config = r#"version: "0.1"
+report:
+  path: "/tmp/reports"
+lineage:
+  url: "http://marquez:5000"
+  namespace: "my-namespace"
+  timeout_secs: 10
+  producer: "https://github.com/myorg/floe"
+entities:
+  - name: "orders"
+    source:
+      format: "csv"
+      path: "/tmp/input"
+    sink:
+      accepted:
+        format: "parquet"
+        path: "/tmp/out"
+    policy:
+      severity: "warn"
+    schema:
+      columns:
+        - name: "id"
+          type: "string"
+"#;
+    let path = write_temp_config(config);
+    validate(&path, ValidateOptions::default()).expect("valid lineage config");
+}

--- a/crates/floe-core/tests/unit/config/local_storage.rs
+++ b/crates/floe-core/tests/unit/config/local_storage.rs
@@ -24,6 +24,7 @@ fn config_with_default_local() -> RootConfig {
         env: None,
         domains: Vec::new(),
         report: None,
+        lineage: None,
         entities: Vec::new(),
     }
 }

--- a/crates/floe-core/tests/unit/config/mod.rs
+++ b/crates/floe-core/tests/unit/config/mod.rs
@@ -5,6 +5,7 @@ pub mod catalogs;
 pub mod config_validation;
 pub mod gcs_storage;
 pub mod gcs_validation;
+pub mod lineage_validation;
 pub mod local_storage;
 pub mod parse;
 pub mod pii_validation;

--- a/crates/floe-core/tests/unit/config/remote_base.rs
+++ b/crates/floe-core/tests/unit/config/remote_base.rs
@@ -17,6 +17,7 @@ fn base_root(definition: StorageDefinition) -> RootConfig {
         env: None,
         domains: Vec::new(),
         report: None,
+        lineage: None,
         entities: Vec::new(),
     }
 }
@@ -31,6 +32,7 @@ fn local_base_resolves_relative_paths() -> FloeResult<()> {
         env: None,
         domains: Vec::new(),
         report: None,
+        lineage: None,
         entities: Vec::new(),
     };
     let resolver = StorageResolver::from_path(&config, Path::new("/tmp/config.yml"))?;

--- a/crates/floe-core/tests/unit/io/write/delta_write.rs
+++ b/crates/floe-core/tests/unit/io/write/delta_write.rs
@@ -611,6 +611,7 @@ fn empty_root_config() -> config::RootConfig {
         env: None,
         domains: Vec::new(),
         report: None,
+        lineage: None,
         entities: Vec::new(),
     }
 }

--- a/crates/floe-core/tests/unit/io/write/iceberg_write.rs
+++ b/crates/floe-core/tests/unit/io/write/iceberg_write.rs
@@ -416,6 +416,7 @@ fn empty_root_config() -> config::RootConfig {
         env: None,
         domains: Vec::new(),
         report: None,
+        lineage: None,
         entities: Vec::new(),
     }
 }

--- a/crates/floe-core/tests/unit/io/write/object_store.rs
+++ b/crates/floe-core/tests/unit/io/write/object_store.rs
@@ -26,6 +26,7 @@ fn sample_config() -> config::RootConfig {
         env: None,
         domains: Vec::new(),
         report: None,
+        lineage: None,
         entities: Vec::new(),
     }
 }
@@ -171,6 +172,7 @@ fn delta_store_config_builds_local_url() -> FloeResult<()> {
         env: None,
         domains: Vec::new(),
         report: None,
+        lineage: None,
         entities: Vec::new(),
     };
     let temp_dir = tempfile::TempDir::new()?;
@@ -236,6 +238,7 @@ fn iceberg_store_config_builds_local_warehouse_without_props() -> FloeResult<()>
         env: None,
         domains: Vec::new(),
         report: None,
+        lineage: None,
         entities: Vec::new(),
     };
     let temp_dir = tempfile::TempDir::new()?;
@@ -313,6 +316,7 @@ fn delta_store_config_builds_adls_url_and_options() -> FloeResult<()> {
         env: None,
         domains: Vec::new(),
         report: None,
+        lineage: None,
         entities: Vec::new(),
     };
     let resolver =
@@ -406,6 +410,7 @@ fn iceberg_store_config_builds_gcs_warehouse_without_props() -> FloeResult<()> {
         env: None,
         domains: Vec::new(),
         report: None,
+        lineage: None,
         entities: Vec::new(),
     };
     let resolver =
@@ -486,6 +491,7 @@ fn iceberg_store_config_rejects_adls_target() -> FloeResult<()> {
         env: None,
         domains: Vec::new(),
         report: None,
+        lineage: None,
         entities: Vec::new(),
     };
     let resolver =
@@ -562,6 +568,7 @@ fn delta_store_config_builds_gcs_url() -> FloeResult<()> {
         env: None,
         domains: Vec::new(),
         report: None,
+        lineage: None,
         entities: Vec::new(),
     };
     let resolver =

--- a/crates/floe-core/tests/unit/io/write/rejected_csv.rs
+++ b/crates/floe-core/tests/unit/io/write/rejected_csv.rs
@@ -72,6 +72,7 @@ fn sample_resolver(config_path: &Path) -> FloeResult<config::StorageResolver> {
         env: None,
         domains: Vec::new(),
         report: None,
+        lineage: None,
         entities: Vec::new(),
     };
     config::StorageResolver::from_path(&root_config, config_path)

--- a/crates/floe-core/tests/unit/report/storage.rs
+++ b/crates/floe-core/tests/unit/report/storage.rs
@@ -18,6 +18,7 @@ fn build_config(definition: StorageDefinition, report: ReportConfig) -> RootConf
         env: None,
         domains: Vec::new(),
         report: Some(report),
+        lineage: None,
         entities: Vec::new(),
     }
 }
@@ -133,6 +134,7 @@ fn local_report_paths_and_uris_are_normalized() {
             formatter: None,
             storage: None,
         }),
+        lineage: None,
         entities: Vec::new(),
     };
     let resolver = resolver_for(&config);


### PR DESCRIPTION
## Summary

- Adds optional `lineage:` top-level config block that posts run/entity lifecycle events to any OpenLineage-compatible HTTP endpoint (Marquez, etc.)
- Emits four facets per entity: `DataQualityMetrics`, `FloeQualityRun`, `SchemaDataset`, and `ParentRun` (auto-detected from Airflow/Dagster env vars)
- Fail-silent: HTTP errors are emitted as warnings; the run continues unaffected
- Bearer auth via `api_key` field (supports `{{VAR}}` placeholder expansion)
- `MultiObserver` added so CLI logging and lineage observers can coexist

## Config shape

```yaml
lineage:
  url: "http://marquez:5000"
  namespace: "my-floe-namespace"
  api_key: "{{OPENLINEAGE_API_KEY}}"   # optional
  timeout_secs: 5                       # optional, default 5
  producer: "https://github.com/myorg/floe"  # optional
```

## Test plan

- [x] `lineage_url_required` — missing `url` → ConfigError
- [x] `lineage_namespace_required` — missing `namespace` → ConfigError
- [x] `lineage_valid_config_parses` — full valid config parses without error
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo test -p floe-core --test unit` — 444 passed, 0 failed

Closes #262

https://claude.ai/code/session_014HWTzh9ZVUBToR1YegqgUQ

---
_Generated by [Claude Code](https://claude.ai/code/session_014HWTzh9ZVUBToR1YegqgUQ)_