### PR TITLE
test(pii): add DataFrame-level tests for all PII masking strategies

### DIFF
--- a/crates/floe-core/src/run/entity/pii.rs
+++ b/crates/floe-core/src/run/entity/pii.rs
@@ -151,7 +151,7 @@ fn mask_column(
     Ok(s)
 }
 
-pub(crate) fn apply_mask(
+fn apply_mask(
     value: &str,
     pattern: &str,
     first_n: Option<usize>,
@@ -179,4 +179,226 @@ pub(crate) fn apply_mask(
         result = result.replace(&format!("{{last{ln_val}}}"), &suffix);
     }
     result
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use polars::prelude::*;
+
+    use super::apply_pii_masking;
+    use crate::config::{PiiColumnConfig, PiiConfig, PiiStrategy};
+
+    fn str_series(name: &str, values: &[Option<&str>]) -> Column {
+        Series::new(name.into(), values).into()
+    }
+
+    fn single_col_df(name: &str, values: &[Option<&str>]) -> DataFrame {
+        DataFrame::new(vec![str_series(name, values)]).unwrap()
+    }
+
+    fn simple_pii(name: &str, strategy: PiiStrategy) -> PiiConfig {
+        PiiConfig {
+            columns: vec![PiiColumnConfig {
+                name: name.to_string(),
+                strategy,
+                mask_pattern: None,
+                redact_value: None,
+            }],
+        }
+    }
+
+    fn get_str(df: &DataFrame, col: &str, row: usize) -> Option<String> {
+        df.column(col)
+            .unwrap()
+            .str()
+            .unwrap()
+            .get(row)
+            .map(|s| s.to_string())
+    }
+
+    // --- hash ---
+
+    #[test]
+    fn hash_produces_64_char_hex() {
+        let mut df = single_col_df("email", &[Some("a@b.com")]);
+        apply_pii_masking(&mut df, &simple_pii("email", PiiStrategy::Hash), &HashMap::new())
+            .unwrap();
+        let v = get_str(&df, "email", 0).unwrap();
+        assert_eq!(v.len(), 64, "SHA-256 hex output must be 64 chars");
+        assert!(v.chars().all(|c| c.is_ascii_hexdigit()));
+    }
+
+    #[test]
+    fn hash_on_empty_string_produces_sha256() {
+        let mut df = single_col_df("email", &[Some("")]);
+        apply_pii_masking(&mut df, &simple_pii("email", PiiStrategy::Hash), &HashMap::new())
+            .unwrap();
+        // SHA-256("") = e3b0c44298fc1c149afbf4c8996fb924...
+        let v = get_str(&df, "email", 0).unwrap();
+        assert_eq!(v.len(), 64);
+        assert!(v.starts_with("e3b0c442"));
+    }
+
+    #[test]
+    fn hash_preserves_null() {
+        let mut df = single_col_df("email", &[Some("a@b.com"), None]);
+        apply_pii_masking(&mut df, &simple_pii("email", PiiStrategy::Hash), &HashMap::new())
+            .unwrap();
+        assert!(get_str(&df, "email", 1).is_none(), "null must stay null after hash");
+    }
+
+    // --- redact ---
+
+    #[test]
+    fn redact_replaces_with_default_placeholder() {
+        let mut df = single_col_df("cc", &[Some("1234-5678-9012-3456")]);
+        apply_pii_masking(&mut df, &simple_pii("cc", PiiStrategy::Redact), &HashMap::new())
+            .unwrap();
+        assert_eq!(get_str(&df, "cc", 0).unwrap(), "[REDACTED]");
+    }
+
+    #[test]
+    fn redact_uses_custom_value() {
+        let mut df = single_col_df("cc", &[Some("secret")]);
+        let pii = PiiConfig {
+            columns: vec![PiiColumnConfig {
+                name: "cc".to_string(),
+                strategy: PiiStrategy::Redact,
+                mask_pattern: None,
+                redact_value: Some("[PII]".to_string()),
+            }],
+        };
+        apply_pii_masking(&mut df, &pii, &HashMap::new()).unwrap();
+        assert_eq!(get_str(&df, "cc", 0).unwrap(), "[PII]");
+    }
+
+    #[test]
+    fn redact_on_empty_string_replaces_with_placeholder() {
+        let mut df = single_col_df("cc", &[Some("")]);
+        apply_pii_masking(&mut df, &simple_pii("cc", PiiStrategy::Redact), &HashMap::new())
+            .unwrap();
+        assert_eq!(get_str(&df, "cc", 0).unwrap(), "[REDACTED]");
+    }
+
+    #[test]
+    fn redact_preserves_null() {
+        let mut df = single_col_df("cc", &[Some("val"), None]);
+        apply_pii_masking(&mut df, &simple_pii("cc", PiiStrategy::Redact), &HashMap::new())
+            .unwrap();
+        assert!(get_str(&df, "cc", 1).is_none(), "null must stay null after redact");
+    }
+
+    // --- nullify ---
+
+    #[test]
+    fn nullify_replaces_all_values_with_null() {
+        let mut df = single_col_df("field", &[Some("a"), Some("b"), None]);
+        apply_pii_masking(&mut df, &simple_pii("field", PiiStrategy::Nullify), &HashMap::new())
+            .unwrap();
+        let col = df.column("field").unwrap();
+        assert!(col.get(0).unwrap().is_null());
+        assert!(col.get(1).unwrap().is_null());
+        assert!(col.get(2).unwrap().is_null());
+    }
+
+    // --- drop ---
+
+    #[test]
+    fn drop_removes_column_from_dataframe() {
+        let mut df = DataFrame::new(vec![
+            str_series("keep", &[Some("x")]),
+            str_series("pii_col", &[Some("secret")]),
+        ])
+        .unwrap();
+        apply_pii_masking(
+            &mut df,
+            &simple_pii("pii_col", PiiStrategy::Drop),
+            &HashMap::new(),
+        )
+        .unwrap();
+        assert!(df.column("pii_col").is_err(), "dropped column must not exist");
+        assert!(df.column("keep").is_ok(), "unrelated column must be untouched");
+    }
+
+    // --- mask ---
+
+    #[test]
+    fn mask_applies_last4_pattern() {
+        let mut df = single_col_df("cc", &[Some("1234567890123456")]);
+        let pii = PiiConfig {
+            columns: vec![PiiColumnConfig {
+                name: "cc".to_string(),
+                strategy: PiiStrategy::Mask,
+                mask_pattern: Some("****{last4}".to_string()),
+                redact_value: None,
+            }],
+        };
+        apply_pii_masking(&mut df, &pii, &HashMap::new()).unwrap();
+        assert_eq!(get_str(&df, "cc", 0).unwrap(), "****3456");
+    }
+
+    #[test]
+    fn mask_on_empty_string_keeps_mask_literal() {
+        let mut df = single_col_df("cc", &[Some("")]);
+        let pii = PiiConfig {
+            columns: vec![PiiColumnConfig {
+                name: "cc".to_string(),
+                strategy: PiiStrategy::Mask,
+                mask_pattern: Some("****{last4}".to_string()),
+                redact_value: None,
+            }],
+        };
+        apply_pii_masking(&mut df, &pii, &HashMap::new()).unwrap();
+        // empty string → no suffix to reveal → {last4} replaced with "" → "****"
+        assert_eq!(get_str(&df, "cc", 0).unwrap(), "****");
+    }
+
+    #[test]
+    fn mask_preserves_null() {
+        let mut df = single_col_df("cc", &[Some("1234567890"), None]);
+        let pii = PiiConfig {
+            columns: vec![PiiColumnConfig {
+                name: "cc".to_string(),
+                strategy: PiiStrategy::Mask,
+                mask_pattern: Some("****{last4}".to_string()),
+                redact_value: None,
+            }],
+        };
+        apply_pii_masking(&mut df, &pii, &HashMap::new()).unwrap();
+        assert!(get_str(&df, "cc", 1).is_none(), "null must stay null after mask");
+    }
+
+    // --- normalize_columns rename path ---
+
+    #[test]
+    fn masking_resolves_schema_to_runtime_name() {
+        // Schema declares "Credit Card"; normalize_columns renames it to "credit_card" at runtime.
+        let mut df = DataFrame::new(vec![str_series("credit_card", &[Some("secret")])]).unwrap();
+        let mut mapping = HashMap::new();
+        mapping.insert("Credit Card".to_string(), "credit_card".to_string());
+        let pii = PiiConfig {
+            columns: vec![PiiColumnConfig {
+                name: "Credit Card".to_string(),
+                strategy: PiiStrategy::Redact,
+                mask_pattern: None,
+                redact_value: None,
+            }],
+        };
+        apply_pii_masking(&mut df, &pii, &mapping).unwrap();
+        assert_eq!(get_str(&df, "credit_card", 0).unwrap(), "[REDACTED]");
+    }
+
+    // --- missing column ---
+
+    #[test]
+    fn missing_column_is_skipped_without_error() {
+        let mut df = single_col_df("other", &[Some("value")]);
+        // "email" is not in the DataFrame (e.g. mismatch=ignore dropped it).
+        apply_pii_masking(&mut df, &simple_pii("email", PiiStrategy::Hash), &HashMap::new())
+            .unwrap();
+        // Other columns must be untouched.
+        assert_eq!(get_str(&df, "other", 0).unwrap(), "value");
+    }
 }

--- a/crates/floe-core/src/run/entity/pii.rs
+++ b/crates/floe-core/src/run/entity/pii.rs
@@ -151,12 +151,7 @@ fn mask_column(
     Ok(s)
 }
 
-fn apply_mask(
-    value: &str,
-    pattern: &str,
-    first_n: Option<usize>,
-    last_n: Option<usize>,
-) -> String {
+fn apply_mask(value: &str, pattern: &str, first_n: Option<usize>, last_n: Option<usize>) -> String {
     let fn_val = first_n.unwrap_or(0);
     let ln_val = last_n.unwrap_or(0);
 
@@ -223,8 +218,12 @@ mod tests {
     #[test]
     fn hash_produces_64_char_hex() {
         let mut df = single_col_df("email", &[Some("a@b.com")]);
-        apply_pii_masking(&mut df, &simple_pii("email", PiiStrategy::Hash), &HashMap::new())
-            .unwrap();
+        apply_pii_masking(
+            &mut df,
+            &simple_pii("email", PiiStrategy::Hash),
+            &HashMap::new(),
+        )
+        .unwrap();
         let v = get_str(&df, "email", 0).unwrap();
         assert_eq!(v.len(), 64, "SHA-256 hex output must be 64 chars");
         assert!(v.chars().all(|c| c.is_ascii_hexdigit()));
@@ -233,8 +232,12 @@ mod tests {
     #[test]
     fn hash_on_empty_string_produces_sha256() {
         let mut df = single_col_df("email", &[Some("")]);
-        apply_pii_masking(&mut df, &simple_pii("email", PiiStrategy::Hash), &HashMap::new())
-            .unwrap();
+        apply_pii_masking(
+            &mut df,
+            &simple_pii("email", PiiStrategy::Hash),
+            &HashMap::new(),
+        )
+        .unwrap();
         // SHA-256("") = e3b0c44298fc1c149afbf4c8996fb924...
         let v = get_str(&df, "email", 0).unwrap();
         assert_eq!(v.len(), 64);
@@ -244,9 +247,16 @@ mod tests {
     #[test]
     fn hash_preserves_null() {
         let mut df = single_col_df("email", &[Some("a@b.com"), None]);
-        apply_pii_masking(&mut df, &simple_pii("email", PiiStrategy::Hash), &HashMap::new())
-            .unwrap();
-        assert!(get_str(&df, "email", 1).is_none(), "null must stay null after hash");
+        apply_pii_masking(
+            &mut df,
+            &simple_pii("email", PiiStrategy::Hash),
+            &HashMap::new(),
+        )
+        .unwrap();
+        assert!(
+            get_str(&df, "email", 1).is_none(),
+            "null must stay null after hash"
+        );
     }
 
     // --- redact ---
@@ -254,8 +264,12 @@ mod tests {
     #[test]
     fn redact_replaces_with_default_placeholder() {
         let mut df = single_col_df("cc", &[Some("1234-5678-9012-3456")]);
-        apply_pii_masking(&mut df, &simple_pii("cc", PiiStrategy::Redact), &HashMap::new())
-            .unwrap();
+        apply_pii_masking(
+            &mut df,
+            &simple_pii("cc", PiiStrategy::Redact),
+            &HashMap::new(),
+        )
+        .unwrap();
         assert_eq!(get_str(&df, "cc", 0).unwrap(), "[REDACTED]");
     }
 
@@ -277,17 +291,28 @@ mod tests {
     #[test]
     fn redact_on_empty_string_replaces_with_placeholder() {
         let mut df = single_col_df("cc", &[Some("")]);
-        apply_pii_masking(&mut df, &simple_pii("cc", PiiStrategy::Redact), &HashMap::new())
-            .unwrap();
+        apply_pii_masking(
+            &mut df,
+            &simple_pii("cc", PiiStrategy::Redact),
+            &HashMap::new(),
+        )
+        .unwrap();
         assert_eq!(get_str(&df, "cc", 0).unwrap(), "[REDACTED]");
     }
 
     #[test]
     fn redact_preserves_null() {
         let mut df = single_col_df("cc", &[Some("val"), None]);
-        apply_pii_masking(&mut df, &simple_pii("cc", PiiStrategy::Redact), &HashMap::new())
-            .unwrap();
-        assert!(get_str(&df, "cc", 1).is_none(), "null must stay null after redact");
+        apply_pii_masking(
+            &mut df,
+            &simple_pii("cc", PiiStrategy::Redact),
+            &HashMap::new(),
+        )
+        .unwrap();
+        assert!(
+            get_str(&df, "cc", 1).is_none(),
+            "null must stay null after redact"
+        );
     }
 
     // --- nullify ---
@@ -295,8 +320,12 @@ mod tests {
     #[test]
     fn nullify_replaces_all_values_with_null() {
         let mut df = single_col_df("field", &[Some("a"), Some("b"), None]);
-        apply_pii_masking(&mut df, &simple_pii("field", PiiStrategy::Nullify), &HashMap::new())
-            .unwrap();
+        apply_pii_masking(
+            &mut df,
+            &simple_pii("field", PiiStrategy::Nullify),
+            &HashMap::new(),
+        )
+        .unwrap();
         let col = df.column("field").unwrap();
         assert!(col.get(0).unwrap().is_null());
         assert!(col.get(1).unwrap().is_null());
@@ -318,8 +347,14 @@ mod tests {
             &HashMap::new(),
         )
         .unwrap();
-        assert!(df.column("pii_col").is_err(), "dropped column must not exist");
-        assert!(df.column("keep").is_ok(), "unrelated column must be untouched");
+        assert!(
+            df.column("pii_col").is_err(),
+            "dropped column must not exist"
+        );
+        assert!(
+            df.column("keep").is_ok(),
+            "unrelated column must be untouched"
+        );
     }
 
     // --- mask ---
@@ -367,7 +402,10 @@ mod tests {
             }],
         };
         apply_pii_masking(&mut df, &pii, &HashMap::new()).unwrap();
-        assert!(get_str(&df, "cc", 1).is_none(), "null must stay null after mask");
+        assert!(
+            get_str(&df, "cc", 1).is_none(),
+            "null must stay null after mask"
+        );
     }
 
     // --- normalize_columns rename path ---
@@ -396,8 +434,12 @@ mod tests {
     fn missing_column_is_skipped_without_error() {
         let mut df = single_col_df("other", &[Some("value")]);
         // "email" is not in the DataFrame (e.g. mismatch=ignore dropped it).
-        apply_pii_masking(&mut df, &simple_pii("email", PiiStrategy::Hash), &HashMap::new())
-            .unwrap();
+        apply_pii_masking(
+            &mut df,
+            &simple_pii("email", PiiStrategy::Hash),
+            &HashMap::new(),
+        )
+        .unwrap();
         // Other columns must be untouched.
         assert_eq!(get_str(&df, "other", 0).unwrap(), "value");
     }


### PR DESCRIPTION
## Summary

PII masking shipped in v0.3.9. Config validation was thorough, but there were **zero tests** verifying that any strategy (`hash`, `redact`, `nullify`, `drop`, `mask`) actually behaves correctly on a live DataFrame. This PR adds 14 inline unit tests directly in `src/run/entity/pii.rs` covering every strategy and every meaningful edge case.

**Gaps now covered:**

| Scenario | Strategies tested |
|----------|------------------|
| Values are masked | hash, redact, nullify, drop, mask |
| Null values preserved (null-in → null-out) | hash, redact, mask |
| Empty string handled without panic | hash (→ SHA-256 of ""), redact (→ `[REDACTED]`), mask (→ mask literal only) |
| Custom `redact_value` used | redact |
| Column removed from DataFrame | drop |
| `schema_to_runtime` rename mapping applied | redact (normalize_columns path) |
| Missing column skipped without error | hash |

## Test plan

- [x] `cargo test -p floe-core pii` — all 47 PII tests pass (33 existing + 14 new)
- [x] `cargo test -p floe-core` — full suite passes, no regressions