### PR TITLE
fix(manifest): wire k8s runner fields from profile into generated manifest

### DIFF
--- a/crates/floe-cli/tests/manifest_output.rs
+++ b/crates/floe-cli/tests/manifest_output.rs
@@ -166,7 +166,7 @@ fn manifest_generate_kubernetes_profile_serializes_k8_runner_fields() {
     let mut f = fs::File::create(&profile_path).expect("create profile file");
     writeln!(
         f,
-        "apiVersion: floe/v1\nkind: EnvironmentProfile\nmetadata:\n  name: prod-k8s\nexecution:\n  runner:\n    type: kubernetes_job\n    command: floe\n    args:\n      - run\n      - -c\n      - /config/config.yml\n    timeout_seconds: 3600\n    ttl_seconds_after_finished: 600\n    poll_interval_seconds: 15\n    secrets:\n      - floe-db\n      - floe-warehouse"
+        "apiVersion: floe/v1\nkind: EnvironmentProfile\nmetadata:\n  name: prod-k8s\nexecution:\n  runner:\n    type: kubernetes_job\n    image: my-registry/floe:latest\n    namespace: floe-prod\n    command: floe\n    args:\n      - run\n      - -c\n      - /config/config.yml\n    timeout_seconds: 3600\n    ttl_seconds_after_finished: 600\n    poll_interval_seconds: 15\n    secrets:\n      - name: DB_PASSWORD\n        secret_name: floe-db-secret\n        key: password"
     )
     .expect("write profile");
 
@@ -184,6 +184,8 @@ fn manifest_generate_kubernetes_profile_serializes_k8_runner_fields() {
     let value: Value = serde_json::from_str(stdout.trim()).expect("stdout should be json");
     let runner = &value["runners"]["definitions"]["default"];
     assert_eq!(runner["type"], "kubernetes_job");
+    assert_eq!(runner["image"], "my-registry/floe:latest");
+    assert_eq!(runner["namespace"], "floe-prod");
     assert_eq!(runner["command"], "floe");
     assert_eq!(
         runner["args"],
@@ -194,7 +196,11 @@ fn manifest_generate_kubernetes_profile_serializes_k8_runner_fields() {
     assert_eq!(runner["poll_interval_seconds"], 15);
     assert_eq!(
         runner["secrets"],
-        serde_json::json!(["floe-db", "floe-warehouse"])
+        serde_json::json!([{
+            "name": "DB_PASSWORD",
+            "secret_name": "floe-db-secret",
+            "key": "password"
+        }])
     );
 }
 

--- a/crates/floe-core/src/manifest/builder.rs
+++ b/crates/floe-core/src/manifest/builder.rs
@@ -5,7 +5,8 @@ use crate::config::{ConfigLocation, RootConfig, SourceOptions, StorageResolver};
 use crate::manifest::model::{
     CommonManifest, ManifestArchiveTarget, ManifestDomain, ManifestEntity, ManifestExecution,
     ManifestExecutionDefaults, ManifestResultContract, ManifestRunnerAuth,
-    ManifestRunnerDefinition, ManifestRunners, ManifestSinkTarget, ManifestSinks, ManifestSource,
+    ManifestRunnerDefinition, ManifestRunnerResources, ManifestRunnerSecret, ManifestRunners,
+    ManifestSinkTarget, ManifestSinks, ManifestSource,
 };
 use crate::profile::ProfileConfig;
 use crate::FloeResult;
@@ -355,12 +356,28 @@ fn runners_contract(profile: Option<&ProfileConfig>) -> ManifestRunners {
                     ttl_seconds_after_finished: profile_runner
                         .and_then(|r| r.ttl_seconds_after_finished),
                     poll_interval_seconds: profile_runner.and_then(|r| r.poll_interval_seconds),
-                    secrets: profile_runner.and_then(|r| r.secrets.clone()),
-                    image: None,
-                    namespace: None,
-                    service_account: None,
-                    resources: None,
-                    env: None,
+                    secrets: profile_runner.and_then(|r| {
+                        r.secrets.as_ref().map(|secrets| {
+                            secrets
+                                .iter()
+                                .map(|s| ManifestRunnerSecret {
+                                    name: s.name.clone(),
+                                    secret_name: s.secret_name.clone(),
+                                    key: s.key.clone(),
+                                })
+                                .collect()
+                        })
+                    }),
+                    image: profile_runner.and_then(|r| r.image.clone()),
+                    namespace: profile_runner.and_then(|r| r.namespace.clone()),
+                    service_account: profile_runner.and_then(|r| r.service_account.clone()),
+                    resources: profile_runner.and_then(|r| {
+                        r.resources.as_ref().map(|res| ManifestRunnerResources {
+                            cpu: res.cpu.clone(),
+                            memory_mb: res.memory_mb,
+                        })
+                    }),
+                    env: profile_runner.and_then(|r| r.env.clone()),
                     workspace_url: None,
                     existing_cluster_id: None,
                     config_uri: None,

--- a/crates/floe-core/src/manifest/model.rs
+++ b/crates/floe-core/src/manifest/model.rs
@@ -53,6 +53,13 @@ pub struct ManifestRunners {
 }
 
 #[derive(Debug, Serialize)]
+pub struct ManifestRunnerSecret {
+    pub name: String,
+    pub secret_name: String,
+    pub key: String,
+}
+
+#[derive(Debug, Serialize)]
 pub struct ManifestRunnerDefinition {
     #[serde(rename = "type")]
     pub runner_type: &'static str,
@@ -61,7 +68,7 @@ pub struct ManifestRunnerDefinition {
     pub timeout_seconds: Option<u64>,
     pub ttl_seconds_after_finished: Option<u64>,
     pub poll_interval_seconds: Option<u64>,
-    pub secrets: Option<Vec<String>>,
+    pub secrets: Option<Vec<ManifestRunnerSecret>>,
     pub image: Option<String>,
     pub namespace: Option<String>,
     pub service_account: Option<String>,

--- a/crates/floe-core/src/profile/parse.rs
+++ b/crates/floe-core/src/profile/parse.rs
@@ -9,7 +9,8 @@ use crate::config::yaml_decode::{
 };
 use crate::profile::types::{
     ProfileConfig, ProfileExecution, ProfileMetadata, ProfileRunner, ProfileRunnerAuth,
-    ProfileValidation, PROFILE_API_VERSION, PROFILE_KIND,
+    ProfileRunnerResources, ProfileRunnerSecret, ProfileValidation, PROFILE_API_VERSION,
+    PROFILE_KIND,
 };
 use crate::{ConfigError, FloeResult};
 
@@ -172,6 +173,11 @@ fn parse_runner(value: &Yaml) -> FloeResult<ProfileRunner> {
             "ttl_seconds_after_finished",
             "poll_interval_seconds",
             "secrets",
+            "image",
+            "namespace",
+            "service_account",
+            "resources",
+            "env",
             "workspace_url",
             "existing_cluster_id",
             "config_uri",
@@ -194,7 +200,18 @@ fn parse_runner(value: &Yaml) -> FloeResult<ProfileRunner> {
     )?;
     let poll_interval_seconds =
         get_optional_u64(hash, "poll_interval_seconds", "profile.execution.runner")?;
-    let secrets = get_optional_string_list(hash, "secrets", "profile.execution.runner")?;
+    let secrets = parse_runner_secrets(hash_get(hash, "secrets"))?;
+    let image = get_optional_string(hash, "image", "profile.execution.runner")?;
+    let namespace = get_optional_string(hash, "namespace", "profile.execution.runner")?;
+    let service_account = get_optional_string(hash, "service_account", "profile.execution.runner")?;
+    let resources = parse_runner_resources(hash_get(hash, "resources"))?;
+    let env = match hash_get(hash, "env") {
+        Some(value) => Some(extract_string_map(
+            yaml_hash(value, "profile.execution.runner.env")?,
+            "profile.execution.runner.env",
+        )?),
+        None => None,
+    };
     let workspace_url = get_optional_string(hash, "workspace_url", "profile.execution.runner")?;
     let existing_cluster_id =
         get_optional_string(hash, "existing_cluster_id", "profile.execution.runner")?;
@@ -218,6 +235,11 @@ fn parse_runner(value: &Yaml) -> FloeResult<ProfileRunner> {
         ttl_seconds_after_finished,
         poll_interval_seconds,
         secrets,
+        image,
+        namespace,
+        service_account,
+        resources,
+        env,
         workspace_url,
         existing_cluster_id,
         config_uri,
@@ -226,6 +248,48 @@ fn parse_runner(value: &Yaml) -> FloeResult<ProfileRunner> {
         auth,
         env_parameters,
     })
+}
+
+fn parse_runner_secrets(value: Option<&Yaml>) -> FloeResult<Option<Vec<ProfileRunnerSecret>>> {
+    let Some(value) = value else {
+        return Ok(None);
+    };
+    let arr = yaml_array(value, "profile.execution.runner.secrets")?;
+    let mut secrets = Vec::with_capacity(arr.len());
+    for item in arr {
+        let hash = yaml_hash(item, "profile.execution.runner.secrets[]")?;
+        validate_known_keys(
+            hash,
+            "profile.execution.runner.secrets[]",
+            &["name", "secret_name", "key"],
+        )?;
+        secrets.push(ProfileRunnerSecret {
+            name: get_required_string(hash, "name", "profile.execution.runner.secrets[]")?,
+            secret_name: get_required_string(
+                hash,
+                "secret_name",
+                "profile.execution.runner.secrets[]",
+            )?,
+            key: get_required_string(hash, "key", "profile.execution.runner.secrets[]")?,
+        });
+    }
+    Ok(Some(secrets))
+}
+
+fn parse_runner_resources(value: Option<&Yaml>) -> FloeResult<Option<ProfileRunnerResources>> {
+    let Some(value) = value else {
+        return Ok(None);
+    };
+    let hash = yaml_hash(value, "profile.execution.runner.resources")?;
+    validate_known_keys(
+        hash,
+        "profile.execution.runner.resources",
+        &["cpu", "memory_mb"],
+    )?;
+    Ok(Some(ProfileRunnerResources {
+        cpu: get_optional_string(hash, "cpu", "profile.execution.runner.resources")?,
+        memory_mb: get_optional_u64(hash, "memory_mb", "profile.execution.runner.resources")?,
+    }))
 }
 
 fn parse_runner_auth(value: Option<&Yaml>) -> FloeResult<Option<ProfileRunnerAuth>> {

--- a/crates/floe-core/src/profile/types.rs
+++ b/crates/floe-core/src/profile/types.rs
@@ -35,7 +35,14 @@ pub struct ProfileRunner {
     pub timeout_seconds: Option<u64>,
     pub ttl_seconds_after_finished: Option<u64>,
     pub poll_interval_seconds: Option<u64>,
-    pub secrets: Option<Vec<String>>,
+    pub secrets: Option<Vec<ProfileRunnerSecret>>,
+    // Kubernetes runner fields
+    pub image: Option<String>,
+    pub namespace: Option<String>,
+    pub service_account: Option<String>,
+    pub resources: Option<ProfileRunnerResources>,
+    pub env: Option<HashMap<String, String>>,
+    // Databricks runner fields
     pub workspace_url: Option<String>,
     pub existing_cluster_id: Option<String>,
     pub config_uri: Option<String>,
@@ -43,6 +50,19 @@ pub struct ProfileRunner {
     pub job_name: Option<String>,
     pub auth: Option<ProfileRunnerAuth>,
     pub env_parameters: Option<HashMap<String, String>>,
+}
+
+#[derive(Debug, Clone)]
+pub struct ProfileRunnerSecret {
+    pub name: String,
+    pub secret_name: String,
+    pub key: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct ProfileRunnerResources {
+    pub cpu: Option<String>,
+    pub memory_mb: Option<u64>,
 }
 
 #[derive(Debug, Clone)]

--- a/crates/floe-core/tests/unit/manifest/mod.rs
+++ b/crates/floe-core/tests/unit/manifest/mod.rs
@@ -197,6 +197,9 @@ metadata:
 execution:
   runner:
     type: kubernetes_job
+    image: my-registry/floe:latest
+    namespace: floe-prod
+    service_account: floe-sa
     command: floe
     args:
       - run
@@ -205,9 +208,15 @@ execution:
     timeout_seconds: 3600
     ttl_seconds_after_finished: 600
     poll_interval_seconds: 15
+    env:
+      FLOE_ENV: prod
+    resources:
+      cpu: "500m"
+      memory_mb: 512
     secrets:
-      - floe-db
-      - floe-warehouse
+      - name: DB_PASSWORD
+        secret_name: floe-db-secret
+        key: password
 "#;
     let profile = parse_profile_from_str(profile_yaml).expect("parse profile");
     let config_path = repo_root().join("example/config.yml");
@@ -220,6 +229,9 @@ execution:
 
     let runner = &value["runners"]["definitions"]["default"];
     assert_eq!(runner["type"], "kubernetes_job");
+    assert_eq!(runner["image"], "my-registry/floe:latest");
+    assert_eq!(runner["namespace"], "floe-prod");
+    assert_eq!(runner["service_account"], "floe-sa");
     assert_eq!(runner["command"], "floe");
     assert_eq!(
         runner["args"],
@@ -228,9 +240,16 @@ execution:
     assert_eq!(runner["timeout_seconds"], 3600);
     assert_eq!(runner["ttl_seconds_after_finished"], 600);
     assert_eq!(runner["poll_interval_seconds"], 15);
+    assert_eq!(runner["env"]["FLOE_ENV"], "prod");
+    assert_eq!(runner["resources"]["cpu"], "500m");
+    assert_eq!(runner["resources"]["memory_mb"], 512);
     assert_eq!(
         runner["secrets"],
-        serde_json::json!(["floe-db", "floe-warehouse"])
+        serde_json::json!([{
+            "name": "DB_PASSWORD",
+            "secret_name": "floe-db-secret",
+            "key": "password"
+        }])
     );
 }
 

--- a/crates/floe-core/tests/unit/profile/parse.rs
+++ b/crates/floe-core/tests/unit/profile/parse.rs
@@ -84,6 +84,9 @@ metadata:
 execution:
   runner:
     type: kubernetes_job
+    image: my-registry/floe:latest
+    namespace: floe-prod
+    service_account: floe-sa
     command: floe
     args:
       - run
@@ -92,13 +95,22 @@ execution:
     timeout_seconds: 3600
     ttl_seconds_after_finished: 600
     poll_interval_seconds: 15
+    env:
+      FLOE_ENV: prod
+    resources:
+      cpu: "500m"
+      memory_mb: 512
     secrets:
-      - floe-db
-      - floe-warehouse
+      - name: DB_PASSWORD
+        secret_name: floe-db-secret
+        key: password
 "#;
     let profile = parse_profile_from_str(yaml).expect("parse k8s profile");
     let runner = &profile.execution.as_ref().expect("execution").runner;
     assert_eq!(runner.runner_type, "kubernetes_job");
+    assert_eq!(runner.image.as_deref(), Some("my-registry/floe:latest"));
+    assert_eq!(runner.namespace.as_deref(), Some("floe-prod"));
+    assert_eq!(runner.service_account.as_deref(), Some("floe-sa"));
     assert_eq!(runner.command.as_deref(), Some("floe"));
     assert_eq!(
         runner.args.as_ref().unwrap(),
@@ -112,9 +124,21 @@ execution:
     assert_eq!(runner.ttl_seconds_after_finished, Some(600));
     assert_eq!(runner.poll_interval_seconds, Some(15));
     assert_eq!(
-        runner.secrets.as_ref().unwrap(),
-        &vec!["floe-db".to_string(), "floe-warehouse".to_string()]
+        runner
+            .env
+            .as_ref()
+            .unwrap()
+            .get("FLOE_ENV")
+            .map(|s| s.as_str()),
+        Some("prod")
     );
+    let res = runner.resources.as_ref().unwrap();
+    assert_eq!(res.cpu.as_deref(), Some("500m"));
+    assert_eq!(res.memory_mb, Some(512));
+    let secret = &runner.secrets.as_ref().unwrap()[0];
+    assert_eq!(secret.name, "DB_PASSWORD");
+    assert_eq!(secret.secret_name, "floe-db-secret");
+    assert_eq!(secret.key, "password");
 }
 
 #[test]

--- a/orchestrators/dagster-floe/pyproject.toml
+++ b/orchestrators/dagster-floe/pyproject.toml
@@ -29,6 +29,9 @@ Issues = "https://github.com/malon64/floe/issues"
 Documentation = "https://github.com/malon64/floe/tree/main/orchestrators/dagster-floe"
 
 [project.optional-dependencies]
+kubernetes = [
+  "kubernetes>=28",
+]
 dev = [
   "pytest>=7",
 ]

--- a/schemas/profile.schema.yaml
+++ b/schemas/profile.schema.yaml
@@ -99,6 +99,100 @@ $defs:
             - "local": execute directly on the current machine (default).
             - "kubernetes_job": delegate execution to a Kubernetes Job (connector-side).
             - "databricks_job": delegate execution to a Databricks Job (connector-side).
+      command:
+        type: string
+        description: Override the entrypoint command (e.g. "floe" or a wrapper script path).
+      args:
+        type: array
+        items:
+          type: string
+        description: >
+          Override the CLI arguments passed to the entrypoint. When absent the manifest
+          execution.base_args + execution.per_entity_args are used.
+      timeout_seconds:
+        type: integer
+        minimum: 1
+        description: >
+          Maximum wall-clock time (in seconds) before the runner considers the job timed out.
+          Defaults to 3600 for kubernetes_job.
+      ttl_seconds_after_finished:
+        type: integer
+        minimum: 0
+        description: >
+          Kubernetes: ttlSecondsAfterFinished on the Job spec — automatically cleans up
+          completed Jobs after this many seconds.
+      poll_interval_seconds:
+        type: integer
+        minimum: 1
+        description: >
+          Polling interval (in seconds) used by the runner while waiting for the job to
+          finish. Defaults to 10 for kubernetes_job.
+      # ── Kubernetes runner fields ──────────────────────────────────────────
+      image:
+        type: string
+        minLength: 1
+        description: >
+          Container image for the Floe runner Pod
+          (required when type = "kubernetes_job").
+          Example: my-registry/floe:1.2.3
+      namespace:
+        type: string
+        minLength: 1
+        description: >
+          Kubernetes namespace where the Job will be created
+          (required when type = "kubernetes_job").
+      service_account:
+        type: string
+        description: >
+          Name of the Kubernetes ServiceAccount to attach to the runner Pod.
+          Required when the Pod needs cloud-provider IAM or RBAC privileges.
+      resources:
+        type: object
+        additionalProperties: false
+        description: CPU and memory resource requests for the runner container.
+        properties:
+          cpu:
+            type: string
+            description: >
+              CPU resource request in Kubernetes quantity notation
+              (e.g. "500m", "1", "2000m").
+          memory_mb:
+            type: integer
+            minimum: 1
+            description: Memory request in mebibytes (e.g. 512 → 512Mi).
+      env:
+        type: object
+        additionalProperties:
+          type: string
+        description: >
+          Additional environment variables injected into the runner container as plain
+          key→value pairs. Use secrets[] for values that must come from Kubernetes Secrets.
+      secrets:
+        type: array
+        description: >
+          Kubernetes Secret key references injected as environment variables into the
+          runner container. Each entry maps a secret key to an env-var name.
+        items:
+          type: object
+          additionalProperties: false
+          required:
+            - name
+            - secret_name
+            - key
+          properties:
+            name:
+              type: string
+              minLength: 1
+              description: Name of the environment variable set in the container.
+            secret_name:
+              type: string
+              minLength: 1
+              description: Name of the Kubernetes Secret resource.
+            key:
+              type: string
+              minLength: 1
+              description: Key within the Kubernetes Secret.
+      # ── Databricks runner fields ──────────────────────────────────────────
       workspace_url:
         type: string
         description: >


### PR DESCRIPTION
## Summary

- `ProfileRunner` gains `image`, `namespace`, `service_account`, `resources` (cpu/memory_mb), `env`, and structured `secrets` fields — the fields a `kubernetes_job` runner actually needs.
- Profile parser (`parse.rs`) accepts and validates all new keys; secrets are parsed as `{name, secret_name, key}` objects matching the Kubernetes Secret key reference shape.
- `builder.rs` maps all new fields into the generated `ManifestRunnerDefinition` instead of hardcoding `None` — the generated manifest is now executable by the Dagster k8s runner without further manual editing.
- `ManifestRunnerSecret` struct replaces `Vec<String>` for secrets, aligning the Rust model with the existing JSON schema (`"items": {"type": "object"}`) and with `kubernetes_runner.py`'s `secret_ref["name"]` / `secret_ref["secret_name"]` / `secret_ref["key"]` access.
- `schemas/profile.schema.yaml` documents all new `kubernetes_job` fields with descriptions and constraints.
- `dagster-floe[kubernetes]` optional dep added so deployment images can express the `kubernetes` Python package requirement explicitly.

## Test plan

- [ ] `cargo test -p floe-core` — 491 tests, all pass
- [ ] `cargo clippy -p floe-core -p floe-cli -p floe-python -- -D warnings` — clean
- [ ] `parse_kubernetes_runner_with_extended_fields` profile test verifies all new fields round-trip through the parser
- [ ] `manifest_with_kubernetes_profile_serializes_k8_runner_fields` manifest test verifies image/namespace/service_account/env/resources/secrets appear in generated JSON