### PR TITLE
[codex] Harden remote incremental state

### DIFF
--- a/crates/floe-cli/src/main.rs
+++ b/crates/floe-cli/src/main.rs
@@ -214,7 +214,7 @@ enum StateCommand {
         config: String,
         #[arg(long, help = "Entity name")]
         entity: String,
-        #[arg(long, help = "Required confirmation to delete the state file")]
+        #[arg(long, help = "Required confirmation to delete the state object")]
         yes: bool,
     },
 }
@@ -710,6 +710,7 @@ fn main() -> FloeResult<()> {
                     Some(state) => {
                         let _ = writeln!(out, "State exists: yes");
                         let _ = writeln!(out, "Tracked files: {}", state.files.len());
+                        let _ = writeln!(out, "Active claims: {}", state.claims.len());
                         let _ = writeln!(
                             out,
                             "Updated at: {}",
@@ -722,6 +723,7 @@ fn main() -> FloeResult<()> {
                     None => {
                         let _ = writeln!(out, "State exists: no");
                         let _ = writeln!(out, "Tracked files: 0");
+                        let _ = writeln!(out, "Active claims: 0");
                     }
                 }
                 let _ = out.flush();
@@ -761,9 +763,9 @@ fn main() -> FloeResult<()> {
                 let _ = writeln!(out, "Entity: {}", inspection.entity_name);
                 let _ = writeln!(out, "State path: {}", inspection.path.uri);
                 if removed {
-                    let _ = writeln!(out, "State reset: removed state file");
+                    let _ = writeln!(out, "State reset: removed state object");
                 } else {
-                    let _ = writeln!(out, "State reset: no state file found");
+                    let _ = writeln!(out, "State reset: no state object found");
                 }
                 let _ = out.flush();
                 Ok(())

--- a/crates/floe-cli/tests/state.rs
+++ b/crates/floe-cli/tests/state.rs
@@ -69,6 +69,7 @@ fn state_inspect_prints_state_summary_and_json() {
         .stdout(predicate::str::contains("Incremental mode: file"))
         .stdout(predicate::str::contains("State exists: yes"))
         .stdout(predicate::str::contains("Tracked files: 1"))
+        .stdout(predicate::str::contains("Active claims: 0"))
         .stdout(predicate::str::contains("\"entity\": \"sales\""));
 }
 
@@ -94,7 +95,9 @@ fn assert_state_reset(config_path: &std::path::Path, state_path: &std::path::Pat
         .assert()
         .success()
         .stdout(predicate::str::contains("Entity: sales"))
-        .stdout(predicate::str::contains("State reset: removed state file"));
+        .stdout(predicate::str::contains(
+            "State reset: removed state object",
+        ));
 
     assert!(!state_path.exists());
 }

--- a/crates/floe-core/src/config/storage.rs
+++ b/crates/floe-core/src/config/storage.rs
@@ -126,6 +126,7 @@ pub struct ResolvedPath {
     pub local_path: Option<PathBuf>,
 }
 
+#[derive(Clone)]
 pub struct StorageResolver {
     config_base: ConfigBase,
     default_name: String,

--- a/crates/floe-core/src/io/storage/mod.rs
+++ b/crates/floe-core/src/io/storage/mod.rs
@@ -20,6 +20,18 @@ pub use target::Target;
 
 pub use planner::ObjectRef;
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StoredObject {
+    pub body: Vec<u8>,
+    pub version: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ConditionalWrite {
+    Written { version: String },
+    Conflict,
+}
+
 pub trait StorageClient: Send + Sync {
     fn list(&self, prefix_or_path: &str) -> FloeResult<Vec<ObjectRef>>;
     fn download_to_temp(&self, uri: &str, temp_dir: &Path) -> FloeResult<PathBuf>;
@@ -28,6 +40,36 @@ pub trait StorageClient: Send + Sync {
     fn copy_object(&self, src_uri: &str, dst_uri: &str) -> FloeResult<()>;
     fn delete_object(&self, uri: &str) -> FloeResult<()>;
     fn exists(&self, uri: &str) -> FloeResult<bool>;
+
+    fn read_object(&self, uri: &str) -> FloeResult<Option<StoredObject>> {
+        let _ = uri;
+        Err(Box::new(ConfigError(
+            "storage backend does not support object reads with version tokens".to_string(),
+        )))
+    }
+
+    fn write_object_conditional(
+        &self,
+        uri: &str,
+        expected_version: Option<&str>,
+        body: &[u8],
+    ) -> FloeResult<ConditionalWrite> {
+        let _ = (uri, expected_version, body);
+        Err(Box::new(ConfigError(
+            "storage backend does not support conditional object writes".to_string(),
+        )))
+    }
+
+    fn delete_object_conditional(
+        &self,
+        uri: &str,
+        expected_version: Option<&str>,
+    ) -> FloeResult<ConditionalWrite> {
+        let _ = (uri, expected_version);
+        Err(Box::new(ConfigError(
+            "storage backend does not support conditional object deletes".to_string(),
+        )))
+    }
 }
 
 pub struct CloudClient {

--- a/crates/floe-core/src/io/storage/ops/inputs.rs
+++ b/crates/floe-core/src/io/storage/ops/inputs.rs
@@ -385,10 +385,14 @@ fn filter_cloud_list_refs(
 ) -> Vec<io::storage::planner::ObjectRef> {
     let filtered = list_refs
         .into_iter()
-        .filter(|obj| source_match.matches_key(&obj.key))
+        .filter(|obj| source_match.matches_key(&obj.key) && !is_floe_state_key(&obj.key))
         .collect::<Vec<_>>();
     let filtered = planner::filter_by_suffixes(filtered, suffixes);
     planner::stable_sort_refs(filtered)
+}
+
+fn is_floe_state_key(key: &str) -> bool {
+    key.starts_with(".floe/") || key.contains("/.floe/")
 }
 
 fn contains_glob_metachar(value: &str) -> bool {

--- a/crates/floe-core/src/io/storage/providers/adls.rs
+++ b/crates/floe-core/src/io/storage/providers/adls.rs
@@ -277,13 +277,18 @@ impl StorageClient for AdlsClient {
         uri: &str,
         expected_version: Option<&str>,
     ) -> FloeResult<ConditionalWrite> {
+        let Some(expected_version) = expected_version else {
+            return Ok(ConditionalWrite::Written {
+                version: "deleted".to_string(),
+            });
+        };
         let key = adls_key_from_uri(uri)?;
         let client = self.container_client.clone();
         self.runtime.block_on(async move {
-            let mut request = client.blob_client(key).delete();
-            if let Some(version) = expected_version {
-                request = request.if_match(IfMatchCondition::Match(version.to_string()));
-            }
+            let request = client
+                .blob_client(key)
+                .delete()
+                .if_match(IfMatchCondition::Match(expected_version.to_string()));
             match request.into_future().await {
                 Ok(_) => Ok(ConditionalWrite::Written {
                     version: "deleted".to_string(),

--- a/crates/floe-core/src/io/storage/providers/adls.rs
+++ b/crates/floe-core/src/io/storage/providers/adls.rs
@@ -1,6 +1,7 @@
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
+use azure_core::prelude::IfMatchCondition;
 use azure_identity::{DefaultAzureCredential, TokenCredentialOptions};
 use azure_storage::StorageCredentials;
 use azure_storage_blobs::prelude::{BlobServiceClient, ContainerClient};
@@ -8,7 +9,9 @@ use futures::StreamExt;
 use tokio::runtime::Runtime;
 
 use crate::errors::StorageError;
-use crate::io::storage::{planner, uri, validation, ObjectRef, StorageClient};
+use crate::io::storage::{
+    planner, uri, validation, ConditionalWrite, ObjectRef, StorageClient, StoredObject,
+};
 use crate::{config, FloeResult};
 
 pub struct AdlsClient {
@@ -207,6 +210,118 @@ impl StorageClient for AdlsClient {
             .to_string();
         planner::exists_by_key(self, &key)
     }
+
+    fn read_object(&self, uri: &str) -> FloeResult<Option<StoredObject>> {
+        let key = adls_key_from_uri(uri)?;
+        let client = self.container_client.clone();
+        self.runtime.block_on(async move {
+            let blob = client.blob_client(key);
+            let mut stream = blob.get().into_stream();
+            let mut body = Vec::new();
+            let mut version = None;
+            while let Some(chunk) = stream.next().await {
+                let resp = match chunk {
+                    Ok(resp) => resp,
+                    Err(err) if is_not_found(&err) => return Ok(None),
+                    Err(err) => {
+                        return Err(
+                            Box::new(StorageError(format!("adls download failed: {err}")))
+                                as Box<dyn std::error::Error + Send + Sync>,
+                        )
+                    }
+                };
+                if version.is_none() {
+                    version = Some(resp.blob.properties.etag.to_string());
+                }
+                let bytes = resp.data.collect().await.map_err(|err| {
+                    Box::new(StorageError(format!("adls download read failed: {err}")))
+                        as Box<dyn std::error::Error + Send + Sync>
+                })?;
+                body.extend_from_slice(&bytes);
+            }
+            Ok(version.map(|version| StoredObject { body, version }))
+        })
+    }
+
+    fn write_object_conditional(
+        &self,
+        uri: &str,
+        expected_version: Option<&str>,
+        body: &[u8],
+    ) -> FloeResult<ConditionalWrite> {
+        let key = adls_key_from_uri(uri)?;
+        let client = self.container_client.clone();
+        let body = body.to_vec();
+        self.runtime.block_on(async move {
+            let condition = expected_version
+                .map(|version| IfMatchCondition::Match(version.to_string()))
+                .unwrap_or_else(|| IfMatchCondition::NotMatch("*".to_string()));
+            match client
+                .blob_client(key)
+                .put_block_blob(body)
+                .if_match(condition)
+                .content_type("application/json")
+                .into_future()
+                .await
+            {
+                Ok(resp) => Ok(ConditionalWrite::Written { version: resp.etag }),
+                Err(err) if is_precondition(&err) => Ok(ConditionalWrite::Conflict),
+                Err(err) => Err(Box::new(StorageError(format!("adls upload failed: {err}")))
+                    as Box<dyn std::error::Error + Send + Sync>),
+            }
+        })
+    }
+
+    fn delete_object_conditional(
+        &self,
+        uri: &str,
+        expected_version: Option<&str>,
+    ) -> FloeResult<ConditionalWrite> {
+        let key = adls_key_from_uri(uri)?;
+        let client = self.container_client.clone();
+        self.runtime.block_on(async move {
+            let mut request = client.blob_client(key).delete();
+            if let Some(version) = expected_version {
+                request = request.if_match(IfMatchCondition::Match(version.to_string()));
+            }
+            match request.into_future().await {
+                Ok(_) => Ok(ConditionalWrite::Written {
+                    version: "deleted".to_string(),
+                }),
+                Err(err) if is_precondition(&err) => Ok(ConditionalWrite::Conflict),
+                Err(err) if is_not_found(&err) => Ok(ConditionalWrite::Written {
+                    version: "deleted".to_string(),
+                }),
+                Err(err) => Err(Box::new(StorageError(format!("adls delete failed: {err}")))
+                    as Box<dyn std::error::Error + Send + Sync>),
+            }
+        })
+    }
+}
+
+fn adls_key_from_uri(uri: &str) -> FloeResult<String> {
+    let key = uri
+        .split_once(".dfs.core.windows.net/")
+        .map(|(_, tail)| tail)
+        .unwrap_or("")
+        .trim_start_matches('/')
+        .to_string();
+    if key.is_empty() {
+        return Err(Box::new(StorageError(
+            "adls state operation requires a blob path".to_string(),
+        )));
+    }
+    Ok(key)
+}
+
+fn is_not_found<E: std::fmt::Display>(err: &E) -> bool {
+    let text = err.to_string();
+    text.contains("404") || text.contains("NotFound")
+}
+
+fn is_precondition<E: std::fmt::Display>(err: &E) -> bool {
+    let text = err.to_string();
+    text.contains("412") || text.contains("condition") || text.contains("Condition")
 }
 
 pub fn parse_adls_uri(uri: &str) -> FloeResult<AdlsLocation> {

--- a/crates/floe-core/src/io/storage/providers/gcs.rs
+++ b/crates/floe-core/src/io/storage/providers/gcs.rs
@@ -255,11 +255,16 @@ impl StorageClient for GcsClient {
         uri: &str,
         expected_version: Option<&str>,
     ) -> FloeResult<ConditionalWrite> {
+        let Some(expected_version) = expected_version else {
+            return Ok(ConditionalWrite::Written {
+                version: "deleted".to_string(),
+            });
+        };
         let location = parse_gcs_uri(uri)?;
         let client = self.client.clone();
         let generation = expected_version
-            .map(str::parse::<i64>)
-            .transpose()
+            .parse::<i64>()
+            .map(Some)
             .map_err(|err| Box::new(StorageError(format!("invalid gcs generation: {err}"))))?;
         self.runtime.block_on(async move {
             match client

--- a/crates/floe-core/src/io/storage/providers/gcs.rs
+++ b/crates/floe-core/src/io/storage/providers/gcs.rs
@@ -10,7 +10,7 @@ use tokio::runtime::Runtime;
 
 use crate::errors::StorageError;
 use crate::io::storage::uri::{format_bucket_uri, parse_bucket_uri, BucketLocation};
-use crate::io::storage::{planner, ObjectRef, StorageClient};
+use crate::io::storage::{planner, ConditionalWrite, ObjectRef, StorageClient, StoredObject};
 use crate::FloeResult;
 
 pub struct GcsClient {
@@ -176,6 +176,123 @@ impl StorageClient for GcsClient {
         let location = parse_gcs_uri(uri)?;
         planner::exists_by_key(self, &location.key)
     }
+
+    fn read_object(&self, uri: &str) -> FloeResult<Option<StoredObject>> {
+        let location = parse_gcs_uri(uri)?;
+        let client = self.client.clone();
+        self.runtime.block_on(async move {
+            let object = client
+                .get_object(&GetObjectRequest {
+                    bucket: location.bucket.clone(),
+                    object: location.key.clone(),
+                    ..Default::default()
+                })
+                .await;
+            let object = match object {
+                Ok(object) => object,
+                Err(err) if is_not_found(&err) => return Ok(None),
+                Err(err) => {
+                    return Err(
+                        Box::new(StorageError(format!("gcs get object failed: {err}")))
+                            as Box<dyn std::error::Error + Send + Sync>,
+                    )
+                }
+            };
+            let data = client
+                .download_object(
+                    &GetObjectRequest {
+                        bucket: location.bucket,
+                        object: location.key,
+                        ..Default::default()
+                    },
+                    &Range::default(),
+                )
+                .await
+                .map_err(|err| {
+                    Box::new(StorageError(format!("gcs download failed: {err}")))
+                        as Box<dyn std::error::Error + Send + Sync>
+                })?;
+            Ok(Some(StoredObject {
+                body: data,
+                version: object.generation.to_string(),
+            }))
+        })
+    }
+
+    fn write_object_conditional(
+        &self,
+        uri: &str,
+        expected_version: Option<&str>,
+        body: &[u8],
+    ) -> FloeResult<ConditionalWrite> {
+        let location = parse_gcs_uri(uri)?;
+        let client = self.client.clone();
+        let data = body.to_vec();
+        let generation = expected_version
+            .map(str::parse::<i64>)
+            .transpose()
+            .map_err(|err| Box::new(StorageError(format!("invalid gcs generation: {err}"))))?;
+        self.runtime.block_on(async move {
+            let upload_type = UploadType::Simple(Media::new(location.key.clone()));
+            let request = UploadObjectRequest {
+                bucket: location.bucket,
+                if_generation_match: Some(generation.unwrap_or(0)),
+                ..Default::default()
+            };
+            match client.upload_object(&request, data, &upload_type).await {
+                Ok(object) => Ok(ConditionalWrite::Written {
+                    version: object.generation.to_string(),
+                }),
+                Err(err) if is_precondition(&err) => Ok(ConditionalWrite::Conflict),
+                Err(err) => Err(Box::new(StorageError(format!("gcs upload failed: {err}")))
+                    as Box<dyn std::error::Error + Send + Sync>),
+            }
+        })
+    }
+
+    fn delete_object_conditional(
+        &self,
+        uri: &str,
+        expected_version: Option<&str>,
+    ) -> FloeResult<ConditionalWrite> {
+        let location = parse_gcs_uri(uri)?;
+        let client = self.client.clone();
+        let generation = expected_version
+            .map(str::parse::<i64>)
+            .transpose()
+            .map_err(|err| Box::new(StorageError(format!("invalid gcs generation: {err}"))))?;
+        self.runtime.block_on(async move {
+            match client
+                .delete_object(&DeleteObjectRequest {
+                    bucket: location.bucket,
+                    object: location.key,
+                    if_generation_match: generation,
+                    ..Default::default()
+                })
+                .await
+            {
+                Ok(_) => Ok(ConditionalWrite::Written {
+                    version: "deleted".to_string(),
+                }),
+                Err(err) if is_precondition(&err) => Ok(ConditionalWrite::Conflict),
+                Err(err) if is_not_found(&err) => Ok(ConditionalWrite::Written {
+                    version: "deleted".to_string(),
+                }),
+                Err(err) => Err(Box::new(StorageError(format!("gcs delete failed: {err}")))
+                    as Box<dyn std::error::Error + Send + Sync>),
+            }
+        })
+    }
+}
+
+fn is_not_found<E: std::fmt::Display>(err: &E) -> bool {
+    let text = err.to_string();
+    text.contains("404") || text.contains("NotFound")
+}
+
+fn is_precondition<E: std::fmt::Display>(err: &E) -> bool {
+    let text = err.to_string();
+    text.contains("412") || text.contains("condition") || text.contains("Precondition")
 }
 
 pub fn parse_gcs_uri(uri: &str) -> FloeResult<GcsLocation> {

--- a/crates/floe-core/src/io/storage/providers/local.rs
+++ b/crates/floe-core/src/io/storage/providers/local.rs
@@ -5,7 +5,7 @@ use glob::glob;
 use crate::errors::{RunError, StorageError};
 use crate::{config, ConfigError, FloeResult};
 
-use crate::io::storage::{planner, ObjectRef, StorageClient};
+use crate::io::storage::{planner, ConditionalWrite, ObjectRef, StorageClient, StoredObject};
 
 pub struct LocalClient;
 
@@ -126,6 +126,71 @@ impl StorageClient for LocalClient {
         let path = Path::new(uri.trim_start_matches("local://"));
         Ok(path.exists())
     }
+
+    fn read_object(&self, uri: &str) -> FloeResult<Option<StoredObject>> {
+        let path = Path::new(uri.trim_start_matches("local://"));
+        if !path.exists() {
+            return Ok(None);
+        }
+        Ok(Some(StoredObject {
+            body: std::fs::read(path)?,
+            version: local_version(path)?,
+        }))
+    }
+
+    fn write_object_conditional(
+        &self,
+        uri: &str,
+        expected_version: Option<&str>,
+        body: &[u8],
+    ) -> FloeResult<ConditionalWrite> {
+        let path = PathBuf::from(uri.trim_start_matches("local://"));
+        let current = if path.exists() {
+            Some(local_version(&path)?)
+        } else {
+            None
+        };
+        if current.as_deref() != expected_version {
+            return Ok(ConditionalWrite::Conflict);
+        }
+        planner::ensure_parent_dir(&path)?;
+        std::fs::write(&path, body)?;
+        Ok(ConditionalWrite::Written {
+            version: local_version(&path)?,
+        })
+    }
+
+    fn delete_object_conditional(
+        &self,
+        uri: &str,
+        expected_version: Option<&str>,
+    ) -> FloeResult<ConditionalWrite> {
+        let path = PathBuf::from(uri.trim_start_matches("local://"));
+        let current = if path.exists() {
+            Some(local_version(&path)?)
+        } else {
+            None
+        };
+        if current.as_deref() != expected_version {
+            return Ok(ConditionalWrite::Conflict);
+        }
+        if path.exists() {
+            std::fs::remove_file(&path)?;
+        }
+        Ok(ConditionalWrite::Written {
+            version: "deleted".to_string(),
+        })
+    }
+}
+
+fn local_version(path: &Path) -> FloeResult<String> {
+    let metadata = std::fs::metadata(path)?;
+    let modified = metadata
+        .modified()?
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_nanos();
+    Ok(format!("{}:{modified}", metadata.len()))
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/crates/floe-core/src/io/storage/providers/local.rs
+++ b/crates/floe-core/src/io/storage/providers/local.rs
@@ -132,6 +132,10 @@ impl StorageClient for LocalClient {
         if !path.exists() {
             return Ok(None);
         }
+        let _lock = FileLock::acquire(path)?;
+        if !path.exists() {
+            return Ok(None);
+        }
         Ok(Some(StoredObject {
             body: std::fs::read(path)?,
             version: local_version(path)?,

--- a/crates/floe-core/src/io/storage/providers/local.rs
+++ b/crates/floe-core/src/io/storage/providers/local.rs
@@ -145,6 +145,8 @@ impl StorageClient for LocalClient {
         body: &[u8],
     ) -> FloeResult<ConditionalWrite> {
         let path = PathBuf::from(uri.trim_start_matches("local://"));
+        planner::ensure_parent_dir(&path)?;
+        let _lock = FileLock::acquire(&path)?;
         let current = if path.exists() {
             Some(local_version(&path)?)
         } else {
@@ -153,7 +155,6 @@ impl StorageClient for LocalClient {
         if current.as_deref() != expected_version {
             return Ok(ConditionalWrite::Conflict);
         }
-        planner::ensure_parent_dir(&path)?;
         std::fs::write(&path, body)?;
         Ok(ConditionalWrite::Written {
             version: local_version(&path)?,
@@ -166,6 +167,8 @@ impl StorageClient for LocalClient {
         expected_version: Option<&str>,
     ) -> FloeResult<ConditionalWrite> {
         let path = PathBuf::from(uri.trim_start_matches("local://"));
+        planner::ensure_parent_dir(&path)?;
+        let _lock = FileLock::acquire(&path)?;
         let current = if path.exists() {
             Some(local_version(&path)?)
         } else {
@@ -180,6 +183,43 @@ impl StorageClient for LocalClient {
         Ok(ConditionalWrite::Written {
             version: "deleted".to_string(),
         })
+    }
+}
+
+struct FileLock {
+    path: PathBuf,
+}
+
+impl FileLock {
+    fn acquire(base: &Path) -> FloeResult<Self> {
+        let lock_path = PathBuf::from(format!("{}.lock", base.display()));
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
+        loop {
+            match std::fs::OpenOptions::new()
+                .write(true)
+                .create_new(true)
+                .open(&lock_path)
+            {
+                Ok(_) => return Ok(Self { path: lock_path }),
+                Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {
+                    if std::time::Instant::now() >= deadline {
+                        return Err(format!(
+                            "timed out acquiring local state lock {}",
+                            lock_path.display()
+                        )
+                        .into());
+                    }
+                    std::thread::sleep(std::time::Duration::from_millis(10));
+                }
+                Err(e) => return Err(Box::new(e)),
+            }
+        }
+    }
+}
+
+impl Drop for FileLock {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_file(&self.path);
     }
 }
 

--- a/crates/floe-core/src/io/storage/providers/s3.rs
+++ b/crates/floe-core/src/io/storage/providers/s3.rs
@@ -9,7 +9,7 @@ use tokio::runtime::Runtime;
 
 use crate::errors::StorageError;
 use crate::io::storage::uri::{format_bucket_uri, parse_bucket_uri, BucketLocation};
-use crate::io::storage::{planner, ObjectRef, StorageClient};
+use crate::io::storage::{planner, ConditionalWrite, ObjectRef, StorageClient, StoredObject};
 use crate::FloeResult;
 
 pub struct S3Client {
@@ -197,6 +197,116 @@ impl StorageClient for S3Client {
         let location = parse_s3_uri(uri)?;
         planner::exists_by_key(self, &location.key)
     }
+
+    fn read_object(&self, uri: &str) -> FloeResult<Option<StoredObject>> {
+        let location = parse_s3_uri(uri)?;
+        self.runtime.block_on(async move {
+            let response = self
+                .client
+                .get_object()
+                .bucket(location.bucket)
+                .key(location.key)
+                .send()
+                .await;
+            let response = match response {
+                Ok(response) => response,
+                Err(err) if is_not_found(&err) => return Ok(None),
+                Err(err) => {
+                    return Err(
+                        Box::new(StorageError(format!("s3 get object failed: {err}")))
+                            as Box<dyn std::error::Error + Send + Sync>,
+                    )
+                }
+            };
+            let version = response.e_tag.unwrap_or_default();
+            let body = response.body.collect().await.map_err(|err| {
+                Box::new(StorageError(format!("s3 read object body failed: {err}")))
+                    as Box<dyn std::error::Error + Send + Sync>
+            })?;
+            Ok(Some(StoredObject {
+                body: body.into_bytes().to_vec(),
+                version,
+            }))
+        })
+    }
+
+    fn write_object_conditional(
+        &self,
+        uri: &str,
+        expected_version: Option<&str>,
+        body: &[u8],
+    ) -> FloeResult<ConditionalWrite> {
+        let location = parse_s3_uri(uri)?;
+        let body = ByteStream::from(body.to_vec());
+        self.runtime.block_on(async move {
+            let mut request = self
+                .client
+                .put_object()
+                .bucket(location.bucket)
+                .key(location.key)
+                .body(body);
+            request = match expected_version {
+                Some(version) => request.if_match(version),
+                None => request.if_none_match("*"),
+            };
+            match request.send().await {
+                Ok(output) => Ok(ConditionalWrite::Written {
+                    version: output.e_tag.unwrap_or_default(),
+                }),
+                Err(err) if is_precondition_or_conflict(&err) => Ok(ConditionalWrite::Conflict),
+                Err(err) => Err(
+                    Box::new(StorageError(format!("s3 put object failed: {err}")))
+                        as Box<dyn std::error::Error + Send + Sync>,
+                ),
+            }
+        })
+    }
+
+    fn delete_object_conditional(
+        &self,
+        uri: &str,
+        expected_version: Option<&str>,
+    ) -> FloeResult<ConditionalWrite> {
+        let Some(expected_version) = expected_version else {
+            return self.delete_object(uri).map(|_| ConditionalWrite::Written {
+                version: "deleted".to_string(),
+            });
+        };
+        let location = parse_s3_uri(uri)?;
+        self.runtime.block_on(async move {
+            match self
+                .client
+                .delete_object()
+                .bucket(location.bucket)
+                .key(location.key)
+                .if_match(expected_version)
+                .send()
+                .await
+            {
+                Ok(_) => Ok(ConditionalWrite::Written {
+                    version: "deleted".to_string(),
+                }),
+                Err(err) if is_precondition_or_conflict(&err) => Ok(ConditionalWrite::Conflict),
+                Err(err) => Err(
+                    Box::new(StorageError(format!("s3 delete object failed: {err}")))
+                        as Box<dyn std::error::Error + Send + Sync>,
+                ),
+            }
+        })
+    }
+}
+
+fn is_not_found<E: std::fmt::Display>(err: &E) -> bool {
+    let text = err.to_string();
+    text.contains("NoSuchKey") || text.contains("NotFound") || text.contains("404")
+}
+
+fn is_precondition_or_conflict<E: std::fmt::Display>(err: &E) -> bool {
+    let text = err.to_string();
+    text.contains("PreconditionFailed")
+        || text.contains("ConditionalRequestConflict")
+        || text.contains("412")
+        || text.contains("409")
 }
 
 pub fn parse_s3_uri(uri: &str) -> FloeResult<S3Location> {

--- a/crates/floe-core/src/io/storage/providers/s3.rs
+++ b/crates/floe-core/src/io/storage/providers/s3.rs
@@ -268,7 +268,9 @@ impl StorageClient for S3Client {
         expected_version: Option<&str>,
     ) -> FloeResult<ConditionalWrite> {
         let Some(expected_version) = expected_version else {
-            return self.delete_object(uri).map(|_| ConditionalWrite::Written {
+            // expected_version == None means we expected no object to exist.
+            // Do not delete — any object present was created by a concurrent runner.
+            return Ok(ConditionalWrite::Written {
                 version: "deleted".to_string(),
             });
         };

--- a/crates/floe-core/src/run/entity/incremental.rs
+++ b/crates/floe-core/src/run/entity/incremental.rs
@@ -1,4 +1,9 @@
+use std::sync::mpsc::{self, Sender};
+use std::thread::{self, JoinHandle};
+use std::time::Duration;
+
 use crate::config::IncrementalMode;
+use crate::config::StorageResolver;
 use crate::io::format::InputFile;
 use crate::io::storage::CloudClient;
 use crate::report::{
@@ -7,7 +12,7 @@ use crate::report::{
 use crate::run::RunContext;
 use crate::state::{
     claim_entity_inputs, promote_claimed_entity_state, release_claimed_entity_state,
-    ClaimedEntityState, EntityFileState,
+    renew_claimed_entity_state, ClaimedEntityState, EntityFileState, CLAIM_TTL_SECONDS,
 };
 use crate::{config, warnings, FloeResult};
 
@@ -84,9 +89,14 @@ pub(super) fn prepare_incremental_context(
     Ok(IncrementalContext {
         pending_inputs: claim_outcome.pending_inputs,
         skipped_reports,
-        pending_state: claim_outcome
-            .claimed_state
-            .map(|claimed| PendingEntityState { claimed }),
+        pending_state: claim_outcome.claimed_state.map(|claimed| {
+            PendingEntityState::new(
+                claimed,
+                context.storage_resolver.clone(),
+                entity.name.clone(),
+                context.run_id.clone(),
+            )
+        }),
     })
 }
 
@@ -127,36 +137,145 @@ fn build_skipped_report(input_file: String, warning: Option<String>) -> FileRepo
 
 pub(super) struct PendingEntityState {
     claimed: ClaimedEntityState,
+    resolver: StorageResolver,
+    entity_name: String,
+    run_id: String,
+    heartbeat: Option<ClaimHeartbeat>,
+    finalized: bool,
 }
 
 impl PendingEntityState {
+    fn new(
+        claimed: ClaimedEntityState,
+        resolver: StorageResolver,
+        entity_name: String,
+        run_id: String,
+    ) -> Self {
+        let heartbeat = ClaimHeartbeat::start(
+            resolver.clone(),
+            entity_name.clone(),
+            run_id.clone(),
+            claimed.clone(),
+        );
+        Self {
+            claimed,
+            resolver,
+            entity_name,
+            run_id,
+            heartbeat: Some(heartbeat),
+            finalized: false,
+        }
+    }
+
     pub(super) fn commit(
-        &self,
-        context: &RunContext,
+        &mut self,
+        _context: &RunContext,
         cloud: &mut CloudClient,
-        entity: &config::EntityConfig,
+        _entity: &config::EntityConfig,
     ) -> FloeResult<()> {
+        self.stop_heartbeat();
         promote_claimed_entity_state(
-            &context.storage_resolver,
+            &self.resolver,
             cloud,
-            entity,
-            &context.run_id,
+            &self.entity_name,
+            &self.run_id,
             &self.claimed,
-        )
+        )?;
+        self.finalized = true;
+        Ok(())
     }
 
     pub(super) fn release(
-        &self,
-        context: &RunContext,
+        &mut self,
+        _context: &RunContext,
         cloud: &mut CloudClient,
-        entity: &config::EntityConfig,
+        _entity: &config::EntityConfig,
     ) -> FloeResult<()> {
+        self.stop_heartbeat();
         release_claimed_entity_state(
-            &context.storage_resolver,
+            &self.resolver,
             cloud,
-            entity,
-            &context.run_id,
+            &self.entity_name,
+            &self.run_id,
             &self.claimed,
-        )
+        )?;
+        self.finalized = true;
+        Ok(())
     }
+
+    fn stop_heartbeat(&mut self) {
+        if let Some(mut heartbeat) = self.heartbeat.take() {
+            heartbeat.stop();
+        }
+    }
+}
+
+impl Drop for PendingEntityState {
+    fn drop(&mut self) {
+        self.stop_heartbeat();
+        if self.finalized {
+            return;
+        }
+        let mut cloud = CloudClient::new();
+        let _ = release_claimed_entity_state(
+            &self.resolver,
+            &mut cloud,
+            &self.entity_name,
+            &self.run_id,
+            &self.claimed,
+        );
+    }
+}
+
+struct ClaimHeartbeat {
+    stop_tx: Option<Sender<()>>,
+    handle: Option<JoinHandle<()>>,
+}
+
+impl ClaimHeartbeat {
+    fn start(
+        resolver: StorageResolver,
+        entity_name: String,
+        run_id: String,
+        claimed: ClaimedEntityState,
+    ) -> Self {
+        let (stop_tx, stop_rx) = mpsc::channel();
+        let interval = claim_renewal_interval();
+        let handle = thread::spawn(move || {
+            while stop_rx.recv_timeout(interval).is_err() {
+                let mut cloud = CloudClient::new();
+                let _ = renew_claimed_entity_state(
+                    &resolver,
+                    &mut cloud,
+                    &entity_name,
+                    &run_id,
+                    &claimed,
+                );
+            }
+        });
+        Self {
+            stop_tx: Some(stop_tx),
+            handle: Some(handle),
+        }
+    }
+
+    fn stop(&mut self) {
+        if let Some(stop_tx) = self.stop_tx.take() {
+            let _ = stop_tx.send(());
+        }
+        if let Some(handle) = self.handle.take() {
+            let _ = handle.join();
+        }
+    }
+}
+
+impl Drop for ClaimHeartbeat {
+    fn drop(&mut self) {
+        self.stop();
+    }
+}
+
+fn claim_renewal_interval() -> Duration {
+    let ttl = CLAIM_TTL_SECONDS.max(1) as u64;
+    Duration::from_secs((ttl / 3).clamp(1, 300))
 }

--- a/crates/floe-core/src/run/entity/incremental.rs
+++ b/crates/floe-core/src/run/entity/incremental.rs
@@ -1,17 +1,15 @@
-use std::collections::BTreeMap;
-use std::path::PathBuf;
-
 use crate::config::IncrementalMode;
 use crate::io::format::InputFile;
+use crate::io::storage::CloudClient;
 use crate::report::{
     FileMismatch, FileOutput, FileReport, FileStatus, FileValidation, MismatchAction,
 };
 use crate::run::RunContext;
 use crate::state::{
-    read_entity_state, resolve_entity_state_path, validate_entity_state, write_entity_state_atomic,
-    EntityFileState, EntityState,
+    claim_entity_inputs, promote_claimed_entity_state, release_claimed_entity_state,
+    ClaimedEntityState, EntityFileState,
 };
-use crate::{config, report, warnings, FloeResult};
+use crate::{config, warnings, FloeResult};
 
 pub(super) struct IncrementalContext {
     pub(super) pending_inputs: Vec<InputFile>,
@@ -21,6 +19,7 @@ pub(super) struct IncrementalContext {
 
 pub(super) fn prepare_incremental_context(
     context: &RunContext,
+    cloud: &mut CloudClient,
     entity: &config::EntityConfig,
     input_files: Vec<InputFile>,
 ) -> FloeResult<IncrementalContext> {
@@ -32,71 +31,62 @@ pub(super) fn prepare_incremental_context(
         });
     }
 
-    let resolved_state = resolve_entity_state_path(&context.storage_resolver, entity)?;
-    let state_path = resolved_state.local_path.ok_or_else(|| {
-        Box::new(crate::ConfigError(format!(
-            "entity.name={} incremental_mode=file requires a local state path",
-            entity.name
-        ))) as Box<dyn std::error::Error + Send + Sync>
-    })?;
-    let existing = read_entity_state(&state_path)?
-        .map(|state| validate_entity_state(entity, state))
-        .transpose()?
-        .unwrap_or_else(|| EntityState::new(&entity.name));
-
-    let mut pending_inputs = Vec::new();
     let mut skipped_reports = Vec::new();
-    let mut pending_entries = BTreeMap::new();
+    let claim_outcome = claim_entity_inputs(
+        &context.storage_resolver,
+        cloud,
+        entity,
+        &context.run_id,
+        input_files,
+    )?;
 
-    for input_file in input_files {
-        match existing.files.get(&input_file.source_uri) {
-            Some(recorded) if file_state_matches(recorded, &input_file) => {
-                skipped_reports.push(build_skipped_report(input_file.source_uri.clone(), None));
-            }
-            Some(recorded) => {
-                let message = format!(
-                    "entity.name={} incremental_mode=file skipping previously ingested file with changed metadata: {} (recorded size={:?}, mtime={:?}; current size={:?}, mtime={:?})",
-                    entity.name,
-                    input_file.source_uri,
-                    recorded.size,
-                    recorded.mtime,
-                    input_file.source_size,
-                    input_file.source_mtime,
-                );
-                warnings::emit(
-                    &context.run_id,
-                    Some(&entity.name),
-                    Some(&input_file.source_uri),
-                    Some("incremental_file_changed"),
-                    &message,
-                );
-                skipped_reports.push(build_skipped_report(
-                    input_file.source_uri.clone(),
-                    Some(message),
-                ));
-            }
-            None => {
-                pending_entries.insert(
-                    input_file.source_uri.clone(),
-                    PendingFileState {
-                        size: input_file.source_size,
-                        mtime: input_file.source_mtime.clone(),
-                    },
-                );
-                pending_inputs.push(input_file);
-            }
+    for (input_file, recorded) in &claim_outcome.already_processed {
+        if file_state_matches(recorded, input_file) {
+            skipped_reports.push(build_skipped_report(input_file.source_uri.clone(), None));
+        } else {
+            let message = format!(
+                "entity.name={} incremental_mode=file skipping previously ingested file with changed metadata: {} (recorded size={:?}, mtime={:?}; current size={:?}, mtime={:?})",
+                entity.name,
+                input_file.source_uri,
+                recorded.size,
+                recorded.mtime,
+                input_file.source_size,
+                input_file.source_mtime,
+            );
+            warnings::emit(
+                &context.run_id,
+                Some(&entity.name),
+                Some(&input_file.source_uri),
+                Some("incremental_file_changed"),
+                &message,
+            );
+            skipped_reports.push(build_skipped_report(
+                input_file.source_uri.clone(),
+                Some(message),
+            ));
         }
+    }
+    for source_uri in claim_outcome.active_claims {
+        let message = format!(
+            "entity.name={} incremental_mode=file skipping file claimed by another active run: {}",
+            entity.name, source_uri
+        );
+        warnings::emit(
+            &context.run_id,
+            Some(&entity.name),
+            Some(&source_uri),
+            Some("incremental_file_claimed"),
+            &message,
+        );
+        skipped_reports.push(build_skipped_report(source_uri, Some(message)));
     }
 
     Ok(IncrementalContext {
-        pending_inputs,
+        pending_inputs: claim_outcome.pending_inputs,
         skipped_reports,
-        pending_state: Some(PendingEntityState {
-            path: state_path,
-            entity_name: entity.name.clone(),
-            base_state: existing,
-            pending_entries,
-        }),
+        pending_state: claim_outcome
+            .claimed_state
+            .map(|claimed| PendingEntityState { claimed }),
     })
 }
 
@@ -135,43 +125,38 @@ fn build_skipped_report(input_file: String, warning: Option<String>) -> FileRepo
     }
 }
 
-struct PendingFileState {
-    size: Option<u64>,
-    mtime: Option<String>,
-}
-
 pub(super) struct PendingEntityState {
-    path: PathBuf,
-    entity_name: String,
-    base_state: EntityState,
-    pending_entries: BTreeMap<String, PendingFileState>,
+    claimed: ClaimedEntityState,
 }
 
 impl PendingEntityState {
-    pub(super) fn commit(&self) -> FloeResult<()> {
-        if self.pending_entries.is_empty() {
-            return Ok(());
-        }
+    pub(super) fn commit(
+        &self,
+        context: &RunContext,
+        cloud: &mut CloudClient,
+        entity: &config::EntityConfig,
+    ) -> FloeResult<()> {
+        promote_claimed_entity_state(
+            &context.storage_resolver,
+            cloud,
+            entity,
+            &context.run_id,
+            &self.claimed,
+        )
+    }
 
-        let processed_at = report::now_rfc3339();
-        let mut state = self.base_state.clone();
-        if state.schema.is_empty() {
-            state.schema = crate::state::ENTITY_STATE_SCHEMA_V1.to_string();
-        }
-        if state.entity.is_empty() {
-            state.entity = self.entity_name.clone();
-        }
-        state.updated_at = Some(processed_at.clone());
-        for (source_uri, pending) in &self.pending_entries {
-            state.files.insert(
-                source_uri.clone(),
-                EntityFileState {
-                    processed_at: processed_at.clone(),
-                    size: pending.size,
-                    mtime: pending.mtime.clone(),
-                },
-            );
-        }
-        write_entity_state_atomic(&self.path, &state)
+    pub(super) fn release(
+        &self,
+        context: &RunContext,
+        cloud: &mut CloudClient,
+        entity: &config::EntityConfig,
+    ) -> FloeResult<()> {
+        release_claimed_entity_state(
+            &context.storage_resolver,
+            cloud,
+            entity,
+            &context.run_id,
+            &self.claimed,
+        )
     }
 }

--- a/crates/floe-core/src/run/entity/mod.rs
+++ b/crates/floe-core/src/run/entity/mod.rs
@@ -117,7 +117,8 @@ pub(super) fn run_entity(
         listed: resolved_files,
         mode: resolved_mode,
     } = plan.resolved_inputs;
-    let incremental = incremental::prepare_incremental_context(context, entity, input_files)?;
+    let incremental =
+        incremental::prepare_incremental_context(context, runtime.storage(), entity, input_files)?;
     let input_files = incremental.pending_inputs;
     let pending_input_count = input_files.len();
 
@@ -353,7 +354,9 @@ pub(super) fn run_entity(
             status,
             report::RunStatus::Success | report::RunStatus::SuccessWithWarnings
         ) {
-            pending_state.commit()?;
+            pending_state.commit(context, runtime.storage(), entity)?;
+        } else {
+            pending_state.release(context, runtime.storage(), entity)?;
         }
     }
 

--- a/crates/floe-core/src/run/entity/mod.rs
+++ b/crates/floe-core/src/run/entity/mod.rs
@@ -117,7 +117,7 @@ pub(super) fn run_entity(
         listed: resolved_files,
         mode: resolved_mode,
     } = plan.resolved_inputs;
-    let incremental =
+    let mut incremental =
         incremental::prepare_incremental_context(context, runtime.storage(), entity, input_files)?;
     let input_files = incremental.pending_inputs;
     let pending_input_count = input_files.len();
@@ -342,7 +342,7 @@ pub(super) fn run_entity(
         }
     }
 
-    if let Some(pending_state) = incremental.pending_state.as_ref() {
+    if let Some(pending_state) = incremental.pending_state.as_mut() {
         let (status, _) = report::compute_run_outcome(
             &run_report
                 .files

--- a/crates/floe-core/src/state/mod.rs
+++ b/crates/floe-core/src/state/mod.rs
@@ -8,7 +8,9 @@ use tempfile::NamedTempFile;
 use crate::config::{
     ConfigBase, EntityConfig, IncrementalMode, ResolvedPath, RootConfig, StorageResolver,
 };
-use crate::io::storage::{extensions, CloudClient, ConditionalWrite};
+use crate::io::storage::{
+    extensions, local::LocalClient, CloudClient, ConditionalWrite, StorageClient,
+};
 use crate::{ConfigError, FloeResult};
 
 pub const ENTITY_STATE_SCHEMA_V1: &str = "floe.state.file-ingest.v1";
@@ -363,26 +365,20 @@ pub fn reset_entity_state_with_base(
         return Ok(false);
     }
 
-    let mut cloud = CloudClient::new();
-    let resolver = StorageResolver::new(&config, config_base)?;
-    let loaded = load_target_state_with_resolver(&mut cloud, &resolver, entity, target)?;
-    if !loaded.existed {
-        return Ok(false);
-    }
-    match &loaded.target {
-        EntityStateTarget::Local { path, .. } => {
-            if path.exists() {
-                fs::remove_file(path)?;
-            }
-            Ok(true)
-        }
+    match target {
+        EntityStateTarget::Local { .. } => Ok(false),
         EntityStateTarget::Remote { storage, uri } => {
+            let mut cloud = CloudClient::new();
+            let resolver = StorageResolver::new(&config, config_base)?;
             let client = cloud.client_for_context(
                 &resolver,
-                storage,
+                &storage,
                 &format!("entity.name={}", entity.name),
             )?;
-            match client.delete_object_conditional(uri, loaded.version.as_deref())? {
+            let Some(object) = client.read_object(&uri)? else {
+                return Ok(false);
+            };
+            match client.delete_object_conditional(&uri, Some(&object.version))? {
                 ConditionalWrite::Written { .. } => Ok(true),
                 ConditionalWrite::Conflict => Err(Box::new(ConfigError(format!(
                     "entity.name={} remote state changed while resetting: {}",
@@ -475,15 +471,19 @@ fn load_local_target(
     uri: String,
     entity: &EntityConfig,
 ) -> FloeResult<LoadedEntityState> {
-    let state = read_entity_state(&path)?
-        .map(|state| validate_entity_state(entity, state))
-        .transpose()?
-        .unwrap_or_else(|| EntityState::new(&entity.name));
-    let existed = path.exists();
+    let object = LocalClient::new().read_object(&uri)?;
+    let (state, version, existed) = match object {
+        Some(object) => (
+            validate_entity_state(entity, parse_entity_state(&object.body)?)?,
+            Some(object.version),
+            true,
+        ),
+        None => (EntityState::new(&entity.name), None, false),
+    };
     Ok(LoadedEntityState {
         target: EntityStateTarget::Local { path, uri },
         state,
-        version: None,
+        version,
         existed,
     })
 }
@@ -497,9 +497,15 @@ fn persist_loaded_state(
     state.schema = ENTITY_STATE_SCHEMA_V2.to_string();
     let body = serde_json::to_vec_pretty(&state)?;
     match &loaded.target {
-        EntityStateTarget::Local { path, .. } => {
-            write_entity_state_atomic(path, &state)?;
-            Ok(Some(None))
+        EntityStateTarget::Local { uri, .. } => {
+            match LocalClient::new().write_object_conditional(
+                uri,
+                loaded.version.as_deref(),
+                &body,
+            )? {
+                ConditionalWrite::Written { version } => Ok(Some(Some(version))),
+                ConditionalWrite::Conflict => Ok(None),
+            }
         }
         EntityStateTarget::Remote { uri, storage } => {
             let client = cloud.client_for_context(resolver, storage, "entity state")?;
@@ -517,11 +523,11 @@ fn delete_loaded_state(
     loaded: &LoadedEntityState,
 ) -> FloeResult<Option<Option<String>>> {
     match &loaded.target {
-        EntityStateTarget::Local { path, .. } => {
-            if path.exists() {
-                fs::remove_file(path)?;
+        EntityStateTarget::Local { uri, .. } => {
+            match LocalClient::new().delete_object_conditional(uri, loaded.version.as_deref())? {
+                ConditionalWrite::Written { version } => Ok(Some(Some(version))),
+                ConditionalWrite::Conflict => Ok(None),
             }
-            Ok(Some(None))
         }
         EntityStateTarget::Remote { uri, storage } => {
             let client = cloud.client_for_context(resolver, storage, "entity state")?;

--- a/crates/floe-core/src/state/mod.rs
+++ b/crates/floe-core/src/state/mod.rs
@@ -17,7 +17,7 @@ pub const ENTITY_STATE_SCHEMA_V1: &str = "floe.state.file-ingest.v1";
 pub const ENTITY_STATE_SCHEMA_V2: &str = "floe.state.file-ingest.v2";
 pub const ENTITY_STATE_FILENAME: &str = "state.json";
 const STATE_CAS_RETRIES: usize = 5;
-const CLAIM_TTL_SECONDS: i64 = 60 * 60;
+pub const CLAIM_TTL_SECONDS: i64 = 60 * 60;
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
 pub struct EntityState {
@@ -244,11 +244,11 @@ pub fn claim_entity_inputs(
 pub fn promote_claimed_entity_state(
     resolver: &StorageResolver,
     cloud: &mut CloudClient,
-    entity: &EntityConfig,
+    entity_name: &str,
     run_id: &str,
     claimed: &ClaimedEntityState,
 ) -> FloeResult<()> {
-    mutate_claimed_state(resolver, cloud, entity, claimed, |state| {
+    mutate_claimed_state(resolver, cloud, entity_name, claimed, |state| {
         let processed_at = now_rfc3339();
         let claimed_files: Vec<String> = state
             .claims
@@ -275,20 +275,39 @@ pub fn promote_claimed_entity_state(
 pub fn release_claimed_entity_state(
     resolver: &StorageResolver,
     cloud: &mut CloudClient,
-    entity: &EntityConfig,
+    entity_name: &str,
     run_id: &str,
     claimed: &ClaimedEntityState,
 ) -> FloeResult<()> {
-    mutate_claimed_state(resolver, cloud, entity, claimed, |state| {
+    mutate_claimed_state(resolver, cloud, entity_name, claimed, |state| {
         state.claims.retain(|_, claim| claim.run_id != run_id);
         state.updated_at = Some(now_rfc3339());
+    })
+}
+
+pub fn renew_claimed_entity_state(
+    resolver: &StorageResolver,
+    cloud: &mut CloudClient,
+    entity_name: &str,
+    run_id: &str,
+    claimed: &ClaimedEntityState,
+) -> FloeResult<()> {
+    mutate_claimed_state(resolver, cloud, entity_name, claimed, |state| {
+        let now = now_rfc3339();
+        let expires_at = rfc3339_after_seconds(CLAIM_TTL_SECONDS);
+        for claim in state.claims.values_mut() {
+            if claim.run_id == run_id {
+                claim.expires_at = expires_at.clone();
+            }
+        }
+        state.updated_at = Some(now);
     })
 }
 
 fn mutate_claimed_state(
     resolver: &StorageResolver,
     cloud: &mut CloudClient,
-    entity: &EntityConfig,
+    entity_name: &str,
     claimed: &ClaimedEntityState,
     mutate: impl Fn(&mut EntityState),
 ) -> FloeResult<()> {
@@ -301,7 +320,12 @@ fn mutate_claimed_state(
                 existed: claimed.version.is_some(),
             }
         } else {
-            load_target_state_with_resolver(cloud, resolver, entity, claimed.target.clone())?
+            load_target_state_with_entity_name(
+                cloud,
+                resolver,
+                entity_name,
+                claimed.target.clone(),
+            )?
         };
         mutate(&mut loaded.state);
         loaded.state.schema = ENTITY_STATE_SCHEMA_V2.to_string();
@@ -316,7 +340,7 @@ fn mutate_claimed_state(
     }
     Err(Box::new(ConfigError(format!(
         "entity.name={} incremental state update conflicted after {STATE_CAS_RETRIES} retries",
-        entity.name
+        entity_name
     ))))
 }
 
@@ -439,22 +463,31 @@ fn load_target_state_with_resolver(
     entity: &EntityConfig,
     target: EntityStateTarget,
 ) -> FloeResult<LoadedEntityState> {
+    load_target_state_with_entity_name(cloud, resolver, &entity.name, target)
+}
+
+fn load_target_state_with_entity_name(
+    cloud: &mut CloudClient,
+    resolver: &StorageResolver,
+    entity_name: &str,
+    target: EntityStateTarget,
+) -> FloeResult<LoadedEntityState> {
     match target {
-        EntityStateTarget::Local { path, uri } => load_local_target(path, uri, entity),
+        EntityStateTarget::Local { path, uri } => load_local_target(path, uri, entity_name),
         EntityStateTarget::Remote { storage, uri } => {
             let client = cloud.client_for_context(
                 resolver,
                 &storage,
-                &format!("entity.name={}", entity.name),
+                &format!("entity.name={entity_name}"),
             )?;
             let object = client.read_object(&uri)?;
             let (state, version, existed) = match object {
                 Some(object) => (
-                    validate_entity_state(entity, parse_entity_state(&object.body)?)?,
+                    validate_entity_state_name(entity_name, parse_entity_state(&object.body)?)?,
                     Some(object.version),
                     true,
                 ),
-                None => (EntityState::new(&entity.name), None, false),
+                None => (EntityState::new(entity_name), None, false),
             };
             Ok(LoadedEntityState {
                 target: EntityStateTarget::Remote { storage, uri },
@@ -469,16 +502,16 @@ fn load_target_state_with_resolver(
 fn load_local_target(
     path: PathBuf,
     uri: String,
-    entity: &EntityConfig,
+    entity_name: &str,
 ) -> FloeResult<LoadedEntityState> {
     let object = LocalClient::new().read_object(&uri)?;
     let (state, version, existed) = match object {
         Some(object) => (
-            validate_entity_state(entity, parse_entity_state(&object.body)?)?,
+            validate_entity_state_name(entity_name, parse_entity_state(&object.body)?)?,
             Some(object.version),
             true,
         ),
-        None => (EntityState::new(&entity.name), None, false),
+        None => (EntityState::new(entity_name), None, false),
     };
     Ok(LoadedEntityState {
         target: EntityStateTarget::Local { path, uri },
@@ -677,17 +710,21 @@ fn is_remote_uri(value: &str) -> bool {
 }
 
 pub fn validate_entity_state(entity: &EntityConfig, state: EntityState) -> FloeResult<EntityState> {
+    validate_entity_state_name(&entity.name, state)
+}
+
+fn validate_entity_state_name(entity_name: &str, state: EntityState) -> FloeResult<EntityState> {
     if state.schema != ENTITY_STATE_SCHEMA_V1 && state.schema != ENTITY_STATE_SCHEMA_V2 {
         return Err(Box::new(ConfigError(format!(
             "entity.name={} state schema mismatch: expected {} or {}, got {}",
-            entity.name, ENTITY_STATE_SCHEMA_V1, ENTITY_STATE_SCHEMA_V2, state.schema
+            entity_name, ENTITY_STATE_SCHEMA_V1, ENTITY_STATE_SCHEMA_V2, state.schema
         ))));
     }
 
-    if state.entity != entity.name {
+    if state.entity != entity_name {
         return Err(Box::new(ConfigError(format!(
             "entity.name={} state entity mismatch: expected {}, got {}",
-            entity.name, entity.name, state.entity
+            entity_name, entity_name, state.entity
         ))));
     }
 

--- a/crates/floe-core/src/state/mod.rs
+++ b/crates/floe-core/src/state/mod.rs
@@ -248,12 +248,14 @@ pub fn promote_claimed_entity_state(
     run_id: &str,
     claimed: &ClaimedEntityState,
 ) -> FloeResult<()> {
+    let our_uris: std::collections::HashSet<String> =
+        claimed.state.claims.keys().cloned().collect();
     mutate_claimed_state(resolver, cloud, entity_name, claimed, |state| {
         let processed_at = now_rfc3339();
         let claimed_files: Vec<String> = state
             .claims
             .iter()
-            .filter(|(_, claim)| claim.run_id == run_id)
+            .filter(|(uri, claim)| claim.run_id == run_id && our_uris.contains(*uri))
             .map(|(source_uri, _)| source_uri.clone())
             .collect();
         for source_uri in claimed_files {

--- a/crates/floe-core/src/state/mod.rs
+++ b/crates/floe-core/src/state/mod.rs
@@ -281,8 +281,12 @@ pub fn release_claimed_entity_state(
     run_id: &str,
     claimed: &ClaimedEntityState,
 ) -> FloeResult<()> {
+    let our_uris: std::collections::HashSet<String> =
+        claimed.state.claims.keys().cloned().collect();
     mutate_claimed_state(resolver, cloud, entity_name, claimed, |state| {
-        state.claims.retain(|_, claim| claim.run_id != run_id);
+        state
+            .claims
+            .retain(|uri, claim| !(claim.run_id == run_id && our_uris.contains(uri)));
         state.updated_at = Some(now_rfc3339());
     })
 }

--- a/crates/floe-core/src/state/mod.rs
+++ b/crates/floe-core/src/state/mod.rs
@@ -8,11 +8,14 @@ use tempfile::NamedTempFile;
 use crate::config::{
     ConfigBase, EntityConfig, IncrementalMode, ResolvedPath, RootConfig, StorageResolver,
 };
-use crate::io::storage::extensions;
+use crate::io::storage::{extensions, CloudClient, ConditionalWrite};
 use crate::{ConfigError, FloeResult};
 
 pub const ENTITY_STATE_SCHEMA_V1: &str = "floe.state.file-ingest.v1";
+pub const ENTITY_STATE_SCHEMA_V2: &str = "floe.state.file-ingest.v2";
 pub const ENTITY_STATE_FILENAME: &str = "state.json";
+const STATE_CAS_RETRIES: usize = 5;
+const CLAIM_TTL_SECONDS: i64 = 60 * 60;
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
 pub struct EntityState {
@@ -21,15 +24,18 @@ pub struct EntityState {
     pub updated_at: Option<String>,
     #[serde(default)]
     pub files: BTreeMap<String, EntityFileState>,
+    #[serde(default)]
+    pub claims: BTreeMap<String, EntityFileClaim>,
 }
 
 impl EntityState {
     pub fn new(entity: impl Into<String>) -> Self {
         Self {
-            schema: ENTITY_STATE_SCHEMA_V1.to_string(),
+            schema: ENTITY_STATE_SCHEMA_V2.to_string(),
             entity: entity.into(),
             updated_at: None,
             files: BTreeMap::new(),
+            claims: BTreeMap::new(),
         }
     }
 }
@@ -37,6 +43,15 @@ impl EntityState {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct EntityFileState {
     pub processed_at: String,
+    pub size: Option<u64>,
+    pub mtime: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct EntityFileClaim {
+    pub run_id: String,
+    pub acquired_at: String,
+    pub expires_at: String,
     pub size: Option<u64>,
     pub mtime: Option<String>,
 }
@@ -65,7 +80,7 @@ pub fn resolve_entity_state_path(
             } else {
                 resolver.resolve_local_path(path)?
             };
-            return Ok(with_local_state_fallback(resolver, entity, resolved));
+            return Ok(resolved);
         }
     }
 
@@ -87,65 +102,7 @@ pub fn resolve_entity_state_path(
         entity.source.storage.as_deref(),
         &default_path,
     )?;
-    Ok(with_local_state_fallback(resolver, entity, resolved))
-}
-
-fn with_local_state_fallback(
-    resolver: &StorageResolver,
-    entity: &EntityConfig,
-    mut resolved: ResolvedPath,
-) -> ResolvedPath {
-    if resolved.local_path.is_none() {
-        resolved.local_path = Some(default_local_state_cache_path(
-            resolver,
-            entity,
-            &resolved.uri,
-        ));
-    }
-    resolved
-}
-
-fn default_local_state_cache_path(
-    resolver: &StorageResolver,
-    entity: &EntityConfig,
-    resolved_uri: &str,
-) -> PathBuf {
-    if resolver.config_is_remote() {
-        remote_config_state_cache_root()
-            .join(short_stable_hash_hex(resolved_uri))
-            .join(&entity.name)
-            .join(ENTITY_STATE_FILENAME)
-    } else {
-        resolver
-            .config_local_dir()
-            .join(".floe/state")
-            .join(&entity.name)
-            .join(ENTITY_STATE_FILENAME)
-    }
-}
-
-fn remote_config_state_cache_root() -> PathBuf {
-    if let Some(path) = std::env::var_os("XDG_CACHE_HOME") {
-        let path = PathBuf::from(path);
-        if path.is_absolute() {
-            return path.join("floe/state");
-        }
-    }
-    if let Some(home) = std::env::var_os("HOME") {
-        return PathBuf::from(home).join(".cache/floe/state");
-    }
-    std::env::current_dir()
-        .unwrap_or_else(|_| PathBuf::from("."))
-        .join(".floe/state")
-}
-
-fn short_stable_hash_hex(value: &str) -> String {
-    let mut hash: u64 = 0xcbf29ce484222325;
-    for byte in value.as_bytes() {
-        hash ^= u64::from(*byte);
-        hash = hash.wrapping_mul(0x100000001b3);
-    }
-    format!("{:016x}", hash)
+    Ok(resolved)
 }
 
 pub fn read_entity_state(path: &Path) -> FloeResult<Option<EntityState>> {
@@ -153,8 +110,212 @@ pub fn read_entity_state(path: &Path) -> FloeResult<Option<EntityState>> {
         return Ok(None);
     }
     let payload = fs::read_to_string(path)?;
-    let state: EntityState = serde_json::from_str(&payload)?;
+    let state = parse_entity_state(payload.as_bytes())?;
     Ok(Some(state))
+}
+
+fn parse_entity_state(payload: &[u8]) -> FloeResult<EntityState> {
+    let mut state: EntityState = serde_json::from_slice(payload)?;
+    if state.schema == ENTITY_STATE_SCHEMA_V1 {
+        state.schema = ENTITY_STATE_SCHEMA_V2.to_string();
+        state.claims.clear();
+    }
+    Ok(state)
+}
+
+#[derive(Debug, Clone)]
+pub enum EntityStateTarget {
+    Local { path: PathBuf, uri: String },
+    Remote { storage: String, uri: String },
+}
+
+#[derive(Debug, Clone)]
+pub struct LoadedEntityState {
+    pub target: EntityStateTarget,
+    pub state: EntityState,
+    pub version: Option<String>,
+    pub existed: bool,
+}
+
+#[derive(Debug, Clone)]
+pub struct ClaimedEntityState {
+    pub target: EntityStateTarget,
+    pub state: EntityState,
+    pub version: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct EntityStateClaimOutcome {
+    pub pending_inputs: Vec<crate::io::format::InputFile>,
+    pub claimed_state: Option<ClaimedEntityState>,
+    pub active_claims: Vec<String>,
+    pub already_processed: Vec<(crate::io::format::InputFile, EntityFileState)>,
+}
+
+pub fn claim_entity_inputs(
+    resolver: &StorageResolver,
+    cloud: &mut CloudClient,
+    entity: &EntityConfig,
+    run_id: &str,
+    input_files: Vec<crate::io::format::InputFile>,
+) -> FloeResult<EntityStateClaimOutcome> {
+    if input_files.is_empty() {
+        return Ok(EntityStateClaimOutcome {
+            pending_inputs: Vec::new(),
+            claimed_state: None,
+            active_claims: Vec::new(),
+            already_processed: Vec::new(),
+        });
+    }
+
+    for _ in 0..STATE_CAS_RETRIES {
+        let mut loaded = load_entity_state(resolver, cloud, entity)?;
+        remove_expired_claims(&mut loaded.state);
+        let mut pending_inputs = Vec::new();
+        let mut active_claims = Vec::new();
+        let mut already_processed = Vec::new();
+        let acquired_at = now_rfc3339();
+        let expires_at = rfc3339_after_seconds(CLAIM_TTL_SECONDS);
+
+        for input_file in &input_files {
+            if let Some(recorded) = loaded.state.files.get(&input_file.source_uri) {
+                already_processed.push((input_file.clone(), recorded.clone()));
+                continue;
+            }
+            match loaded.state.claims.get(&input_file.source_uri) {
+                Some(claim) if claim.run_id != run_id => {
+                    active_claims.push(input_file.source_uri.clone());
+                }
+                _ => {
+                    loaded.state.claims.insert(
+                        input_file.source_uri.clone(),
+                        EntityFileClaim {
+                            run_id: run_id.to_string(),
+                            acquired_at: acquired_at.clone(),
+                            expires_at: expires_at.clone(),
+                            size: input_file.source_size,
+                            mtime: input_file.source_mtime.clone(),
+                        },
+                    );
+                    pending_inputs.push(input_file.clone());
+                }
+            }
+        }
+
+        if pending_inputs.is_empty() {
+            if active_claims.is_empty() {
+                let _ = persist_loaded_state(cloud, resolver, &loaded)?;
+            }
+            return Ok(EntityStateClaimOutcome {
+                pending_inputs,
+                claimed_state: None,
+                active_claims,
+                already_processed,
+            });
+        }
+
+        loaded.state.schema = ENTITY_STATE_SCHEMA_V2.to_string();
+        loaded.state.updated_at = Some(acquired_at);
+        match persist_loaded_state(cloud, resolver, &loaded)? {
+            Some(version) => {
+                return Ok(EntityStateClaimOutcome {
+                    pending_inputs,
+                    claimed_state: Some(ClaimedEntityState {
+                        target: loaded.target,
+                        state: loaded.state,
+                        version,
+                    }),
+                    active_claims,
+                    already_processed,
+                });
+            }
+            None => continue,
+        }
+    }
+
+    Err(Box::new(ConfigError(format!(
+        "entity.name={} incremental state update conflicted after {STATE_CAS_RETRIES} retries",
+        entity.name
+    ))))
+}
+
+pub fn promote_claimed_entity_state(
+    resolver: &StorageResolver,
+    cloud: &mut CloudClient,
+    entity: &EntityConfig,
+    run_id: &str,
+    claimed: &ClaimedEntityState,
+) -> FloeResult<()> {
+    mutate_claimed_state(resolver, cloud, entity, claimed, |state| {
+        let processed_at = now_rfc3339();
+        let claimed_files: Vec<String> = state
+            .claims
+            .iter()
+            .filter(|(_, claim)| claim.run_id == run_id)
+            .map(|(source_uri, _)| source_uri.clone())
+            .collect();
+        for source_uri in claimed_files {
+            if let Some(claim) = state.claims.remove(&source_uri) {
+                state.files.insert(
+                    source_uri,
+                    EntityFileState {
+                        processed_at: processed_at.clone(),
+                        size: claim.size,
+                        mtime: claim.mtime,
+                    },
+                );
+            }
+        }
+        state.updated_at = Some(processed_at);
+    })
+}
+
+pub fn release_claimed_entity_state(
+    resolver: &StorageResolver,
+    cloud: &mut CloudClient,
+    entity: &EntityConfig,
+    run_id: &str,
+    claimed: &ClaimedEntityState,
+) -> FloeResult<()> {
+    mutate_claimed_state(resolver, cloud, entity, claimed, |state| {
+        state.claims.retain(|_, claim| claim.run_id != run_id);
+        state.updated_at = Some(now_rfc3339());
+    })
+}
+
+fn mutate_claimed_state(
+    resolver: &StorageResolver,
+    cloud: &mut CloudClient,
+    entity: &EntityConfig,
+    claimed: &ClaimedEntityState,
+    mutate: impl Fn(&mut EntityState),
+) -> FloeResult<()> {
+    for attempt in 0..STATE_CAS_RETRIES {
+        let mut loaded = if attempt == 0 {
+            LoadedEntityState {
+                target: claimed.target.clone(),
+                state: claimed.state.clone(),
+                version: claimed.version.clone(),
+                existed: claimed.version.is_some(),
+            }
+        } else {
+            load_target_state_with_resolver(cloud, resolver, entity, claimed.target.clone())?
+        };
+        mutate(&mut loaded.state);
+        loaded.state.schema = ENTITY_STATE_SCHEMA_V2.to_string();
+        let persisted = if loaded.state.files.is_empty() && loaded.state.claims.is_empty() {
+            delete_loaded_state(cloud, resolver, &loaded)?
+        } else {
+            persist_loaded_state(cloud, resolver, &loaded)?
+        };
+        if persisted.is_some() {
+            return Ok(());
+        }
+    }
+    Err(Box::new(ConfigError(format!(
+        "entity.name={} incremental state update conflicted after {STATE_CAS_RETRIES} retries",
+        entity.name
+    ))))
 }
 
 pub fn inspect_entity_state_with_base(
@@ -171,13 +332,12 @@ pub fn inspect_entity_state(
     config_base: ConfigBase,
     entity_name: &str,
 ) -> FloeResult<EntityStateInspection> {
-    let (entity, path) = resolve_entity_state_target(config, config_base, entity_name)?;
-    let state = match &path.local_path {
-        Some(local_path) => read_entity_state(local_path)?
-            .map(|state| validate_entity_state(entity, state))
-            .transpose()?,
-        None => None,
-    };
+    let (entity, path) = resolve_entity_state_target(config, config_base.clone(), entity_name)?;
+    let resolver = StorageResolver::new(config, config_base)?;
+    let target = state_target_from_resolved(&path)?;
+    let mut cloud = CloudClient::new();
+    let loaded = load_target_state_with_resolver(&mut cloud, &resolver, entity, target)?;
+    let state = loaded.existed.then_some(loaded.state);
 
     Ok(EntityStateInspection {
         entity_name: entity.name.clone(),
@@ -193,20 +353,44 @@ pub fn reset_entity_state_with_base(
     entity_name: &str,
 ) -> FloeResult<bool> {
     let config = crate::load_config(config_path)?;
-    let (entity, path) = resolve_entity_state_target(&config, config_base, entity_name)?;
-    let Some(local_path) = path.local_path.as_ref() else {
-        return Err(Box::new(ConfigError(format!(
-            "entity.name={} state path is not local and cannot be reset: {}",
-            entity.name, path.uri
-        ))));
-    };
-
-    if !local_path.exists() {
+    let (entity, path) = resolve_entity_state_target(&config, config_base.clone(), entity_name)?;
+    let target = state_target_from_resolved(&path)?;
+    if let EntityStateTarget::Local { path, .. } = &target {
+        if path.exists() {
+            fs::remove_file(path)?;
+            return Ok(true);
+        }
         return Ok(false);
     }
 
-    fs::remove_file(local_path)?;
-    Ok(true)
+    let mut cloud = CloudClient::new();
+    let resolver = StorageResolver::new(&config, config_base)?;
+    let loaded = load_target_state_with_resolver(&mut cloud, &resolver, entity, target)?;
+    if !loaded.existed {
+        return Ok(false);
+    }
+    match &loaded.target {
+        EntityStateTarget::Local { path, .. } => {
+            if path.exists() {
+                fs::remove_file(path)?;
+            }
+            Ok(true)
+        }
+        EntityStateTarget::Remote { storage, uri } => {
+            let client = cloud.client_for_context(
+                &resolver,
+                storage,
+                &format!("entity.name={}", entity.name),
+            )?;
+            match client.delete_object_conditional(uri, loaded.version.as_deref())? {
+                ConditionalWrite::Written { .. } => Ok(true),
+                ConditionalWrite::Conflict => Err(Box::new(ConfigError(format!(
+                    "entity.name={} remote state changed while resetting: {}",
+                    entity.name, uri
+                )))),
+            }
+        }
+    }
 }
 
 fn resolve_entity_state_target<'a>(
@@ -241,6 +425,155 @@ pub fn write_entity_state_atomic(path: &Path, state: &EntityState) -> FloeResult
     temp.as_file_mut().sync_all()?;
     temp.persist(path).map_err(|err| err.error)?;
     Ok(())
+}
+
+fn load_entity_state(
+    resolver: &StorageResolver,
+    cloud: &mut CloudClient,
+    entity: &EntityConfig,
+) -> FloeResult<LoadedEntityState> {
+    let resolved = resolve_entity_state_path(resolver, entity)?;
+    let target = state_target_from_resolved(&resolved)?;
+    load_target_state_with_resolver(cloud, resolver, entity, target)
+}
+
+fn load_target_state_with_resolver(
+    cloud: &mut CloudClient,
+    resolver: &StorageResolver,
+    entity: &EntityConfig,
+    target: EntityStateTarget,
+) -> FloeResult<LoadedEntityState> {
+    match target {
+        EntityStateTarget::Local { path, uri } => load_local_target(path, uri, entity),
+        EntityStateTarget::Remote { storage, uri } => {
+            let client = cloud.client_for_context(
+                resolver,
+                &storage,
+                &format!("entity.name={}", entity.name),
+            )?;
+            let object = client.read_object(&uri)?;
+            let (state, version, existed) = match object {
+                Some(object) => (
+                    validate_entity_state(entity, parse_entity_state(&object.body)?)?,
+                    Some(object.version),
+                    true,
+                ),
+                None => (EntityState::new(&entity.name), None, false),
+            };
+            Ok(LoadedEntityState {
+                target: EntityStateTarget::Remote { storage, uri },
+                state,
+                version,
+                existed,
+            })
+        }
+    }
+}
+
+fn load_local_target(
+    path: PathBuf,
+    uri: String,
+    entity: &EntityConfig,
+) -> FloeResult<LoadedEntityState> {
+    let state = read_entity_state(&path)?
+        .map(|state| validate_entity_state(entity, state))
+        .transpose()?
+        .unwrap_or_else(|| EntityState::new(&entity.name));
+    let existed = path.exists();
+    Ok(LoadedEntityState {
+        target: EntityStateTarget::Local { path, uri },
+        state,
+        version: None,
+        existed,
+    })
+}
+
+fn persist_loaded_state(
+    cloud: &mut CloudClient,
+    resolver: &StorageResolver,
+    loaded: &LoadedEntityState,
+) -> FloeResult<Option<Option<String>>> {
+    let mut state = loaded.state.clone();
+    state.schema = ENTITY_STATE_SCHEMA_V2.to_string();
+    let body = serde_json::to_vec_pretty(&state)?;
+    match &loaded.target {
+        EntityStateTarget::Local { path, .. } => {
+            write_entity_state_atomic(path, &state)?;
+            Ok(Some(None))
+        }
+        EntityStateTarget::Remote { uri, storage } => {
+            let client = cloud.client_for_context(resolver, storage, "entity state")?;
+            match client.write_object_conditional(uri, loaded.version.as_deref(), &body)? {
+                ConditionalWrite::Written { version } => Ok(Some(Some(version))),
+                ConditionalWrite::Conflict => Ok(None),
+            }
+        }
+    }
+}
+
+fn delete_loaded_state(
+    cloud: &mut CloudClient,
+    resolver: &StorageResolver,
+    loaded: &LoadedEntityState,
+) -> FloeResult<Option<Option<String>>> {
+    match &loaded.target {
+        EntityStateTarget::Local { path, .. } => {
+            if path.exists() {
+                fs::remove_file(path)?;
+            }
+            Ok(Some(None))
+        }
+        EntityStateTarget::Remote { uri, storage } => {
+            let client = cloud.client_for_context(resolver, storage, "entity state")?;
+            match client.delete_object_conditional(uri, loaded.version.as_deref())? {
+                ConditionalWrite::Written { version } => Ok(Some(Some(version))),
+                ConditionalWrite::Conflict => Ok(None),
+            }
+        }
+    }
+}
+
+fn state_target_from_resolved(resolved: &ResolvedPath) -> FloeResult<EntityStateTarget> {
+    if let Some(path) = &resolved.local_path {
+        return Ok(EntityStateTarget::Local {
+            path: path.clone(),
+            uri: resolved.uri.clone(),
+        });
+    }
+    if is_remote_uri(&resolved.uri) {
+        return Ok(EntityStateTarget::Remote {
+            storage: resolved.storage.clone(),
+            uri: resolved.uri.clone(),
+        });
+    }
+    Err(Box::new(ConfigError(format!(
+        "state path is neither local nor supported remote: {}",
+        resolved.uri
+    ))))
+}
+
+fn remove_expired_claims(state: &mut EntityState) {
+    let now = time::OffsetDateTime::now_utc();
+    state.claims.retain(|_, claim| {
+        time::OffsetDateTime::parse(
+            &claim.expires_at,
+            &time::format_description::well_known::Rfc3339,
+        )
+        .map(|expires_at| expires_at > now)
+        .unwrap_or(false)
+    });
+}
+
+fn now_rfc3339() -> String {
+    time::OffsetDateTime::now_utc()
+        .format(&time::format_description::well_known::Rfc3339)
+        .unwrap_or_else(|_| crate::report::now_rfc3339())
+}
+
+fn rfc3339_after_seconds(seconds: i64) -> String {
+    (time::OffsetDateTime::now_utc() + time::Duration::seconds(seconds))
+        .format(&time::format_description::well_known::Rfc3339)
+        .unwrap_or_else(|_| crate::report::now_rfc3339())
 }
 
 fn join_state_path(source_root: &str, entity_name: &str) -> String {
@@ -338,10 +671,10 @@ fn is_remote_uri(value: &str) -> bool {
 }
 
 pub fn validate_entity_state(entity: &EntityConfig, state: EntityState) -> FloeResult<EntityState> {
-    if state.schema != ENTITY_STATE_SCHEMA_V1 {
+    if state.schema != ENTITY_STATE_SCHEMA_V1 && state.schema != ENTITY_STATE_SCHEMA_V2 {
         return Err(Box::new(ConfigError(format!(
-            "entity.name={} state schema mismatch: expected {}, got {}",
-            entity.name, ENTITY_STATE_SCHEMA_V1, state.schema
+            "entity.name={} state schema mismatch: expected {} or {}, got {}",
+            entity.name, ENTITY_STATE_SCHEMA_V1, ENTITY_STATE_SCHEMA_V2, state.schema
         ))));
     }
 

--- a/crates/floe-core/src/state/mod.rs
+++ b/crates/floe-core/src/state/mod.rs
@@ -185,10 +185,10 @@ pub fn claim_entity_inputs(
                 continue;
             }
             match loaded.state.claims.get(&input_file.source_uri) {
-                Some(claim) if claim.run_id != run_id => {
+                Some(_) => {
                     active_claims.push(input_file.source_uri.clone());
                 }
-                _ => {
+                None => {
                     loaded.state.claims.insert(
                         input_file.source_uri.clone(),
                         EntityFileClaim {
@@ -298,11 +298,13 @@ pub fn renew_claimed_entity_state(
     run_id: &str,
     claimed: &ClaimedEntityState,
 ) -> FloeResult<()> {
+    let our_uris: std::collections::HashSet<String> =
+        claimed.state.claims.keys().cloned().collect();
     mutate_claimed_state(resolver, cloud, entity_name, claimed, |state| {
         let now = now_rfc3339();
         let expires_at = rfc3339_after_seconds(CLAIM_TTL_SECONDS);
-        for claim in state.claims.values_mut() {
-            if claim.run_id == run_id {
+        for (uri, claim) in state.claims.iter_mut() {
+            if claim.run_id == run_id && our_uris.contains(uri) {
                 claim.expires_at = expires_at.clone();
             }
         }

--- a/crates/floe-core/tests/unit/io/storage/local.rs
+++ b/crates/floe-core/tests/unit/io/storage/local.rs
@@ -5,7 +5,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use floe_core::config;
 use floe_core::io::storage::extensions::glob_patterns_for_format;
 use floe_core::io::storage::local::{resolve_local_inputs, LocalClient};
-use floe_core::io::storage::StorageClient;
+use floe_core::io::storage::{ConditionalWrite, StorageClient};
 
 fn temp_dir(prefix: &str) -> PathBuf {
     let mut path = std::env::temp_dir();
@@ -178,4 +178,51 @@ fn local_client_download_copies_file() {
         .download_to_temp(src.to_string_lossy().as_ref(), &dest_dir)
         .expect("download");
     assert_eq!(fs::read_to_string(downloaded).expect("read"), "hello");
+}
+
+#[test]
+fn local_client_conditional_state_create_update_and_delete() {
+    let root = temp_dir("floe-local-state-conditional");
+    let state_path = root.join("state.json");
+    let uri = state_path.to_string_lossy();
+    let client = LocalClient::new();
+
+    let created = client
+        .write_object_conditional(uri.as_ref(), None, br#"{"a":1}"#)
+        .expect("create");
+    let ConditionalWrite::Written { version } = created else {
+        panic!("create should write");
+    };
+    assert_eq!(
+        fs::read_to_string(&state_path).expect("read created"),
+        r#"{"a":1}"#
+    );
+
+    let stale_create = client
+        .write_object_conditional(uri.as_ref(), None, br#"{"a":2}"#)
+        .expect("stale create");
+    assert_eq!(stale_create, ConditionalWrite::Conflict);
+
+    let updated = client
+        .write_object_conditional(uri.as_ref(), Some(&version), br#"{"aa":22}"#)
+        .expect("update");
+    let ConditionalWrite::Written { version: updated } = updated else {
+        panic!("update should write");
+    };
+    assert_ne!(updated, version);
+
+    let stale_update = client
+        .write_object_conditional(uri.as_ref(), Some(&version), br#"{"a":3}"#)
+        .expect("stale update");
+    assert_eq!(stale_update, ConditionalWrite::Conflict);
+
+    assert!(client
+        .read_object(uri.as_ref())
+        .expect("read object")
+        .is_some());
+    let deleted = client
+        .delete_object_conditional(uri.as_ref(), Some(&updated))
+        .expect("delete");
+    assert!(matches!(deleted, ConditionalWrite::Written { .. }));
+    assert!(!state_path.exists());
 }

--- a/crates/floe-core/tests/unit/run/entity/incremental.rs
+++ b/crates/floe-core/tests/unit/run/entity/incremental.rs
@@ -355,6 +355,7 @@ fn incremental_file_mode_fails_on_mismatched_state_schema() {
             entity: "customer".to_string(),
             updated_at: None,
             files: Default::default(),
+            claims: Default::default(),
         },
     )
     .expect("write state");

--- a/crates/floe-core/tests/unit/run/entity/incremental.rs
+++ b/crates/floe-core/tests/unit/run/entity/incremental.rs
@@ -462,3 +462,41 @@ fn incremental_file_mode_does_not_commit_state_after_unsuccessful_entity() {
         .expect("read state")
         .is_none());
 }
+
+#[test]
+fn incremental_file_mode_releases_claims_after_error_exit() {
+    let root = tempfile::TempDir::new().expect("temp dir");
+    let input_dir = root.path().join("in");
+    let accepted_dir = root.path().join("out/accepted");
+    let report_path = root.path().join("report-file");
+    fs::create_dir_all(&input_dir).expect("create input dir");
+    write_csv(&input_dir, "customers.csv", "id;name\n1;alice\n");
+    fs::write(&report_path, "not a directory").expect("write report file");
+    let config_path = write_config(
+        root.path(),
+        &config_yaml(
+            &input_dir,
+            &accepted_dir,
+            None,
+            &report_path,
+            "warn",
+            "",
+            None,
+        ),
+    );
+
+    let err = run(
+        &config_path,
+        RunOptions {
+            profile: None,
+            run_id: Some("incremental-report-write-error".to_string()),
+            entities: Vec::new(),
+            dry_run: false,
+        },
+    )
+    .expect_err("report write should fail");
+    assert!(err.to_string().contains("Not a directory") || err.to_string().contains("os error"));
+    assert!(read_entity_state(&state_path(&input_dir))
+        .expect("read state")
+        .is_none());
+}

--- a/crates/floe-core/tests/unit/state/mod.rs
+++ b/crates/floe-core/tests/unit/state/mod.rs
@@ -3,11 +3,13 @@ use std::fs;
 use std::path::Path;
 
 use floe_core::config::{ConfigBase, StorageResolver};
+use floe_core::io::format::InputFile;
+use floe_core::io::storage::CloudClient;
 use floe_core::load_config;
 use floe_core::state::{
-    inspect_entity_state_with_base, read_entity_state, reset_entity_state_with_base,
-    resolve_entity_state_path, write_entity_state_atomic, EntityFileState, EntityState,
-    ENTITY_STATE_SCHEMA_V1,
+    claim_entity_inputs, inspect_entity_state_with_base, read_entity_state,
+    reset_entity_state_with_base, resolve_entity_state_path, write_entity_state_atomic,
+    EntityFileClaim, EntityFileState, EntityState, ENTITY_STATE_SCHEMA_V1, ENTITY_STATE_SCHEMA_V2,
 };
 
 fn load_config_from_yaml(
@@ -28,26 +30,6 @@ fn build_local_resolver(
     let resolver =
         StorageResolver::new(&config, ConfigBase::local_from_path(&config_path)).expect("resolver");
     (config, resolver)
-}
-
-fn short_stable_hash_hex(value: &str) -> String {
-    let mut hash: u64 = 0xcbf29ce484222325;
-    for byte in value.as_bytes() {
-        hash ^= u64::from(*byte);
-        hash = hash.wrapping_mul(0x100000001b3);
-    }
-    format!("{:016x}", hash)
-}
-
-fn with_cache_home<T>(cache_home: &Path, test: impl FnOnce() -> T) -> T {
-    let previous = std::env::var_os("XDG_CACHE_HOME");
-    std::env::set_var("XDG_CACHE_HOME", cache_home);
-    let output = test();
-    match previous {
-        Some(value) => std::env::set_var("XDG_CACHE_HOME", value),
-        None => std::env::remove_var("XDG_CACHE_HOME"),
-    }
-    output
 }
 
 #[test]
@@ -501,22 +483,12 @@ entities:
         resolved.uri,
         "s3://raw-bucket/landing/incoming/sales/.floe/state/sales/state.json"
     );
-    assert_eq!(
-        resolved.local_path.as_deref(),
-        Some(
-            temp_dir
-                .path()
-                .join(".floe/state/sales/state.json")
-                .as_path()
-        )
-    );
+    assert_eq!(resolved.local_path, None);
 }
 
 #[test]
-fn resolves_default_entity_state_path_from_remote_config_into_persistent_cache() {
+fn resolves_default_entity_state_path_from_remote_config_into_remote_state() {
     let temp_dir = tempfile::TempDir::new().expect("temp dir");
-    let cache_home = temp_dir.path().join("cache-home");
-    fs::create_dir_all(&cache_home).expect("cache dir");
     let yaml = r#"version: "0.1"
 storages:
   default: "lake"
@@ -550,29 +522,16 @@ entities:
     .expect("remote base");
     let resolver = StorageResolver::new(&config, remote_base).expect("resolver");
 
-    let resolved = with_cache_home(&cache_home, || {
-        resolve_entity_state_path(&resolver, &config.entities[0]).expect("state path")
-    });
+    let resolved = resolve_entity_state_path(&resolver, &config.entities[0]).expect("state path");
     let expected_uri = "s3://raw-bucket/landing/incoming/sales/.floe/state/sales/state.json";
 
     assert_eq!(resolved.uri, expected_uri);
-    assert_eq!(
-        resolved.local_path.as_deref(),
-        Some(
-            cache_home
-                .join("floe/state")
-                .join(short_stable_hash_hex(expected_uri))
-                .join("sales/state.json")
-                .as_path()
-        )
-    );
+    assert_eq!(resolved.local_path, None);
 }
 
 #[test]
-fn resolves_remote_config_state_cache_for_all_remote_storage_backends() {
+fn resolves_remote_config_state_uri_for_all_remote_storage_backends() {
     let temp_dir = tempfile::TempDir::new().expect("temp dir");
-    let cache_home = temp_dir.path().join("cache-home");
-    fs::create_dir_all(&cache_home).expect("cache dir");
 
     let cases = [
         (
@@ -665,30 +624,20 @@ entities:
         ),
     ];
 
-    with_cache_home(&cache_home, || {
-        for (yaml, config_uri, expected_uri) in cases {
-            let config = load_config_from_yaml(&temp_dir, yaml);
-            let base = ConfigBase::remote_from_uri(
-                temp_dir.path().join("ephemeral-config-download"),
-                config_uri,
-            )
-            .expect("remote base");
-            let resolver = StorageResolver::new(&config, base).expect("resolver");
-            let resolved =
-                resolve_entity_state_path(&resolver, &config.entities[0]).expect("state path");
+    for (yaml, config_uri, expected_uri) in cases {
+        let config = load_config_from_yaml(&temp_dir, yaml);
+        let base = ConfigBase::remote_from_uri(
+            temp_dir.path().join("ephemeral-config-download"),
+            config_uri,
+        )
+        .expect("remote base");
+        let resolver = StorageResolver::new(&config, base).expect("resolver");
+        let resolved =
+            resolve_entity_state_path(&resolver, &config.entities[0]).expect("state path");
 
-            assert_eq!(resolved.uri, expected_uri);
-            assert_eq!(
-                resolved.local_path,
-                Some(
-                    cache_home
-                        .join("floe/state")
-                        .join(short_stable_hash_hex(expected_uri))
-                        .join("sales/state.json")
-                )
-            );
-        }
-    });
+        assert_eq!(resolved.uri, expected_uri);
+        assert_eq!(resolved.local_path, None);
+    }
 }
 
 #[test]
@@ -791,6 +740,7 @@ fn writes_and_reads_entity_state_atomically() {
         entity: "sales".to_string(),
         updated_at: Some("2026-04-20T13:00:00Z".to_string()),
         files,
+        claims: Default::default(),
     };
 
     write_entity_state_atomic(&state_path, &state).expect("write state");
@@ -798,7 +748,9 @@ fn writes_and_reads_entity_state_atomically() {
         .expect("read state")
         .expect("state exists");
 
-    assert_eq!(loaded, state);
+    let mut expected = state;
+    expected.schema = ENTITY_STATE_SCHEMA_V2.to_string();
+    assert_eq!(loaded, expected);
     assert!(Path::new(&state_path).exists());
     assert_eq!(
         fs::read_dir(state_path.parent().expect("parent"))
@@ -814,6 +766,110 @@ fn read_entity_state_returns_none_when_missing() {
     let temp_dir = tempfile::TempDir::new().expect("temp dir");
     let missing = temp_dir.path().join("missing/state.json");
     assert!(read_entity_state(&missing).expect("read missing").is_none());
+}
+
+fn state_claim_config(
+    temp_dir: &tempfile::TempDir,
+) -> (
+    floe_core::config::RootConfig,
+    StorageResolver,
+    std::path::PathBuf,
+) {
+    let source_dir = temp_dir.path().join("incoming");
+    fs::create_dir_all(&source_dir).expect("mkdir source");
+    let yaml = format!(
+        r#"version: "0.1"
+entities:
+  - name: "sales"
+    incremental_mode: "file"
+    source:
+      format: "csv"
+      path: "{}"
+    sink:
+      accepted:
+        format: "parquet"
+        path: "{}"
+    policy:
+      severity: "warn"
+    schema:
+      columns:
+        - name: "id"
+          type: "string"
+"#,
+        source_dir.display(),
+        temp_dir.path().join("out").display()
+    );
+    let (config, resolver) = build_local_resolver(temp_dir, &yaml);
+    (config, resolver, source_dir)
+}
+
+fn claim_input(uri: &str) -> InputFile {
+    InputFile {
+        source_uri: uri.to_string(),
+        source_name: "sales.csv".to_string(),
+        source_stem: "sales".to_string(),
+        source_size: Some(42),
+        source_mtime: Some("2026-04-22T08:00:00Z".to_string()),
+    }
+}
+
+#[test]
+fn claim_entity_inputs_skips_active_claims_from_other_runs() {
+    let temp_dir = tempfile::TempDir::new().expect("temp dir");
+    let (config, resolver, source_dir) = state_claim_config(&temp_dir);
+    let entity = &config.entities[0];
+    let input = claim_input("local:///tmp/incoming/sales.csv");
+    let mut cloud = CloudClient::new();
+
+    let first = claim_entity_inputs(&resolver, &mut cloud, entity, "run-a", vec![input.clone()])
+        .expect("first claim");
+    assert_eq!(first.pending_inputs.len(), 1);
+    assert!(first.claimed_state.is_some());
+
+    let second = claim_entity_inputs(&resolver, &mut cloud, entity, "run-b", vec![input.clone()])
+        .expect("second claim");
+    assert!(second.pending_inputs.is_empty());
+    assert_eq!(second.active_claims, vec![input.source_uri.clone()]);
+
+    let state = read_entity_state(&source_dir.join(".floe/state/sales/state.json"))
+        .expect("read state")
+        .expect("state exists");
+    assert_eq!(state.files.len(), 0);
+    assert_eq!(state.claims.len(), 1);
+    assert_eq!(state.claims[&input.source_uri].run_id, "run-a");
+}
+
+#[test]
+fn claim_entity_inputs_removes_expired_claims_before_acquiring() {
+    let temp_dir = tempfile::TempDir::new().expect("temp dir");
+    let (config, resolver, source_dir) = state_claim_config(&temp_dir);
+    let entity = &config.entities[0];
+    let input = claim_input("local:///tmp/incoming/sales.csv");
+    let state_path = source_dir.join(".floe/state/sales/state.json");
+    let mut state = EntityState::new("sales");
+    state.claims.insert(
+        input.source_uri.clone(),
+        EntityFileClaim {
+            run_id: "crashed-run".to_string(),
+            acquired_at: "2000-01-01T00:00:00Z".to_string(),
+            expires_at: "2000-01-01T01:00:00Z".to_string(),
+            size: input.source_size,
+            mtime: input.source_mtime.clone(),
+        },
+    );
+    write_entity_state_atomic(&state_path, &state).expect("write expired claim");
+    let mut cloud = CloudClient::new();
+
+    let outcome = claim_entity_inputs(&resolver, &mut cloud, entity, "run-b", vec![input.clone()])
+        .expect("claim after expiry");
+
+    assert_eq!(outcome.pending_inputs.len(), 1);
+    assert!(outcome.active_claims.is_empty());
+    let state = read_entity_state(&state_path)
+        .expect("read state")
+        .expect("state exists");
+    assert_eq!(state.claims.len(), 1);
+    assert_eq!(state.claims[&input.source_uri].run_id, "run-b");
 }
 
 #[test]
@@ -868,6 +924,7 @@ entities:
                 mtime: Some("2026-04-22T08:00:00Z".to_string()),
             },
         )]),
+        claims: Default::default(),
     };
     write_entity_state_atomic(&state_path, &state).expect("write state");
 
@@ -884,7 +941,9 @@ entities:
         inspection.path.local_path.as_deref(),
         Some(state_path.as_path())
     );
-    assert_eq!(inspection.state, Some(state));
+    let mut expected = state;
+    expected.schema = ENTITY_STATE_SCHEMA_V2.to_string();
+    assert_eq!(inspection.state, Some(expected));
 }
 
 fn write_reset_test_config() -> (tempfile::TempDir, std::path::PathBuf, std::path::PathBuf) {

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -29,12 +29,14 @@
   - `--output <new.yml>` writes the updated config to a new file instead of overwriting `-c`.
 
 - `floe state inspect -c <config> --entity <name>`
-  - Print the resolved incremental state path for an entity and the current state JSON when present.
+  - Print the resolved incremental state URI for an entity and the current state JSON when present.
+  - Shows processed-file and active-claim counts.
   - Helpful for confirming what Floe has already seen in `incremental_mode: file`.
 
 - `floe state reset -c <config> --entity <name> --yes`
-  - Remove the local state file for an entity.
+  - Remove the local or remote state object for an entity.
   - Requires `--yes` because the next incremental run may reprocess previously tracked files.
+  - Remote resets use the same conditional delete support as remote incremental state.
 
 ### Dry-run behavior
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -165,8 +165,10 @@ is available for templating within that entity.
 - `state.path` (optional)
   - Overrides the file or object used to store entity state.
   - Supports local paths and cloud URIs for S3 (`s3://`), GCS (`gs://`), and ADLS (`abfs://`).
-  - Relative paths resolve like other entity paths. With a cloud source storage context,
-    a relative state path resolves under that storage prefix.
+  - Relative paths always resolve as local filesystem paths, regardless of the source
+    storage context. Only explicit cloud URIs (`s3://`, `gs://`, `abfs://`) use remote
+    storage. A relative override with a cloud source will produce local state and will
+    not benefit from remote claim coordination.
   - If omitted and `incremental_mode: file` is used, Floe derives the path under the
     source root as `.floe/state/<entity>/state.json`.
   - For cloud sources, the derived default is a remote object under the source root,

--- a/docs/config.md
+++ b/docs/config.md
@@ -163,11 +163,37 @@ is available for templating within that entity.
 
 - Entity-local state settings used by incremental ingestion.
 - `state.path` (optional)
-  - Overrides the local file used to store entity state.
-  - Must be a local path, not `s3://`, `gs://`, or `abfs://`.
-  - When the config itself is remote, the override must be an absolute local path.
+  - Overrides the file or object used to store entity state.
+  - Supports local paths and cloud URIs for S3 (`s3://`), GCS (`gs://`), and ADLS (`abfs://`).
+  - Relative paths resolve like other entity paths. With a cloud source storage context,
+    a relative state path resolves under that storage prefix.
   - If omitted and `incremental_mode: file` is used, Floe derives the path under the
     source root as `.floe/state/<entity>/state.json`.
+  - For cloud sources, the derived default is a remote object under the source root,
+    for example `s3://bucket/prefix/incoming/.floe/state/customer/state.json`.
+
+#### File incremental state and concurrency
+
+`incremental_mode: file` writes state using schema `floe.state.file-ingest.v2`.
+Existing `floe.state.file-ingest.v1` files are still readable; Floe rewrites state
+as v2 the next time it updates the entity.
+
+The durable `files` map tracks file URIs that have completed successfully. The
+`claims` map tracks files currently owned by a run, with `run_id`, acquisition
+time, expiry time, size, and mtime. The default claim TTL is one hour.
+
+Before processing, Floe removes expired claims, skips previously processed files,
+and skips files actively claimed by another run with an incremental warning in
+the report. New pending files are claimed with an optimistic conditional state
+write before accepted sink output is written. On success, the run promotes its
+claims into `files`; on entity failure, it removes its claims so the files can be
+retried. Conditional write conflicts are retried a small fixed number of times
+and then fail with a clear concurrency error.
+
+Remote state requires object-store permissions to read, write with conditional
+preconditions, and delete the state object. Normal source listing permissions are
+still needed for input discovery; state itself does not require listing except
+where the selected cloud provider or IAM policy requires it for object access.
 
 ### `source` (required)
 

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -11,11 +11,15 @@ entity. The order is deterministic and is reflected in reports.
    - In normal runs, resolved cloud objects are then downloaded to temp files.
    - In dry-run, resolution is list-only for cloud inputs (no downloads, no writes).
 2. Resolve storage targets for accepted/rejected/report outputs.
-3. If `incremental_mode: file` is enabled, load the entity state file and skip any
-   file URI already recorded as previously ingested.
+3. If `incremental_mode: file` is enabled, load the entity state file/object and
+   skip any file URI already recorded as previously ingested.
    - If the current size/mtime still matches the recorded state, Floe skips the file silently.
    - If the size/mtime changed, Floe still skips the file and emits an
      `incremental_file_changed` warning instead of reprocessing it.
+   - If another run has an active claim on the file, Floe skips it for this run
+     and emits an `incremental_file_claimed` warning.
+   - Remaining pending files are claimed with a conditional state update before
+     accepted sink output is written.
 4. Prepare output directories if needed.
 
 ### B) File-level prechecks (per file)
@@ -63,10 +67,17 @@ via `sink.accepted.options.max_size_per_file`).
 
 ### F) Incremental state commit
 
-When `incremental_mode: file` is enabled and the entity finishes successfully,
-Floe updates the entity state file with the newly processed file URIs plus
-observed size/mtime metadata. Later runs reuse that state to skip any file URI
-already present in the state file.
+When `incremental_mode: file` is enabled, Floe first claims pending file URIs in
+state. Local state uses atomic file replacement. Remote state on S3, GCS, and
+ADLS uses optimistic conditional writes so concurrent runners do not silently
+overwrite one another.
+
+When the entity finishes successfully, Floe promotes this run's claims into the
+durable processed-file map with observed size/mtime metadata. Later runs reuse
+that state to skip any file URI already present in the state file. If the entity
+does not finish successfully, Floe removes this run's claims so those files can
+be retried. Claims expire after one hour so a later runner can recover work from
+a crashed process.
 
 The recorded metadata is used only to detect that a previously ingested file has
 changed since the earlier run. In that case Floe emits an

--- a/docs/summary.md
+++ b/docs/summary.md
@@ -45,7 +45,7 @@ important references so you can quickly find the right guide.
 
 - CLI usage (`validate`, `run`, `manifest generate`, `add-entity`, `state inspect`, `state reset`): [docs/cli.md](cli.md)
 - `floe add-entity` can bootstrap a missing config file and infer entity name/format from input path extensions (CSV/JSON/Parquet).
-- `floe state inspect` / `floe state reset` help manage per-entity incremental state for `incremental_mode: file`.
+- `floe state inspect` / `floe state reset` help manage local or remote per-entity incremental state for `incremental_mode: file`.
 
 ## Benchmarking & development
 


### PR DESCRIPTION
## Summary
- add remote-capable v2 incremental state with per-file claims and v1 read compatibility
- add conditional object state operations for local, S3, GCS, and ADLS storage backends
- update incremental file mode to claim before processing, promote on success, release on failure, and report active claims
- update state CLI and docs for remote state semantics

## Validation
- cargo fmt --all -- --check
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace -- --nocapture

## Notes
- Live S3/GCS/ADLS integration was not run; provider conditional operations compile and local CAS behavior is covered by tests.