### PR TITLE
feat(lineage): add circuit breaker and retry to OpenLineage observer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -477,6 +477,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0f477b951e452a0b6b4a10b53ccd569042d1d01729b519e02074a9c0958a063"
 
 [[package]]
+name = "assert-json-diff"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "assert_cmd"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1707,6 +1717,15 @@ name = "colorchoice"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+
+[[package]]
+name = "colored"
+version = "3.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
+dependencies = [
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "comfy-table"
@@ -3414,6 +3433,7 @@ dependencies = [
  "iceberg",
  "iceberg-catalog-rest",
  "iceberg-storage-opendal",
+ "mockito",
  "orc-rust",
  "polars",
  "rayon",
@@ -4046,6 +4066,7 @@ dependencies = [
  "http 1.4.0",
  "http-body 1.0.1",
  "httparse",
+ "httpdate",
  "itoa",
  "pin-project-lite",
  "pin-utils",
@@ -4859,6 +4880,31 @@ dependencies = [
  "libc",
  "wasi 0.11.1+wasi-snapshot-preview1",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "mockito"
+version = "1.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90820618712cab19cfc46b274c6c22546a82affcb3c3bdf0f29e3db8e1bb92c0"
+dependencies = [
+ "assert-json-diff",
+ "bytes",
+ "colored",
+ "futures-core",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.8.1",
+ "hyper-util",
+ "log",
+ "pin-project-lite",
+ "rand 0.9.4",
+ "regex",
+ "serde_json",
+ "serde_urlencoded",
+ "similar",
+ "tokio",
 ]
 
 [[package]]
@@ -7419,6 +7465,12 @@ name = "simdutf8"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
+name = "similar"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
 
 [[package]]
 name = "simple_asn1"

--- a/crates/floe-core/Cargo.toml
+++ b/crates/floe-core/Cargo.toml
@@ -51,6 +51,7 @@ hex = "0.4"
 
 [dev-dependencies]
 rust_xlsxwriter = "0.67"
+mockito = "1"
 
 [features]
 vendored-openssl = []

--- a/crates/floe-core/src/config/parse.rs
+++ b/crates/floe-core/src/config/parse.rs
@@ -1061,6 +1061,20 @@ fn opt_u64(hash: &Hash, key: &str, ctx: &str) -> FloeResult<Option<u64>> {
     }
 }
 
+fn opt_u32(hash: &Hash, key: &str, ctx: &str) -> FloeResult<Option<u32>> {
+    match opt_u64(hash, key, ctx)? {
+        None => Ok(None),
+        Some(v) => {
+            if v > u32::MAX as u64 {
+                return Err(Box::new(ConfigError(format!(
+                    "value at {ctx}.{key} exceeds maximum allowed value"
+                ))));
+            }
+            Ok(Some(v as u32))
+        }
+    }
+}
+
 fn parse_pii_config(value: &Yaml) -> FloeResult<PiiConfig> {
     let hash = yaml_hash(value, "pii")?;
     validate_known_keys(hash, "pii", &["columns"])?;
@@ -1111,7 +1125,7 @@ fn parse_lineage_config(value: &Yaml) -> FloeResult<LineageConfig> {
     validate_known_keys(
         hash,
         "lineage",
-        &["url", "api_key", "timeout_secs", "namespace", "producer"],
+        &["url", "api_key", "timeout_secs", "namespace", "producer", "max_failures"],
     )?;
     Ok(LineageConfig {
         url: get_string(hash, "url", "lineage")?,
@@ -1119,5 +1133,6 @@ fn parse_lineage_config(value: &Yaml) -> FloeResult<LineageConfig> {
         timeout_secs: opt_u64(hash, "timeout_secs", "lineage")?,
         namespace: get_string(hash, "namespace", "lineage")?,
         producer: opt_string(hash, "producer", "lineage")?,
+        max_failures: opt_u32(hash, "max_failures", "lineage")?,
     })
 }

--- a/crates/floe-core/src/config/parse.rs
+++ b/crates/floe-core/src/config/parse.rs
@@ -1125,7 +1125,14 @@ fn parse_lineage_config(value: &Yaml) -> FloeResult<LineageConfig> {
     validate_known_keys(
         hash,
         "lineage",
-        &["url", "api_key", "timeout_secs", "namespace", "producer", "max_failures"],
+        &[
+            "url",
+            "api_key",
+            "timeout_secs",
+            "namespace",
+            "producer",
+            "max_failures",
+        ],
     )?;
     Ok(LineageConfig {
         url: get_string(hash, "url", "lineage")?,

--- a/crates/floe-core/src/config/types.rs
+++ b/crates/floe-core/src/config/types.rs
@@ -28,6 +28,7 @@ pub struct LineageConfig {
     pub timeout_secs: Option<u64>,
     pub namespace: String,
     pub producer: Option<String>,
+    pub max_failures: Option<u32>,
 }
 
 #[derive(Debug)]

--- a/crates/floe-core/src/config/validate.rs
+++ b/crates/floe-core/src/config/validate.rs
@@ -103,6 +103,11 @@ fn validate_lineage(lineage: &crate::config::LineageConfig) -> FloeResult<()> {
             "lineage.namespace must not be empty".to_string(),
         )));
     }
+    if lineage.max_failures == Some(0) {
+        return Err(Box::new(ConfigError(
+            "lineage.max_failures must be at least 1".to_string(),
+        )));
+    }
     Ok(())
 }
 

--- a/crates/floe-core/src/lineage/mod.rs
+++ b/crates/floe-core/src/lineage/mod.rs
@@ -85,10 +85,9 @@ impl OpenLineageObserver {
         let max_failures = self.config.max_failures.unwrap_or(3) as usize;
         let retry_delays_ms: &[u64] = &[0, 100, 500];
 
-        let mut last_is_retryable = false;
         let mut succeeded = false;
 
-        for (attempt, &delay_ms) in retry_delays_ms.iter().enumerate() {
+        'retry: for (attempt, &delay_ms) in retry_delays_ms.iter().enumerate() {
             if delay_ms > 0 {
                 std::thread::sleep(Duration::from_millis(delay_ms));
             }
@@ -96,12 +95,11 @@ impl OpenLineageObserver {
                 Ok(()) => {
                     self.consecutive_failures.store(0, Ordering::Relaxed);
                     succeeded = true;
-                    break;
+                    break 'retry;
                 }
                 Err(is_retryable) => {
-                    last_is_retryable = is_retryable;
                     if !is_retryable || attempt == retry_delays_ms.len() - 1 {
-                        break;
+                        break 'retry;
                     }
                 }
             }
@@ -111,15 +109,14 @@ impl OpenLineageObserver {
             return;
         }
 
-        if !last_is_retryable {
-            crate::warnings::emit(
-                "",
-                None,
-                None,
-                Some("lineage_http_error"),
-                &format!("lineage: POST {url} returned a non-retryable error — check api_key and url"),
-            );
-        }
+        // Always warn when an event is dropped, whether the failure was retryable or not.
+        crate::warnings::emit(
+            "",
+            None,
+            None,
+            Some("lineage_http_error"),
+            &format!("lineage: POST {url} failed — event dropped"),
+        );
 
         let failures = self.consecutive_failures.fetch_add(1, Ordering::Relaxed) + 1;
         if failures >= max_failures && !self.circuit_open.swap(true, Ordering::Relaxed) {
@@ -287,6 +284,10 @@ impl RunObserver for OpenLineageObserver {
     fn on_event(&self, event: RunEvent) {
         match event {
             RunEvent::RunStarted { run_id, ts_ms, .. } => {
+                // Reset circuit breaker at the start of each run so a recovered endpoint
+                // is retried in subsequent runs within the same long-lived process.
+                self.consecutive_failures.store(0, Ordering::Relaxed);
+                self.circuit_open.store(false, Ordering::Relaxed);
                 if let Ok(mut guard) = self.run_start_ms.lock() {
                     *guard = Some(ts_ms);
                 }

--- a/crates/floe-core/src/lineage/mod.rs
+++ b/crates/floe-core/src/lineage/mod.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
@@ -14,6 +15,8 @@ pub struct OpenLineageObserver {
     entity_run_ids: Mutex<HashMap<String, String>>,
     run_start_ms: Mutex<Option<u128>>,
     entity_schemas: HashMap<String, Vec<(String, String)>>,
+    consecutive_failures: AtomicUsize,
+    circuit_open: AtomicBool,
 }
 
 impl OpenLineageObserver {
@@ -48,36 +51,87 @@ impl OpenLineageObserver {
             entity_run_ids: Mutex::new(HashMap::new()),
             run_start_ms: Mutex::new(None),
             entity_schemas,
+            consecutive_failures: AtomicUsize::new(0),
+            circuit_open: AtomicBool::new(false),
         })
     }
 
-    fn post_event(&self, body: Value) {
-        let url = format!("{}/api/v1/lineage", self.config.url.trim_end_matches('/'));
-        let mut req = self.client.post(&url).json(&body);
+    fn attempt_post(&self, url: &str, body: &Value) -> Result<(), bool> {
+        let mut req = self.client.post(url).json(body);
         if let Some(api_key) = self.config.api_key.as_deref() {
             req = req.bearer_auth(api_key);
         }
         match req.send() {
-            Err(e) => {
-                crate::warnings::emit(
-                    "",
-                    None,
-                    None,
-                    Some("lineage_http_error"),
-                    &format!("lineage: POST {url} failed: {e}"),
-                );
-            }
+            Err(_) => Err(true),
             Ok(resp) => {
-                if let Err(e) = resp.error_for_status() {
-                    crate::warnings::emit(
-                        "",
-                        None,
-                        None,
-                        Some("lineage_http_error"),
-                        &format!("lineage: POST {url} returned error status: {e}"),
-                    );
+                let status = resp.status();
+                if status.is_success() {
+                    Ok(())
+                } else if status.as_u16() == 429 || status.is_server_error() {
+                    Err(true)
+                } else {
+                    Err(false)
                 }
             }
+        }
+    }
+
+    fn post_event(&self, body: Value) {
+        if self.circuit_open.load(Ordering::Relaxed) {
+            return;
+        }
+
+        let url = format!("{}/api/v1/lineage", self.config.url.trim_end_matches('/'));
+        let max_failures = self.config.max_failures.unwrap_or(3) as usize;
+        let retry_delays_ms: &[u64] = &[0, 100, 500];
+
+        let mut last_is_retryable = false;
+        let mut succeeded = false;
+
+        for (attempt, &delay_ms) in retry_delays_ms.iter().enumerate() {
+            if delay_ms > 0 {
+                std::thread::sleep(Duration::from_millis(delay_ms));
+            }
+            match self.attempt_post(&url, &body) {
+                Ok(()) => {
+                    self.consecutive_failures.store(0, Ordering::Relaxed);
+                    succeeded = true;
+                    break;
+                }
+                Err(is_retryable) => {
+                    last_is_retryable = is_retryable;
+                    if !is_retryable || attempt == retry_delays_ms.len() - 1 {
+                        break;
+                    }
+                }
+            }
+        }
+
+        if succeeded {
+            return;
+        }
+
+        if !last_is_retryable {
+            crate::warnings::emit(
+                "",
+                None,
+                None,
+                Some("lineage_http_error"),
+                &format!("lineage: POST {url} returned a non-retryable error — check api_key and url"),
+            );
+        }
+
+        let failures = self.consecutive_failures.fetch_add(1, Ordering::Relaxed) + 1;
+        if failures >= max_failures && !self.circuit_open.swap(true, Ordering::Relaxed) {
+            crate::warnings::emit(
+                "",
+                None,
+                None,
+                Some("lineage_circuit_open"),
+                &format!(
+                    "lineage: disabled for this run after {failures} consecutive failures — check endpoint {url}"
+                ),
+            );
         }
     }
 
@@ -357,4 +411,14 @@ pub fn build_observer(
 ) -> crate::FloeResult<Arc<dyn RunObserver>> {
     let obs = OpenLineageObserver::new(config, entities)?;
     Ok(Arc::new(obs))
+}
+
+impl OpenLineageObserver {
+    pub fn is_circuit_open(&self) -> bool {
+        self.circuit_open.load(Ordering::Relaxed)
+    }
+
+    pub fn consecutive_failures(&self) -> usize {
+        self.consecutive_failures.load(Ordering::Relaxed)
+    }
 }

--- a/crates/floe-core/tests/unit/config/lineage_validation.rs
+++ b/crates/floe-core/tests/unit/config/lineage_validation.rs
@@ -95,3 +95,60 @@ entities:
     let path = write_temp_config(config);
     validate(&path, ValidateOptions::default()).expect("valid lineage config");
 }
+
+#[test]
+fn lineage_max_failures_zero_rejected() {
+    let config = r#"version: "0.1"
+report:
+  path: "/tmp/reports"
+lineage:
+  url: "http://marquez:5000"
+  namespace: "my-namespace"
+  max_failures: 0
+entities:
+  - name: "orders"
+    source:
+      format: "csv"
+      path: "/tmp/input"
+    sink:
+      accepted:
+        format: "parquet"
+        path: "/tmp/out"
+    policy:
+      severity: "warn"
+    schema:
+      columns:
+        - name: "id"
+          type: "string"
+"#;
+    assert_validation_error(config, &["max_failures", "at least 1"]);
+}
+
+#[test]
+fn lineage_max_failures_valid() {
+    let config = r#"version: "0.1"
+report:
+  path: "/tmp/reports"
+lineage:
+  url: "http://marquez:5000"
+  namespace: "my-namespace"
+  max_failures: 5
+entities:
+  - name: "orders"
+    source:
+      format: "csv"
+      path: "/tmp/input"
+    sink:
+      accepted:
+        format: "parquet"
+        path: "/tmp/out"
+    policy:
+      severity: "warn"
+    schema:
+      columns:
+        - name: "id"
+          type: "string"
+"#;
+    let path = write_temp_config(config);
+    validate(&path, ValidateOptions::default()).expect("max_failures: 5 should be valid");
+}

--- a/crates/floe-core/tests/unit/run/lineage.rs
+++ b/crates/floe-core/tests/unit/run/lineage.rs
@@ -1,0 +1,142 @@
+use floe_core::config::LineageConfig;
+use floe_core::lineage::OpenLineageObserver;
+use floe_core::run::events::{RunEvent, RunObserver};
+
+fn make_config(server_url: &str, max_failures: Option<u32>) -> LineageConfig {
+    LineageConfig {
+        url: server_url.to_string(),
+        api_key: None,
+        timeout_secs: Some(2),
+        namespace: "test-ns".to_string(),
+        producer: None,
+        max_failures,
+    }
+}
+
+fn run_started_event() -> RunEvent {
+    RunEvent::RunStarted {
+        run_id: "test-run-1".to_string(),
+        config: "config.yml".to_string(),
+        report_base: None,
+        ts_ms: 1_000_000,
+    }
+}
+
+// Circuit opens after max_failures consecutive failures and stops hitting the server.
+#[test]
+fn circuit_opens_after_threshold() {
+    let mut server = mockito::Server::new();
+    let mock = server
+        .mock("POST", "/api/v1/lineage")
+        .with_status(500)
+        // 1 failure call × 3 retry attempts = 3 server hits, then circuit opens.
+        .expect(3)
+        .create();
+
+    let config = make_config(&server.url(), Some(1));
+    let obs = OpenLineageObserver::new(&config, &[]).unwrap();
+
+    // First call: retries 3 times, all fail → circuit opens.
+    obs.on_event(run_started_event());
+    assert!(obs.is_circuit_open(), "circuit should be open after max_failures");
+
+    // Subsequent calls should not hit the server (circuit is open).
+    obs.on_event(run_started_event());
+    obs.on_event(run_started_event());
+
+    mock.assert();
+}
+
+// A successful attempt resets the consecutive failure counter.
+#[test]
+fn success_resets_failure_counter() {
+    let mut server = mockito::Server::new();
+    let _mock = server
+        .mock("POST", "/api/v1/lineage")
+        .with_status(200)
+        .expect(2)
+        .create();
+
+    let config = make_config(&server.url(), Some(3));
+    let obs = OpenLineageObserver::new(&config, &[]).unwrap();
+
+    obs.on_event(run_started_event());
+    obs.on_event(run_started_event());
+
+    assert!(!obs.is_circuit_open(), "circuit should remain closed on success");
+    assert_eq!(obs.consecutive_failures(), 0, "failures should be reset on success");
+}
+
+// A 4xx response (non-retryable) is counted as one failure without retrying.
+#[test]
+fn non_retryable_error_counts_without_retry() {
+    let mut server = mockito::Server::new();
+    // Exactly 1 request expected — no retries for 401.
+    let mock = server
+        .mock("POST", "/api/v1/lineage")
+        .with_status(401)
+        .expect(1)
+        .create();
+
+    let config = make_config(&server.url(), Some(3));
+    let obs = OpenLineageObserver::new(&config, &[]).unwrap();
+
+    obs.on_event(run_started_event());
+
+    assert_eq!(obs.consecutive_failures(), 1);
+    assert!(!obs.is_circuit_open(), "one 4xx should not open the circuit (threshold is 3)");
+    mock.assert();
+}
+
+// A 429 (Too Many Requests) is retryable and triggers all retry attempts.
+#[test]
+fn rate_limit_response_is_retried() {
+    let mut server = mockito::Server::new();
+    // 3 retries expected for a 429.
+    let mock = server
+        .mock("POST", "/api/v1/lineage")
+        .with_status(429)
+        .expect(3)
+        .create();
+
+    let config = make_config(&server.url(), Some(5));
+    let obs = OpenLineageObserver::new(&config, &[]).unwrap();
+
+    obs.on_event(run_started_event());
+
+    assert_eq!(obs.consecutive_failures(), 1);
+    mock.assert();
+}
+
+// After a failure then a success, the circuit does not open even if the
+// failed call exhausted all retries.
+#[test]
+fn circuit_stays_closed_after_recovery() {
+    let mut server = mockito::Server::new();
+
+    // First event: 500 (all 3 retry attempts fail).
+    let fail_mock = server
+        .mock("POST", "/api/v1/lineage")
+        .with_status(500)
+        .expect(3)
+        .create();
+
+    let config = make_config(&server.url(), Some(3));
+    let obs = OpenLineageObserver::new(&config, &[]).unwrap();
+
+    obs.on_event(run_started_event());
+    assert_eq!(obs.consecutive_failures(), 1);
+    fail_mock.assert();
+
+    // Switch server to return 200.
+    let success_mock = server
+        .mock("POST", "/api/v1/lineage")
+        .with_status(200)
+        .expect(1)
+        .create();
+
+    obs.on_event(run_started_event());
+    assert_eq!(obs.consecutive_failures(), 0, "failure counter resets on success");
+    assert!(!obs.is_circuit_open());
+    success_mock.assert();
+}

--- a/crates/floe-core/tests/unit/run/lineage.rs
+++ b/crates/floe-core/tests/unit/run/lineage.rs
@@ -22,6 +22,16 @@ fn run_started_event() -> RunEvent {
     }
 }
 
+// EntityStarted is used in tests where we need to trigger a POST without the
+// RunStarted reset side-effect, matching the realistic per-run event sequence.
+fn entity_started_event() -> RunEvent {
+    RunEvent::EntityStarted {
+        run_id: "test-run-1".to_string(),
+        name: "orders".to_string(),
+        ts_ms: 1_001_000,
+    }
+}
+
 // Circuit opens after max_failures consecutive failures and stops hitting the server.
 #[test]
 fn circuit_opens_after_threshold() {
@@ -36,13 +46,16 @@ fn circuit_opens_after_threshold() {
     let config = make_config(&server.url(), Some(1));
     let obs = OpenLineageObserver::new(&config, &[]).unwrap();
 
-    // First call: retries 3 times, all fail → circuit opens.
+    // RunStarted: resets circuit state, then POSTs once → all 3 retries fail → circuit opens.
     obs.on_event(run_started_event());
-    assert!(obs.is_circuit_open(), "circuit should be open after max_failures");
+    assert!(
+        obs.is_circuit_open(),
+        "circuit should be open after max_failures"
+    );
 
-    // Subsequent calls should not hit the server (circuit is open).
-    obs.on_event(run_started_event());
-    obs.on_event(run_started_event());
+    // Subsequent events in this run should not hit the server (circuit is open).
+    obs.on_event(entity_started_event());
+    obs.on_event(entity_started_event());
 
     mock.assert();
 }
@@ -51,6 +64,7 @@ fn circuit_opens_after_threshold() {
 #[test]
 fn success_resets_failure_counter() {
     let mut server = mockito::Server::new();
+    // RunStarted + one EntityStarted = 2 successful POSTs.
     let _mock = server
         .mock("POST", "/api/v1/lineage")
         .with_status(200)
@@ -61,10 +75,17 @@ fn success_resets_failure_counter() {
     let obs = OpenLineageObserver::new(&config, &[]).unwrap();
 
     obs.on_event(run_started_event());
-    obs.on_event(run_started_event());
+    obs.on_event(entity_started_event());
 
-    assert!(!obs.is_circuit_open(), "circuit should remain closed on success");
-    assert_eq!(obs.consecutive_failures(), 0, "failures should be reset on success");
+    assert!(
+        !obs.is_circuit_open(),
+        "circuit should remain closed on success"
+    );
+    assert_eq!(
+        obs.consecutive_failures(),
+        0,
+        "failures should be reset on success"
+    );
 }
 
 // A 4xx response (non-retryable) is counted as one failure without retrying.
@@ -84,7 +105,10 @@ fn non_retryable_error_counts_without_retry() {
     obs.on_event(run_started_event());
 
     assert_eq!(obs.consecutive_failures(), 1);
-    assert!(!obs.is_circuit_open(), "one 4xx should not open the circuit (threshold is 3)");
+    assert!(
+        !obs.is_circuit_open(),
+        "one 4xx should not open the circuit (threshold is 3)"
+    );
     mock.assert();
 }
 
@@ -92,7 +116,7 @@ fn non_retryable_error_counts_without_retry() {
 #[test]
 fn rate_limit_response_is_retried() {
     let mut server = mockito::Server::new();
-    // 3 retries expected for a 429.
+    // 3 retry attempts expected for a 429.
     let mock = server
         .mock("POST", "/api/v1/lineage")
         .with_status(429)
@@ -108,13 +132,12 @@ fn rate_limit_response_is_retried() {
     mock.assert();
 }
 
-// After a failure then a success, the circuit does not open even if the
-// failed call exhausted all retries.
+// After a failure then a success within the same run, the circuit stays closed.
 #[test]
 fn circuit_stays_closed_after_recovery() {
     let mut server = mockito::Server::new();
 
-    // First event: 500 (all 3 retry attempts fail).
+    // RunStarted: 500 (all 3 retry attempts fail), failure counter = 1.
     let fail_mock = server
         .mock("POST", "/api/v1/lineage")
         .with_status(500)
@@ -128,15 +151,60 @@ fn circuit_stays_closed_after_recovery() {
     assert_eq!(obs.consecutive_failures(), 1);
     fail_mock.assert();
 
-    // Switch server to return 200.
+    // EntityStarted: 200 → failure counter resets to 0.
     let success_mock = server
         .mock("POST", "/api/v1/lineage")
         .with_status(200)
         .expect(1)
         .create();
 
-    obs.on_event(run_started_event());
-    assert_eq!(obs.consecutive_failures(), 0, "failure counter resets on success");
+    obs.on_event(entity_started_event());
+    assert_eq!(
+        obs.consecutive_failures(),
+        0,
+        "failure counter resets on success"
+    );
     assert!(!obs.is_circuit_open());
+    success_mock.assert();
+}
+
+// Circuit state is reset at the start of each new run (RunStarted) so a
+// recovered endpoint is retried in subsequent runs within the same process.
+#[test]
+fn circuit_resets_on_new_run_started() {
+    let mut server = mockito::Server::new();
+
+    // Run 1: all events fail → circuit opens.
+    let fail_mock = server
+        .mock("POST", "/api/v1/lineage")
+        .with_status(500)
+        .expect(3)
+        .create();
+
+    let config = make_config(&server.url(), Some(1));
+    let obs = OpenLineageObserver::new(&config, &[]).unwrap();
+
+    obs.on_event(run_started_event());
+    assert!(obs.is_circuit_open());
+    fail_mock.assert();
+
+    // Run 2: RunStarted resets the circuit; endpoint now returns 200.
+    let success_mock = server
+        .mock("POST", "/api/v1/lineage")
+        .with_status(200)
+        .expect(1)
+        .create();
+
+    obs.on_event(RunEvent::RunStarted {
+        run_id: "test-run-2".to_string(),
+        config: "config.yml".to_string(),
+        report_base: None,
+        ts_ms: 2_000_000,
+    });
+    assert!(
+        !obs.is_circuit_open(),
+        "circuit should reset for the new run"
+    );
+    assert_eq!(obs.consecutive_failures(), 0);
     success_mock.assert();
 }

--- a/crates/floe-core/tests/unit/run/mod.rs
+++ b/crates/floe-core/tests/unit/run/mod.rs
@@ -1,6 +1,7 @@
 pub mod check_order;
 pub mod checks;
 pub mod entity;
+pub mod lineage;
 pub mod normalize;
 pub mod pii;
 pub mod report;


### PR DESCRIPTION
## Summary

- **Circuit breaker**: after `max_failures` consecutive failures (default 3, configurable via `lineage.max_failures`), the observer stops making HTTP calls for the rest of the run and emits a single `lineage_circuit_open` warning — prevents a down lineage endpoint from blocking an N-entity pipeline for N × timeout seconds
- **Retry with backoff**: transient failures (connection errors, 5xx, 429) are retried up to 3 times at 0 / 100 / 500 ms delays before counting as a failure; non-retryable 4xx errors are counted immediately without retrying
- **Failure counter reset**: a successful event resets the consecutive failure counter so the circuit stays closed on intermittent issues

## Test plan

- [ ] All 486 existing `floe-core` tests pass (`cargo test -p floe-core`)
- [ ] 5 new circuit breaker tests in `tests/unit/run/lineage.rs` cover: circuit opens after threshold, success resets counter, 4xx does not retry, 429 retries 3×, circuit stays closed after recovery
- [ ] 2 new config validation tests in `tests/unit/config/lineage_validation.rs` cover: `max_failures: 0` rejected, `max_failures: 5` accepted
- [ ] Manual: point lineage URL at a refused port and run a multi-entity config — expect 1 `lineage_circuit_open` warning and no pipeline delay after circuit trips