### PR TITLE
Harden profile validation and catalog overrides

### DIFF
--- a/crates/floe-cli/src/main.rs
+++ b/crates/floe-cli/src/main.rs
@@ -1,9 +1,9 @@
 use clap::{Parser, Subcommand, ValueEnum};
 use floe_core::{
-    add_entity_to_config, build_common_manifest_json, inspect_entity_state_with_base, load_config,
-    parse_profile, reset_entity_state_with_base, resolve_config_location, run_with_base,
-    validate_profile, validate_with_base, AddEntityOptions, FloeResult, RunOptions,
-    ValidateOptions,
+    add_entity_to_config, build_common_manifest_json, inspect_entity_state_with_base,
+    load_config_with_profile_overrides, parse_profile, reset_entity_state_with_base,
+    resolve_config_location, run_with_base, validate_profile, validate_with_base, AddEntityOptions,
+    FloeResult, RunOptions, ValidateOptions,
 };
 use std::io::Write;
 
@@ -295,7 +295,8 @@ fn main() -> FloeResult<()> {
                     }
                     None => {
                         exit_with_error(Box::new(floe_core::ConfigError(
-                            "floe validate requires --config unless --profile is provided".to_string(),
+                            "floe validate requires --config unless --profile is provided"
+                                .to_string(),
                         )));
                     }
                 }
@@ -323,7 +324,7 @@ fn main() -> FloeResult<()> {
 
             let options = ValidateOptions {
                 entities: entities.clone(),
-                profile_vars,
+                profile_vars: profile_vars.clone(),
                 profile_catalogs: parsed_profile
                     .as_ref()
                     .and_then(|profile| profile.catalogs.clone()),
@@ -334,7 +335,13 @@ fn main() -> FloeResult<()> {
 
             match validation_result {
                 Ok(()) => {
-                    let config = load_config(&config_location.path)?;
+                    let config = load_config_with_profile_overrides(
+                        &config_location.path,
+                        &profile_vars,
+                        parsed_profile
+                            .as_ref()
+                            .and_then(|profile| profile.catalogs.as_ref()),
+                    )?;
                     println!("Config valid: {}", config_location.display);
                     println!("Version: {}", config.version);
                     println!(
@@ -499,9 +506,24 @@ fn main() -> FloeResult<()> {
                     None
                 };
 
+                let profile_vars = if let Some(ref parsed) = profile_config {
+                    let config_env_vars = floe_core::extract_config_env_vars(&config_location.path)
+                        .unwrap_or_default();
+                    match floe_core::resolve_vars(floe_core::VarSources {
+                        profile: &parsed.variables,
+                        cli: &std::collections::HashMap::new(),
+                        config: &config_env_vars,
+                    }) {
+                        Ok(vars) => vars,
+                        Err(err) => exit_with_error(err),
+                    }
+                } else {
+                    std::collections::HashMap::new()
+                };
+
                 let options = ValidateOptions {
                     entities: entities.clone(),
-                    profile_vars: std::collections::HashMap::new(),
+                    profile_vars: profile_vars.clone(),
                     profile_catalogs: profile_config
                         .as_ref()
                         .and_then(|profile| profile.catalogs.clone()),
@@ -512,7 +534,13 @@ fn main() -> FloeResult<()> {
                     exit_with_error(err);
                 }
 
-                let config = load_config(&config_location.path)?;
+                let config = load_config_with_profile_overrides(
+                    &config_location.path,
+                    &profile_vars,
+                    profile_config
+                        .as_ref()
+                        .and_then(|profile| profile.catalogs.as_ref()),
+                )?;
                 let manifest_json = build_common_manifest_json(
                     &config_location,
                     &config,

--- a/crates/floe-cli/src/main.rs
+++ b/crates/floe-cli/src/main.rs
@@ -114,7 +114,7 @@ enum Command {
     #[command(about = "Validate a config file", long_about = VALIDATE_LONG_ABOUT)]
     Validate {
         #[arg(short, long, help = "Path or URI to the Floe config file")]
-        config: String,
+        config: Option<String>,
         #[arg(
             long,
             value_delimiter = ',',
@@ -263,33 +263,50 @@ fn main() -> FloeResult<()> {
             entities,
             profile,
         } => {
-            let config_location = match resolve_config_location(&config) {
-                Ok(location) => location,
-                Err(err) => {
-                    let mut err_out = std::io::stderr().lock();
-                    let _ = writeln!(err_out, "Error: {err}");
-                    let _ = err_out.flush();
-                    std::process::exit(1);
-                }
-            };
-
-            let profile_vars = if let Some(ref profile_path) = profile {
+            let parsed_profile = if let Some(ref profile_path) = profile {
                 let path = std::path::Path::new(profile_path);
                 let parsed = match parse_profile(path) {
                     Ok(p) => p,
-                    Err(err) => {
-                        let mut err_out = std::io::stderr().lock();
-                        let _ = writeln!(err_out, "Error: {err}");
-                        let _ = err_out.flush();
-                        std::process::exit(1);
-                    }
+                    Err(err) => exit_with_error(err),
                 };
                 if let Err(err) = validate_profile(&parsed) {
-                    let mut err_out = std::io::stderr().lock();
-                    let _ = writeln!(err_out, "Error: {err}");
-                    let _ = err_out.flush();
-                    std::process::exit(1);
+                    exit_with_error(err);
                 }
+                Some(parsed)
+            } else {
+                None
+            };
+
+            let Some(config) = config else {
+                match parsed_profile {
+                    Some(profile) => {
+                        println!("Profile valid: {}", profile.metadata.name);
+                        println!("Schema: {}/{}", profile.api_version, profile.kind);
+                        println!(
+                            "Catalogs: {}",
+                            profile
+                                .catalogs
+                                .as_ref()
+                                .map(|catalogs| catalogs.definitions.len())
+                                .unwrap_or(0)
+                        );
+                        let _ = std::io::stdout().lock().flush();
+                        return Ok(());
+                    }
+                    None => {
+                        exit_with_error(Box::new(floe_core::ConfigError(
+                            "floe validate requires --config unless --profile is provided".to_string(),
+                        )));
+                    }
+                }
+            };
+
+            let config_location = match resolve_config_location(&config) {
+                Ok(location) => location,
+                Err(err) => exit_with_error(err),
+            };
+
+            let profile_vars = if let Some(ref parsed) = parsed_profile {
                 let config_env_vars =
                     floe_core::extract_config_env_vars(&config_location.path).unwrap_or_default();
                 match floe_core::resolve_vars(floe_core::VarSources {
@@ -298,12 +315,7 @@ fn main() -> FloeResult<()> {
                     config: &config_env_vars,
                 }) {
                     Ok(vars) => vars,
-                    Err(err) => {
-                        let mut err_out = std::io::stderr().lock();
-                        let _ = writeln!(err_out, "Error: {err}");
-                        let _ = err_out.flush();
-                        std::process::exit(1);
-                    }
+                    Err(err) => exit_with_error(err),
                 }
             } else {
                 std::collections::HashMap::new()
@@ -312,6 +324,9 @@ fn main() -> FloeResult<()> {
             let options = ValidateOptions {
                 entities: entities.clone(),
                 profile_vars,
+                profile_catalogs: parsed_profile
+                    .as_ref()
+                    .and_then(|profile| profile.catalogs.clone()),
             };
 
             let validation_result =
@@ -350,12 +365,7 @@ fn main() -> FloeResult<()> {
                     let _ = std::io::stdout().lock().flush();
                     Ok(())
                 }
-                Err(err) => {
-                    let mut err_out = std::io::stderr().lock();
-                    let _ = writeln!(err_out, "Error: {err}");
-                    let _ = err_out.flush();
-                    std::process::exit(1);
-                }
+                Err(err) => exit_with_error(err),
             }
         }
         Command::Run {
@@ -475,40 +485,32 @@ fn main() -> FloeResult<()> {
                     }
                 };
 
-                let options = ValidateOptions {
-                    entities: entities.clone(),
-                    profile_vars: std::collections::HashMap::new(),
-                };
-                if let Err(err) =
-                    validate_with_base(&config_location.path, config_location.base.clone(), options)
-                {
-                    let mut err_out = std::io::stderr().lock();
-                    let _ = writeln!(err_out, "Error: {err}");
-                    let _ = err_out.flush();
-                    std::process::exit(1);
-                }
-
                 let profile_config = if let Some(ref profile_path) = profile {
                     let path = std::path::Path::new(profile_path);
                     let parsed = match parse_profile(path) {
                         Ok(p) => p,
-                        Err(err) => {
-                            let mut err_out = std::io::stderr().lock();
-                            let _ = writeln!(err_out, "Error: {err}");
-                            let _ = err_out.flush();
-                            std::process::exit(1);
-                        }
+                        Err(err) => exit_with_error(err),
                     };
                     if let Err(err) = validate_profile(&parsed) {
-                        let mut err_out = std::io::stderr().lock();
-                        let _ = writeln!(err_out, "Error: {err}");
-                        let _ = err_out.flush();
-                        std::process::exit(1);
+                        exit_with_error(err);
                     }
                     Some(parsed)
                 } else {
                     None
                 };
+
+                let options = ValidateOptions {
+                    entities: entities.clone(),
+                    profile_vars: std::collections::HashMap::new(),
+                    profile_catalogs: profile_config
+                        .as_ref()
+                        .and_then(|profile| profile.catalogs.clone()),
+                };
+                if let Err(err) =
+                    validate_with_base(&config_location.path, config_location.base.clone(), options)
+                {
+                    exit_with_error(err);
+                }
 
                 let config = load_config(&config_location.path)?;
                 let manifest_json = build_common_manifest_json(

--- a/crates/floe-cli/tests/manifest_output.rs
+++ b/crates/floe-cli/tests/manifest_output.rs
@@ -212,3 +212,73 @@ fn manifest_generate_with_missing_profile_fails() {
         .failure()
         .stderr(predicate::str::contains("Error:"));
 }
+
+#[test]
+fn manifest_generate_applies_profile_variables_to_config() {
+    let tmp = tempdir().expect("create temp dir");
+    let config_path = tmp.path().join("config.yml");
+    let profile_path = tmp.path().join("profile.yml");
+
+    fs::write(
+        &config_path,
+        r#"version: "0.1"
+report:
+  path: "{{REPORT_DIR}}"
+entities:
+  - name: customers
+    source:
+      format: csv
+      path: "{{INCOMING_DIR}}/customers.csv"
+    sink:
+      accepted:
+        format: parquet
+        path: "{{OUTPUT_DIR}}/customers/"
+    policy:
+      severity: warn
+    schema:
+      columns:
+        - name: customer_id
+          type: string
+          nullable: false
+"#,
+    )
+    .expect("write config");
+    fs::write(
+        &profile_path,
+        r#"apiVersion: floe/v1
+kind: EnvironmentProfile
+metadata:
+  name: dev
+variables:
+  REPORT_DIR: ./reports-dev
+  INCOMING_DIR: ./in-dev
+  OUTPUT_DIR: ./out-dev
+"#,
+    )
+    .expect("write profile");
+
+    let mut cmd = Command::new(assert_cmd::cargo::cargo_bin!("floe"));
+    let assert = cmd
+        .args(["manifest", "generate", "-c"])
+        .arg(&config_path)
+        .arg("--profile")
+        .arg(&profile_path)
+        .args(["--output", "-"])
+        .assert()
+        .success();
+
+    let stdout = String::from_utf8_lossy(&assert.get_output().stdout);
+    let value: Value = serde_json::from_str(stdout.trim()).expect("stdout should be json");
+    assert!(value["report_base_uri"]
+        .as_str()
+        .expect("report base uri")
+        .contains("reports-dev"));
+    assert!(value["entities"][0]["source"]["path"]
+        .as_str()
+        .expect("source path")
+        .contains("in-dev"));
+    assert!(value["entities"][0]["sinks"]["accepted"]["path"]
+        .as_str()
+        .expect("accepted path")
+        .contains("out-dev"));
+}

--- a/crates/floe-cli/tests/validate_output.rs
+++ b/crates/floe-cli/tests/validate_output.rs
@@ -55,5 +55,7 @@ fn validate_profile_only_output_is_human_text() {
         .assert()
         .success()
         .stdout(predicate::str::contains("Profile valid: dev"))
-        .stdout(predicate::str::contains("Schema: floe/v1/EnvironmentProfile"));
+        .stdout(predicate::str::contains(
+            "Schema: floe/v1/EnvironmentProfile",
+        ));
 }

--- a/crates/floe-cli/tests/validate_output.rs
+++ b/crates/floe-cli/tests/validate_output.rs
@@ -44,3 +44,16 @@ fn validate_invalid_config_sets_exit_1_and_error_text() {
         .failure()
         .stderr(predicate::str::contains("Error:"));
 }
+
+#[test]
+fn validate_profile_only_output_is_human_text() {
+    let profile_path = repo_root().join("example/profiles/dev.yml");
+
+    let mut cmd = Command::new(assert_cmd::cargo::cargo_bin!("floe"));
+    cmd.args(["validate", "--profile"])
+        .arg(&profile_path)
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Profile valid: dev"))
+        .stdout(predicate::str::contains("Schema: floe/v1/EnvironmentProfile"));
+}

--- a/crates/floe-core/src/config/mod.rs
+++ b/crates/floe-core/src/config/mod.rs
@@ -13,6 +13,6 @@ pub use storage::{resolve_local_path, ConfigBase, ResolvedPath, StorageResolver}
 pub use types::*;
 
 pub use parse::extract_raw_env_vars;
-pub(crate) use parse::{parse_config, parse_config_with_vars};
+pub(crate) use parse::{parse_catalogs_with_context, parse_config, parse_config_with_vars};
 pub(crate) use template::apply_templates_with_vars;
 pub(crate) use validate::validate_config;

--- a/crates/floe-core/src/config/parse.rs
+++ b/crates/floe-core/src/config/parse.rs
@@ -713,7 +713,9 @@ pub(crate) fn parse_catalogs_with_context(
     let mut definitions = Vec::with_capacity(definitions_yaml.len());
     for (index, item) in definitions_yaml.iter().enumerate() {
         let definition = parse_catalog_definition(item, &definitions_context).map_err(|err| {
-            Box::new(ConfigError(format!("{definitions_context}[{index}]: {err}")))
+            Box::new(ConfigError(format!(
+                "{definitions_context}[{index}]: {err}"
+            )))
         })?;
         definitions.push(definition);
     }

--- a/crates/floe-core/src/config/parse.rs
+++ b/crates/floe-core/src/config/parse.rs
@@ -695,35 +695,43 @@ fn parse_storage_definition(value: &Yaml) -> FloeResult<StorageDefinition> {
     })
 }
 
-fn parse_catalogs(value: &Yaml) -> FloeResult<CatalogsConfig> {
-    let hash = yaml_hash(value, "catalogs")?;
-    validate_known_keys(hash, "catalogs", &["default", "definitions"])?;
+pub(crate) fn parse_catalogs_with_context(
+    value: &Yaml,
+    context: &str,
+) -> FloeResult<CatalogsConfig> {
+    let definitions_context = format!("{context}.definitions");
+    let hash = yaml_hash(value, context)?;
+    validate_known_keys(hash, context, &["default", "definitions"])?;
     let definitions_yaml = match hash_get(hash, "definitions") {
-        Some(value) => yaml_array(value, "catalogs.definitions")?,
+        Some(value) => yaml_array(value, &definitions_context)?,
         None => {
-            return Err(Box::new(ConfigError(
-                "missing required field catalogs.definitions".to_string(),
-            )))
+            return Err(Box::new(ConfigError(format!(
+                "missing required field {definitions_context}"
+            ))))
         }
     };
     let mut definitions = Vec::with_capacity(definitions_yaml.len());
     for (index, item) in definitions_yaml.iter().enumerate() {
-        let definition = parse_catalog_definition(item).map_err(|err| {
-            Box::new(ConfigError(format!("catalogs.definitions[{index}]: {err}")))
+        let definition = parse_catalog_definition(item, &definitions_context).map_err(|err| {
+            Box::new(ConfigError(format!("{definitions_context}[{index}]: {err}")))
         })?;
         definitions.push(definition);
     }
     Ok(CatalogsConfig {
-        default: opt_string(hash, "default", "catalogs")?,
+        default: opt_string(hash, "default", context)?,
         definitions,
     })
 }
 
-fn parse_catalog_definition(value: &Yaml) -> FloeResult<CatalogDefinition> {
-    let hash = yaml_hash(value, "catalogs.definitions")?;
+fn parse_catalogs(value: &Yaml) -> FloeResult<CatalogsConfig> {
+    parse_catalogs_with_context(value, "catalogs")
+}
+
+fn parse_catalog_definition(value: &Yaml, context: &str) -> FloeResult<CatalogDefinition> {
+    let hash = yaml_hash(value, context)?;
     validate_known_keys(
         hash,
-        "catalogs.definitions",
+        context,
         &[
             "name",
             "type",
@@ -748,14 +756,14 @@ fn parse_catalog_definition(value: &Yaml) -> FloeResult<CatalogDefinition> {
             "create_schema_if_missing",
         ],
     )?;
-    let name = get_string(hash, "name", "catalogs.definitions")?;
-    let catalog_type = get_string(hash, "type", "catalogs.definitions")?;
-    let type_config = parse_catalog_type_config(&name, &catalog_type, hash)?;
+    let name = get_string(hash, "name", context)?;
+    let catalog_type = get_string(hash, "type", context)?;
+    let type_config = parse_catalog_type_config(&name, &catalog_type, hash, context)?;
     Ok(CatalogDefinition {
         name,
         type_config,
-        warehouse_storage: opt_string(hash, "warehouse_storage", "catalogs.definitions")?,
-        warehouse_prefix: opt_string(hash, "warehouse_prefix", "catalogs.definitions")?,
+        warehouse_storage: opt_string(hash, "warehouse_storage", context)?,
+        warehouse_prefix: opt_string(hash, "warehouse_prefix", context)?,
     })
 }
 
@@ -763,37 +771,33 @@ fn parse_catalog_type_config(
     name: &str,
     catalog_type: &str,
     hash: &yaml_rust2::yaml::Hash,
+    context: &str,
 ) -> FloeResult<CatalogTypeConfig> {
     match catalog_type {
         "glue" => Ok(CatalogTypeConfig::Glue {
-            region: get_string(hash, "region", "catalogs.definitions")?,
-            database: get_string(hash, "database", "catalogs.definitions")?,
-            create_database_if_missing: opt_bool(
-                hash,
-                "create_database_if_missing",
-                "catalogs.definitions",
-            )?
-            .unwrap_or(true),
-            allow_takeover: opt_bool(hash, "allow_takeover", "catalogs.definitions")?
-                .unwrap_or(false),
+            region: get_string(hash, "region", context)?,
+            database: get_string(hash, "database", context)?,
+            create_database_if_missing: opt_bool(hash, "create_database_if_missing", context)?
+                .unwrap_or(true),
+            allow_takeover: opt_bool(hash, "allow_takeover", context)?.unwrap_or(false),
         }),
         "rest" => Ok(CatalogTypeConfig::Rest {
-            uri: get_string(hash, "uri", "catalogs.definitions")?,
-            credential: opt_string(hash, "credential", "catalogs.definitions")?,
-            warehouse: opt_string(hash, "warehouse", "catalogs.definitions")?,
-            oauth2_server_uri: opt_string(hash, "oauth2_server_uri", "catalogs.definitions")?,
-            scope: opt_string(hash, "scope", "catalogs.definitions")?,
+            uri: get_string(hash, "uri", context)?,
+            credential: opt_string(hash, "credential", context)?,
+            warehouse: opt_string(hash, "warehouse", context)?,
+            oauth2_server_uri: opt_string(hash, "oauth2_server_uri", context)?,
+            scope: opt_string(hash, "scope", context)?,
         }),
         "unity" => Ok(CatalogTypeConfig::Unity {
-            host: get_string(hash, "host", "catalogs.definitions")?,
-            catalog: get_string(hash, "catalog", "catalogs.definitions")?,
-            schema: get_string(hash, "schema", "catalogs.definitions")?,
-            token: get_string(hash, "token", "catalogs.definitions")?,
-            create_schema_if_missing: opt_bool(hash, "create_schema_if_missing", "catalogs.definitions")?
+            host: get_string(hash, "host", context)?,
+            catalog: get_string(hash, "catalog", context)?,
+            schema: get_string(hash, "schema", context)?,
+            token: get_string(hash, "token", context)?,
+            create_schema_if_missing: opt_bool(hash, "create_schema_if_missing", context)?
                 .unwrap_or(false),
         }),
         other => Err(Box::new(crate::errors::ConfigError(format!(
-            "catalogs.definitions name={name} has unsupported type={other} (supported: glue, rest, unity)"
+            "{context} name={name} has unsupported type={other} (supported: glue, rest, unity)"
         )))),
     }
 }

--- a/crates/floe-core/src/lib.rs
+++ b/crates/floe-core/src/lib.rs
@@ -38,6 +38,7 @@ pub type FloeResult<T> = Result<T, Box<dyn std::error::Error + Send + Sync>>;
 pub struct ValidateOptions {
     pub entities: Vec<String>,
     pub profile_vars: std::collections::HashMap<String, String>,
+    pub profile_catalogs: Option<config::CatalogsConfig>,
 }
 
 #[derive(Debug, Default)]
@@ -58,7 +59,8 @@ pub fn validate_with_base(
     _config_base: config::ConfigBase,
     options: ValidateOptions,
 ) -> FloeResult<()> {
-    let config = config::parse_config_with_vars(config_path, &options.profile_vars)?;
+    let mut config = config::parse_config_with_vars(config_path, &options.profile_vars)?;
+    apply_profile_catalogs(&mut config, options.profile_catalogs.as_ref());
     config::validate_config(&config)?;
 
     if !options.entities.is_empty() {
@@ -70,6 +72,21 @@ pub fn validate_with_base(
 
 pub fn load_config(config_path: &Path) -> FloeResult<config::RootConfig> {
     config::parse_config(config_path)
+}
+
+pub fn validate_profile_file(profile_path: &Path) -> FloeResult<ProfileConfig> {
+    let profile = parse_profile(profile_path)?;
+    validate_profile(&profile)?;
+    Ok(profile)
+}
+
+pub(crate) fn apply_profile_catalogs(
+    config: &mut config::RootConfig,
+    profile_catalogs: Option<&config::CatalogsConfig>,
+) {
+    if let Some(catalogs) = profile_catalogs {
+        config.catalogs = Some(catalogs.clone());
+    }
 }
 
 pub fn extract_config_env_vars(

--- a/crates/floe-core/src/lib.rs
+++ b/crates/floe-core/src/lib.rs
@@ -74,6 +74,16 @@ pub fn load_config(config_path: &Path) -> FloeResult<config::RootConfig> {
     config::parse_config(config_path)
 }
 
+pub fn load_config_with_profile_overrides(
+    config_path: &Path,
+    profile_vars: &std::collections::HashMap<String, String>,
+    profile_catalogs: Option<&config::CatalogsConfig>,
+) -> FloeResult<config::RootConfig> {
+    let mut config = config::parse_config_with_vars(config_path, profile_vars)?;
+    apply_profile_catalogs(&mut config, profile_catalogs);
+    Ok(config)
+}
+
 pub fn validate_profile_file(profile_path: &Path) -> FloeResult<ProfileConfig> {
     let profile = parse_profile(profile_path)?;
     validate_profile(&profile)?;

--- a/crates/floe-core/src/profile/parse.rs
+++ b/crates/floe-core/src/profile/parse.rs
@@ -54,6 +54,7 @@ fn parse_profile_doc(doc: &Yaml) -> FloeResult<ProfileConfig> {
             "metadata",
             "execution",
             "variables",
+            "catalogs",
             "validation",
         ],
     )?;
@@ -88,6 +89,14 @@ fn parse_profile_doc(doc: &Yaml) -> FloeResult<ProfileConfig> {
         None => HashMap::new(),
     };
 
+    let catalogs = match hash_get(root, "catalogs") {
+        Some(value) => Some(crate::config::parse_catalogs_with_context(
+            value,
+            "profile.catalogs",
+        )?),
+        None => None,
+    };
+
     let validation = match hash_get(root, "validation") {
         Some(value) => Some(parse_validation(value)?),
         None => None,
@@ -99,6 +108,7 @@ fn parse_profile_doc(doc: &Yaml) -> FloeResult<ProfileConfig> {
         metadata,
         execution,
         variables,
+        catalogs,
         validation,
     })
 }

--- a/crates/floe-core/src/profile/types.rs
+++ b/crates/floe-core/src/profile/types.rs
@@ -1,5 +1,7 @@
 use std::collections::HashMap;
 
+use crate::config::CatalogsConfig;
+
 /// Top-level profile document (apiVersion + kind + sections).
 #[derive(Debug, Clone)]
 pub struct ProfileConfig {
@@ -8,6 +10,7 @@ pub struct ProfileConfig {
     pub metadata: ProfileMetadata,
     pub execution: Option<ProfileExecution>,
     pub variables: HashMap<String, String>,
+    pub catalogs: Option<CatalogsConfig>,
     pub validation: Option<ProfileValidation>,
 }
 

--- a/crates/floe-core/src/profile/validate.rs
+++ b/crates/floe-core/src/profile/validate.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use crate::profile::types::{ProfileConfig, ProfileRunner};
 use crate::{ConfigError, FloeResult};
@@ -24,6 +24,44 @@ pub fn validate_profile(profile: &ProfileConfig) -> FloeResult<()> {
     }
 
     validate_no_malformed_vars(&profile.variables)?;
+    validate_profile_catalogs(profile)?;
+
+    Ok(())
+}
+
+fn validate_profile_catalogs(profile: &ProfileConfig) -> FloeResult<()> {
+    let Some(catalogs) = &profile.catalogs else {
+        return Ok(());
+    };
+    if catalogs.definitions.is_empty() {
+        return Err(Box::new(ConfigError(
+            "profile.catalogs.definitions must not be empty".to_string(),
+        )));
+    }
+
+    let mut names = HashSet::new();
+    for definition in &catalogs.definitions {
+        if definition.name.trim().is_empty() {
+            return Err(Box::new(ConfigError(
+                "profile.catalogs.definitions.name must not be empty".to_string(),
+            )));
+        }
+        if !names.insert(definition.name.as_str()) {
+            return Err(Box::new(ConfigError(format!(
+                "profile.catalogs.definitions name={} is duplicated",
+                definition.name
+            ))));
+        }
+    }
+
+    if let Some(default_name) = &catalogs.default {
+        if !names.contains(default_name.as_str()) {
+            return Err(Box::new(ConfigError(format!(
+                "profile.catalogs.default={} does not match any definition",
+                default_name
+            ))));
+        }
+    }
 
     Ok(())
 }

--- a/crates/floe-core/src/run/context.rs
+++ b/crates/floe-core/src/run/context.rs
@@ -25,7 +25,11 @@ impl RunContext {
         options: &RunOptions,
         profile_vars: HashMap<String, String>,
     ) -> FloeResult<Self> {
-        let config = config::parse_config_with_vars(config_path, &profile_vars)?;
+        let mut config = config::parse_config_with_vars(config_path, &profile_vars)?;
+        crate::apply_profile_catalogs(
+            &mut config,
+            options.profile.as_ref().and_then(|profile| profile.catalogs.as_ref()),
+        );
         let storage_resolver = config::StorageResolver::new(&config, config_base)?;
         let catalog_resolver = config::CatalogResolver::new(&config)?;
         let config_dir =

--- a/crates/floe-core/src/run/context.rs
+++ b/crates/floe-core/src/run/context.rs
@@ -28,7 +28,10 @@ impl RunContext {
         let mut config = config::parse_config_with_vars(config_path, &profile_vars)?;
         crate::apply_profile_catalogs(
             &mut config,
-            options.profile.as_ref().and_then(|profile| profile.catalogs.as_ref()),
+            options
+                .profile
+                .as_ref()
+                .and_then(|profile| profile.catalogs.as_ref()),
         );
         let storage_resolver = config::StorageResolver::new(&config, config_base)?;
         let catalog_resolver = config::CatalogResolver::new(&config)?;

--- a/crates/floe-core/src/run/mod.rs
+++ b/crates/floe-core/src/run/mod.rs
@@ -116,6 +116,7 @@ pub fn run_with_runtime(
     let validate_options = ValidateOptions {
         entities: options.entities.clone(),
         profile_vars: profile_vars.clone(),
+        profile_catalogs: options.profile.as_ref().and_then(|profile| profile.catalogs.clone()),
     };
     crate::validate_with_base(config_path, config_base.clone(), validate_options)?;
     let context = RunContext::new(config_path, config_base, &options, profile_vars)?;

--- a/crates/floe-core/src/run/mod.rs
+++ b/crates/floe-core/src/run/mod.rs
@@ -116,7 +116,10 @@ pub fn run_with_runtime(
     let validate_options = ValidateOptions {
         entities: options.entities.clone(),
         profile_vars: profile_vars.clone(),
-        profile_catalogs: options.profile.as_ref().and_then(|profile| profile.catalogs.clone()),
+        profile_catalogs: options
+            .profile
+            .as_ref()
+            .and_then(|profile| profile.catalogs.clone()),
     };
     crate::validate_with_base(config_path, config_base.clone(), validate_options)?;
     let context = RunContext::new(config_path, config_base, &options, profile_vars)?;

--- a/crates/floe-core/tests/unit/profile/validate.rs
+++ b/crates/floe-core/tests/unit/profile/validate.rs
@@ -270,3 +270,47 @@ fn validate_merged_vars_unresolved_fails() {
         "got: {err}"
     );
 }
+
+#[test]
+fn validate_profile_accepts_catalogs() {
+    let yaml = r#"
+apiVersion: floe/v1
+kind: EnvironmentProfile
+metadata:
+  name: prod
+catalogs:
+  default: prod_glue
+  definitions:
+    - name: prod_glue
+      type: glue
+      region: eu-west-1
+      database: bronze
+      warehouse_storage: lake_s3
+"#;
+    let profile = parse_profile_from_str(yaml).expect("parse");
+    validate_profile(&profile).expect("catalog profile should validate");
+    assert_eq!(profile.catalogs.unwrap().definitions.len(), 1);
+}
+
+#[test]
+fn validate_profile_rejects_catalog_default_without_definition() {
+    let yaml = r#"
+apiVersion: floe/v1
+kind: EnvironmentProfile
+metadata:
+  name: prod
+catalogs:
+  default: missing
+  definitions:
+    - name: prod_glue
+      type: glue
+      region: eu-west-1
+      database: bronze
+"#;
+    let profile = parse_profile_from_str(yaml).expect("parse");
+    let err = validate_profile(&profile).unwrap_err();
+    assert!(
+        err.to_string().contains("catalogs.default=missing"),
+        "got: {err}"
+    );
+}

--- a/docs/profiles.md
+++ b/docs/profiles.md
@@ -255,3 +255,60 @@ my-project/
 
 See `example/profiles/` in this repository for ready-to-use templates.
 The machine-readable field reference is in `profile.schema.yaml` at the repo root.
+
+## Environment catalog overrides
+
+Profiles can carry a `catalogs:` block with the same catalog definition shape as
+main Floe configs. When a command is run with both `--config` and `--profile`,
+the profile `catalogs:` block replaces the config-level `catalogs:` block for
+that invocation. This keeps entity logic in the shared config while moving
+Glue, REST Iceberg, or Unity Catalog endpoints into environment-specific files.
+
+```yaml
+apiVersion: floe/v1
+kind: EnvironmentProfile
+metadata:
+  name: prod
+catalogs:
+  default: prod_glue
+  definitions:
+    - name: prod_glue
+      type: glue
+      region: eu-west-1
+      database: bronze
+      warehouse_storage: lake_s3
+      warehouse_prefix: iceberg
+```
+
+Notes:
+
+- `warehouse_storage` still references a storage definition from the main config.
+- Profile-only validation (`floe validate --profile profiles/prod.yml`) checks the
+  profile schema, known keys, runner contracts, variable placeholder syntax,
+  duplicate catalog names, and `catalogs.default` references.
+- Full config validation (`floe validate -c config.yml --profile profiles/prod.yml`)
+  additionally checks catalog/storage compatibility and entity sink bindings.
+
+## Hardening assessment and plan
+
+Current profile feature gaps and fixes:
+
+1. **No standalone profile validation path** — previously `floe validate` always
+   required a config. Fixed by allowing `floe validate --profile <file>` to parse
+   and validate an `EnvironmentProfile` by itself.
+2. **Environment-specific catalogs forced into shared configs** — catalog targets
+   are often environment-specific. Fixed by adding `profile.catalogs` and applying
+   it as an invocation-scoped replacement for config-level `catalogs`.
+3. **Partial profile validation only** — profile parsing rejected unknown keys and
+   checked runner/variable basics, but catalog duplicates/default references had
+   no profile-level guard. Fixed with profile catalog validation.
+4. **Validation order inconsistency** — manifest generation validated the config
+   before loading the profile, so profile-provided catalogs could not satisfy
+   catalog bindings. Fixed by loading the profile first and passing profile
+   catalogs into config validation.
+5. **Remaining hardening work** — profile `validation.strict` is parsed but not
+   enforced, profile paths are local-only while config supports URI resolution,
+   and profile catalog validation cannot fully verify `warehouse_storage` without
+   a config. Future work should wire `strict` into schema checks, reuse config URI
+   resolution for profile loading, and add a combined validation report that
+   clearly separates profile-only errors from config/profile integration errors.

--- a/profile.schema.yaml
+++ b/profile.schema.yaml
@@ -37,6 +37,9 @@ properties:
   variables:
     $ref: "#/$defs/variables"
 
+  catalogs:
+    $ref: "#/$defs/catalogs"
+
   validation:
     $ref: "#/$defs/profile_validation"
 
@@ -145,6 +148,100 @@ $defs:
 
       Syntactically malformed placeholders (${ without a closing }, or ${} with
       an empty key) are rejected at profile validation time.
+
+
+  catalogs:
+    type: object
+    additionalProperties: false
+    required:
+      - definitions
+    description: >
+      Environment-specific catalog definitions for Iceberg and Delta sinks.
+      When provided with a main config, the profile catalogs block replaces the
+      config-level catalogs block for that command invocation.
+    properties:
+      default:
+        type: string
+        description: Default catalog name used when entity sinks omit a catalog.
+      definitions:
+        type: array
+        minItems: 1
+        items:
+          $ref: "#/$defs/catalog_definition"
+
+  catalog_definition:
+    type: object
+    additionalProperties: false
+    required:
+      - name
+      - type
+    properties:
+      name:
+        type: string
+        minLength: 1
+      type:
+        type: string
+        enum: [glue, rest, unity]
+      warehouse_storage:
+        type: string
+        description: Optional storage definition name used as the catalog warehouse root.
+      warehouse_prefix:
+        type: string
+        description: Optional path prefix under the warehouse storage.
+      region:
+        type: string
+        description: Glue catalog region; required when type is glue.
+      database:
+        type: string
+        description: Glue database; required when type is glue.
+      create_database_if_missing:
+        type: boolean
+      allow_takeover:
+        type: boolean
+      uri:
+        type: string
+        description: REST catalog URI; required when type is rest.
+      credential:
+        type: string
+      warehouse:
+        type: string
+      oauth2_server_uri:
+        type: string
+      scope:
+        type: string
+      host:
+        type: string
+        description: Unity Catalog host; required when type is unity.
+      catalog:
+        type: string
+        description: Unity Catalog name; required when type is unity.
+      schema:
+        type: string
+        description: Unity schema name; required when type is unity.
+      token:
+        type: string
+        description: Unity authentication token or substituted secret.
+      create_schema_if_missing:
+        type: boolean
+    allOf:
+      - if:
+          properties:
+            type:
+              const: glue
+        then:
+          required: [region, database]
+      - if:
+          properties:
+            type:
+              const: rest
+        then:
+          required: [uri]
+      - if:
+          properties:
+            type:
+              const: unity
+        then:
+          required: [host, catalog, schema, token]
 
   profile_validation:
     type: object


### PR DESCRIPTION
### Motivation
- Allow profiles to carry environment-specific catalog configuration so `catalogs` can be defined in `profile.yml` and used when validating or running against a main config. 
- Add a standalone profile validation path so `floe validate --profile <file>` can check a profile alone against the profile schema and runtime contract. 
- Close validation gaps: detect duplicate/empty catalog names and invalid `catalogs.default` references in profiles, and ensure profile-provided catalogs are considered during config validation. 
- Improve validation ordering so manifest/validate/run flows can rely on profile-supplied catalogs when present.

### Description
- Added `catalogs: Option<CatalogsConfig>` to the profile model and extended the profile parser to call a `parse_catalogs_with_context` helper so profile-level catalog errors show the correct context. 
- Introduced `validate_profile_catalogs` to check non-empty definitions, non-empty names, duplicate names, and `catalogs.default` membership, and wired it into `validate_profile`. 
- Added `ValidateOptions.profile_catalogs` and `apply_profile_catalogs` which injects profile `catalogs` into the in-memory `RootConfig` prior to `config::validate_config`, and applied this during validate/manifest/run flows and `RunContext` construction. 
- Made `floe validate` accept `--profile` without `--config`: the CLI now parses/validates the profile first and prints profile-only success information when no config is supplied; when both are supplied the profile is loaded first and profile catalogs are passed into config validation. 
- Extended `profile.schema.yaml` and `docs/profiles.md` with a `catalogs` definition and usage notes, and added unit/CLI tests covering profile-only validation and profile catalog validation.

### Testing
- Ran `cargo test -p floe-core validate_profile -- --nocapture` and the profile validation unit tests passed. 
- Ran `cargo test -p floe-core validate_profile_accepts_catalogs -- --nocapture` and `cargo test -p floe-cli validate_profile_only_output_is_human_text -- --nocapture`, both succeeded. 
- Ran combined test/CLI checks (profile catalog & CLI validate test) and `git diff --check`; they passed. 
- `cargo fmt` was not executed because `rustfmt` is not installed in the toolchain here and `rustup component add rustfmt` failed to download in this environment (network/proxy error).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01a23f843c8321bb506441ffb05c32)