### PR TITLE
chore: bump all crates to v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,37 @@
 
 All notable changes to Floe are documented in this file.
 
+## v0.4.0
+
+- **OpenLineage circuit breaker and retry** (`docs/lineage.md`):
+  - Transient failures (connection errors, HTTP 5xx, 429) are retried up to 3 times with 0 / 100 / 500 ms backoff before counting as a failure.
+  - Non-retryable 4xx responses (e.g. 401 bad API key) are counted immediately without retrying and emit a `lineage_http_error` warning.
+  - After `max_failures` consecutive failures (default 3, configurable via `lineage.max_failures`), the circuit opens and all subsequent events in the run are skipped with no HTTP calls.
+  - A single `lineage_circuit_open` warning is emitted when the circuit trips. The circuit resets at `RunStarted` so a recovered endpoint is retried in the next pipeline execution without restarting the process.
+  - A `lineage_http_error` warning is emitted whenever any event is dropped so silent event loss is always visible in operator logs.
+
+- **Hardened remote incremental state** (`docs/how-it-works.md`):
+  - State schema bumped to v2 — a `claims` map sits alongside the existing `files` map, enabling CAS-based concurrent-writer safety on S3, GCS, and ADLS via conditional writes (`If-Match` / generation numbers).
+  - Local storage uses `FileLock` (O_CREAT|O_EXCL) to serialize version-check + write, preventing two concurrent local processes from both returning `Written`.
+  - Claim scope is restricted to the owning runner: promotion, release, and renewal only touch URIs held by the current `ClaimedEntityState`, preventing cross-runner interference when multiple processes share a `run_id`.
+  - Unexpired claims from the same `run_id` now block re-claiming — two processes sharing a `run_id` can no longer process the same files concurrently.
+  - Deletes remain conditional even when `expected_version` is `None`, preserving state written by a concurrent runner.
+  - V1 state files (no `claims` field) are silently upgraded to V2 on read.
+
+- **Kubernetes manifest runner fields** (`context/orchestrators.md`):
+  - `floe manifest generate` with a Kubernetes profile now emits full runner fields in the manifest: `image`, `namespace`, `service_account`, `resources` (cpu / memory_mb), `env`, and structured `secrets`.
+  - `secrets` changed from `Vec<String>` to `Vec<{name, secret_name, key}>` to match the shape expected by `kubernetes_runner.py`.
+  - `dagster-floe[kubernetes]` optional extra added to express the Kubernetes client dependency explicitly.
+
+- **Internal hardening** (no config or API changes):
+  - `PolicySeverity` is now a typed enum parsed at config load time — string comparison in mismatch, precheck, and run/entity paths replaced with enum match.
+  - `AcceptedWriteReportState` removed — `run_accepted_write_phase` returns `AcceptedWriteOutput` directly, eliminating a 24-field manual field-by-field copy.
+  - Error types (`ConfigError`, `RunError`, `StorageError`, `IoError`) adopt `thiserror` — removes ~40 lines of boilerplate `Display + Error` impls.
+  - `SinkFormat` trait centralises write, seed, and data-driven config validation — adding a new format no longer requires changes to validate.rs or dispatch code.
+  - State module eliminates duplicated load / persist / claim patterns (76 fewer lines, same behaviour).
+
+- **macOS wheels**: universal2 wheel replaces separate aarch64 + x86_64 artifacts — a single `.whl` runs natively on both Apple Silicon and Intel Macs.
+
 ## v0.3.9
 
 - **Column-level PII masking** (`docs/pii.md`):

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,8 @@ All notable changes to Floe are documented in this file.
 
 - **macOS wheels**: universal2 wheel replaces separate aarch64 + x86_64 artifacts — a single `.whl` runs natively on both Apple Silicon and Intel Macs.
 
+- **`dagster-floe` 0.1.5**: adds `dagster-floe[kubernetes]` optional extra so consumers can declare the `kubernetes>=28` dependency explicitly when using the Kubernetes runner.
+
 ## v0.3.9
 
 - **Column-level PII masking** (`docs/pii.md`):

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3399,7 +3399,7 @@ dependencies = [
 
 [[package]]
 name = "floe-cli"
-version = "0.3.10"
+version = "0.4.0"
 dependencies = [
  "assert_cmd",
  "clap",
@@ -3412,7 +3412,7 @@ dependencies = [
 
 [[package]]
 name = "floe-core"
-version = "0.3.10"
+version = "0.4.0"
 dependencies = [
  "apache-avro 0.16.0",
  "arrow",
@@ -3455,7 +3455,7 @@ dependencies = [
 
 [[package]]
 name = "floe-python"
-version = "0.3.10"
+version = "0.4.0"
 dependencies = [
  "floe-core",
  "pyo3",

--- a/context/bump-release.md
+++ b/context/bump-release.md
@@ -1,0 +1,142 @@
+# Floe — How to do a version bump PR
+
+This document describes the exact steps to bump Floe to a new version and open a release PR. Follow them in order.
+
+---
+
+## 1. Decide the new version
+
+Floe follows semantic versioning. The config schema version (`version: "0.x"` in YAML) is versioned independently and only changes when the config surface changes in a user-visible way.
+
+| Change | Version bump |
+|---|---|
+| Breaking config or API change | minor (`0.X.0`) |
+| New feature, backward-compatible | minor (`0.X.0`) or patch (`0.x.Y`) |
+| Bug fix, internal refactor, test, doc | patch (`0.x.Y`) |
+
+When in doubt: if a user upgrading the binary needs to change their config YAML or manifest JSON, it's a minor bump.
+
+---
+
+## 2. Create the branch
+
+```bash
+git checkout main && git pull
+git checkout -b chore/bump-v<NEW_VERSION>
+```
+
+---
+
+## 3. Bump versions in all three `Cargo.toml` files
+
+Files to update — change `version = "..."` **and** the `floe-core` dependency version in the crates that reference it:
+
+| File | Fields |
+|---|---|
+| `crates/floe-core/Cargo.toml` | `version` |
+| `crates/floe-cli/Cargo.toml` | `version`, `floe-core` dependency version |
+| `crates/floe-python/Cargo.toml` | `version`, `floe-core` dependency version |
+
+There is no workspace-level `version` field — each crate is bumped independently but all three must stay in sync.
+
+---
+
+## 4. Update `Cargo.lock`
+
+```bash
+cargo check -p floe-core -p floe-cli -p floe-python
+```
+
+`cargo check` is sufficient — it resolves dependencies and rewrites `Cargo.lock` without a full compile. Do not run `cargo generate-lockfile` alone as it does not validate crate graph consistency.
+
+---
+
+## 5. Write the `CHANGELOG.md` entry
+
+Add a new `## vX.Y.Z` section **at the top** of `CHANGELOG.md` (below the file header, above the previous version). Structure:
+
+- One bullet per user-visible change group (feature, fix, behaviour change).
+- Sub-bullets for details and caveats.
+- Reference the relevant doc file in parentheses where applicable.
+- "Internal hardening" section at the end for refactors with no config/API changes — still worth documenting so the diff is traceable.
+
+Source material: `git log <previous-tag>..HEAD --oneline` gives the full list of commits since the last release. Read the commit bodies (not just summaries) for the detailed changes.
+
+---
+
+## 6. Update documentation
+
+For each user-visible change, check whether the matching doc file needs updating:
+
+| Change | Doc file |
+|---|---|
+| New config field | `docs/config.md` |
+| New sink behaviour | `docs/sinks/<format>.md` |
+| Lineage changes | `docs/lineage.md` |
+| Incremental state changes | `docs/how-it-works.md` |
+| PII changes | `docs/pii.md` |
+| Manifest / orchestrator changes | `context/orchestrators.md` |
+| Profile/variable changes | `docs/profiles.md`, `docs/variables.md` |
+| CLI changes | `docs/cli.md` |
+
+Also update `context/architecture.md` if a new key abstraction was added or removed, and `context/project.md` if the supported formats or storages table changed.
+
+---
+
+## 7. Run CI checks locally
+
+All three must pass before pushing:
+
+```bash
+cargo fmt --all
+cargo clippy -p floe-core -p floe-cli -p floe-python -- -D warnings
+cargo test -p floe-core
+```
+
+---
+
+## 8. Commit and push
+
+```bash
+git add crates/floe-core/Cargo.toml \
+        crates/floe-cli/Cargo.toml \
+        crates/floe-python/Cargo.toml \
+        Cargo.lock \
+        CHANGELOG.md \
+        docs/ \
+        context/
+git commit -m "chore: bump all crates to <NEW_VERSION> and update docs"
+git push -u origin chore/bump-v<NEW_VERSION>
+```
+
+---
+
+## 9. Open the PR
+
+Title: `chore: bump all crates to v<NEW_VERSION>`
+
+PR body template:
+
+```markdown
+## Summary
+- Bump `floe-core`, `floe-cli`, `floe-python` from `<OLD>` to `<NEW>`.
+- Update `CHANGELOG.md` with v<NEW_VERSION> entry.
+- Update docs: <list doc files touched>.
+
+## Checklist
+- [ ] All three `Cargo.toml` versions updated
+- [ ] `Cargo.lock` updated via `cargo check`
+- [ ] `CHANGELOG.md` entry written
+- [ ] Docs updated for all user-visible changes
+- [ ] `cargo fmt`, `clippy`, `cargo test -p floe-core` all pass
+```
+
+Merge target: `main`. No feature flags needed — this is a pure version bump.
+
+---
+
+## Notes
+
+- The Python orchestrator packages (`dagster-floe`, `airflow-floe`) have their own `pyproject.toml` versions and are bumped separately when they have changes. A Rust-only bump does not require bumping the Python packages.
+- The `floe-python` PyPI wheel version is derived from its `Cargo.toml` version — bumping it here also bumps the published Python package.
+- GitHub releases and PyPI publishes are triggered by CI on merge to `main` — no manual tagging required.

--- a/context/orchestrators.md
+++ b/context/orchestrators.md
@@ -45,7 +45,17 @@ Schema identifier: `floe.manifest.v1`
     "default": "local",
     "definitions": {
       "local": { "type": "local_process" },
-      "k8s": { "type": "kubernetes_job", "image": "...", "namespace": "..." }
+      "k8s": {
+        "type": "kubernetes_job",
+        "image": "my-registry/floe:0.4.0",
+        "namespace": "data-platform",
+        "service_account": "floe-runner",
+        "resources": { "cpu": "500m", "memory_mb": 512 },
+        "env": { "AWS_REGION": "eu-west-1" },
+        "secrets": [
+          { "name": "AWS_ACCESS_KEY_ID", "secret_name": "aws-creds", "key": "access-key-id" }
+        ]
+      }
     }
   },
   "entities": [
@@ -161,6 +171,22 @@ defs = load_floe_assets("manifest.dagster.json", runner=LocalRunner())
 | `databricks_job` | Submits a Databricks job run, polls until completion |
 
 Each entity can override the runner via `entity.runner`; otherwise `runners.default` is used.
+
+### Kubernetes runner fields
+
+When `type = kubernetes_job`, the manifest runner definition supports:
+
+| Field | Type | Description |
+|---|---|---|
+| `image` | string | Container image (required) |
+| `namespace` | string | Kubernetes namespace (required) |
+| `service_account` | string | ServiceAccount to attach to the runner Pod |
+| `resources.cpu` | string | CPU request in Kubernetes quantity notation (e.g. `500m`) |
+| `resources.memory_mb` | integer | Memory request in mebibytes |
+| `env` | object | Plain env-var key→value pairs injected into the container |
+| `secrets` | array | Kubernetes Secret key references: `[{name, secret_name, key}]` |
+
+These fields are populated automatically when `floe manifest generate` is given a profile with a `kubernetes_job` runner block. The `dagster-floe[kubernetes]` optional extra expresses the Kubernetes client requirement.
 
 ---
 

--- a/crates/floe-cli/Cargo.toml
+++ b/crates/floe-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "floe-cli"
-version = "0.3.10"
+version = "0.4.0"
 edition = "2021"
 description = "CLI for Floe, a YAML-driven technical ingestion tool."
 license = "MIT"
@@ -17,7 +17,7 @@ path = "src/main.rs"
 
 [dependencies]
 clap = { version = "4", features = ["derive"] }
-floe-core = { path = "../floe-core", version = "0.3.10" }
+floe-core = { path = "../floe-core", version = "0.4.0" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 

--- a/crates/floe-cli/tests/manifest_output.rs
+++ b/crates/floe-cli/tests/manifest_output.rs
@@ -134,7 +134,7 @@ fn manifest_generate_with_kubernetes_profile_has_kubernetes_runner() {
     let mut f = fs::File::create(&profile_path).expect("create profile file");
     writeln!(
         f,
-        "apiVersion: floe/v1\nkind: EnvironmentProfile\nmetadata:\n  name: prod-k8s\nexecution:\n  runner:\n    type: kubernetes_job"
+        "apiVersion: floe/v1\nkind: EnvironmentProfile\nmetadata:\n  name: prod-k8s\nexecution:\n  runner:\n    type: kubernetes_job\n    image: my-registry/floe:0.4.0\n    namespace: data-platform"
     )
     .expect("write profile");
 

--- a/crates/floe-core/Cargo.toml
+++ b/crates/floe-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "floe-core"
-version = "0.3.10"
+version = "0.4.0"
 edition = "2021"
 description = "Core library for Floe, a YAML-driven technical ingestion tool."
 license = "MIT"

--- a/crates/floe-core/src/profile/validate.rs
+++ b/crates/floe-core/src/profile/validate.rs
@@ -176,6 +176,30 @@ fn validate_runner_type(runner_type: &str) -> FloeResult<()> {
 }
 
 fn validate_runner_contract(runner: &ProfileRunner) -> FloeResult<()> {
+    if runner.runner_type == "kubernetes_job" {
+        if runner
+            .image
+            .as_deref()
+            .map(str::trim)
+            .unwrap_or("")
+            .is_empty()
+        {
+            return Err(Box::new(ConfigError(
+                "profile.execution.runner.image is required for kubernetes_job".to_string(),
+            )));
+        }
+        if runner
+            .namespace
+            .as_deref()
+            .map(str::trim)
+            .unwrap_or("")
+            .is_empty()
+        {
+            return Err(Box::new(ConfigError(
+                "profile.execution.runner.namespace is required for kubernetes_job".to_string(),
+            )));
+        }
+    }
     if runner.runner_type != "databricks_job" {
         return Ok(());
     }

--- a/crates/floe-core/tests/unit/profile/validate.rs
+++ b/crates/floe-core/tests/unit/profile/validate.rs
@@ -140,7 +140,6 @@ variables:
 
 #[test]
 fn known_runner_types_are_accepted() {
-    // kubernetes_job needs no extra fields; databricks_job requires the full contract.
     let k8s_yaml = r#"
 apiVersion: floe/v1
 kind: EnvironmentProfile
@@ -149,6 +148,8 @@ metadata:
 execution:
   runner:
     type: kubernetes_job
+    image: my-registry/floe:0.4.0
+    namespace: data-platform
 "#;
     let dbx_yaml = r#"
 apiVersion: floe/v1
@@ -169,6 +170,40 @@ execution:
         let profile = parse_profile_from_str(yaml).expect("parse");
         validate_profile(&profile).expect("known runner type must pass profile validation");
     }
+}
+
+#[test]
+fn validate_kubernetes_job_missing_image_fails() {
+    let yaml = r#"
+apiVersion: floe/v1
+kind: EnvironmentProfile
+metadata:
+  name: k8s-prod
+execution:
+  runner:
+    type: kubernetes_job
+    namespace: data-platform
+"#;
+    let profile = parse_profile_from_str(yaml).expect("parse");
+    let err = validate_profile(&profile).unwrap_err();
+    assert!(err.to_string().contains("image"), "got: {err}");
+}
+
+#[test]
+fn validate_kubernetes_job_missing_namespace_fails() {
+    let yaml = r#"
+apiVersion: floe/v1
+kind: EnvironmentProfile
+metadata:
+  name: k8s-prod
+execution:
+  runner:
+    type: kubernetes_job
+    image: my-registry/floe:0.4.0
+"#;
+    let profile = parse_profile_from_str(yaml).expect("parse");
+    let err = validate_profile(&profile).unwrap_err();
+    assert!(err.to_string().contains("namespace"), "got: {err}");
 }
 
 #[test]

--- a/crates/floe-python/Cargo.toml
+++ b/crates/floe-python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "floe-python"
-version = "0.3.10"
+version = "0.4.0"
 edition = "2021"
 description = "Python bindings for floe-core (PyO3-based)"
 license = "Apache-2.0"
@@ -13,7 +13,7 @@ name = "_floe"
 crate-type = ["cdylib"]
 
 [dependencies]
-floe-core = { path = "../floe-core", version = "0.3.10" }
+floe-core = { path = "../floe-core", version = "0.4.0" }
 pyo3 = { version = "0.22", features = ["extension-module", "abi3-py310"] }
 serde_json = "1"
 

--- a/docs/lineage.md
+++ b/docs/lineage.md
@@ -17,13 +17,14 @@ lineage:
   producer: "https://github.com/myorg/floe"  # optional
 ```
 
-| Field          | Required | Description                                                          |
-|----------------|----------|----------------------------------------------------------------------|
-| `url`          | yes      | Base URL of the OpenLineage-compatible endpoint                      |
-| `namespace`    | yes      | OpenLineage namespace used for all jobs and datasets in this run     |
-| `api_key`      | no       | Bearer token sent in the `Authorization` header                      |
-| `timeout_secs` | no       | HTTP request timeout in seconds (default: `5`)                       |
-| `producer`     | no       | URI identifying this producer (default: the Floe GitHub URL)        |
+| Field            | Required | Description                                                          |
+|------------------|----------|----------------------------------------------------------------------|
+| `url`            | yes      | Base URL of the OpenLineage-compatible endpoint                      |
+| `namespace`      | yes      | OpenLineage namespace used for all jobs and datasets in this run     |
+| `api_key`        | no       | Bearer token sent in the `Authorization` header                      |
+| `timeout_secs`   | no       | HTTP request timeout in seconds (default: `5`)                       |
+| `producer`       | no       | URI identifying this producer (default: the Floe GitHub URL)        |
+| `max_failures`   | no       | Consecutive failures before the circuit opens (default: `3`)        |
 
 `api_key` supports `{{VAR}}` placeholder expansion via the same profile and
 env-vars mechanism used for the rest of the config.
@@ -60,9 +61,31 @@ and each entity-level job (`START`/`COMPLETE`/`FAIL`):
 | Airflow      | `AIRFLOW_CTX_DAG_RUN_ID`, `AIRFLOW_CTX_DAG_ID`, `AIRFLOW_CTX_TASK_ID`       |
 | Dagster      | `DAGSTER_RUN_ID`, `DAGSTER_JOB_NAME`                                          |
 
+## Resilience: circuit breaker and retry
+
+Floe uses a circuit breaker to avoid blocking long pipelines when the lineage
+endpoint is down or slow.
+
+**Retry behaviour** — transient failures (connection errors, HTTP 5xx, 429) are
+retried up to 3 times with 0 / 100 / 500 ms backoff before counting as a
+failure. Non-retryable 4xx errors (e.g. 401 bad API key) are counted immediately
+without retrying.
+
+**Circuit breaker** — after `max_failures` consecutive failures (default 3,
+configurable via `lineage.max_failures`), the circuit opens for the remainder of
+the run. Subsequent events are skipped immediately with no HTTP calls. A single
+`lineage_circuit_open` warning is emitted when the circuit trips.
+
+**Recovery** — the circuit resets at the start of each new run (`RunStarted`),
+so a recovered endpoint is retried in the next pipeline execution without
+restarting the process.
+
+A `lineage_http_error` warning is emitted whenever an event is dropped (whether
+retried or not) so silent event loss is always visible in operator logs.
+
 ## Fail-silent behaviour
 
-HTTP errors (connection failures, 4xx/5xx responses) are emitted as `warn`-level
+HTTP errors that do not trip the circuit breaker are emitted as `warn`-level
 log events and do not affect the run outcome. The ingestion continues normally.
 
 Warnings are always surfaced to stderr even when `--log-format off` is used,

--- a/orchestrators/dagster-floe/pyproject.toml
+++ b/orchestrators/dagster-floe/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "dagster-floe"
-version = "0.1.4"
+version = "0.1.5"
 description = "Dagster connector for Floe CLI (config-driven ingestion)"
 requires-python = ">=3.10"
 readme = "README.md"


### PR DESCRIPTION
## Summary

- Bump `floe-core`, `floe-cli`, `floe-python` from `0.3.10` to `0.4.0`
- `Cargo.lock` updated via `cargo check`
- `CHANGELOG.md`: new `v0.4.0` entry covering all changes since `0.3.10`
- `docs/lineage.md`: document `max_failures`, circuit breaker behaviour, and retry policy
- `context/orchestrators.md`: document full Kubernetes runner fields + structured secrets shape
- `context/bump-release.md`: new step-by-step guide for future bump PRs

## What's in v0.4.0

**OpenLineage circuit breaker and retry** — transient failures are retried (0/100/500 ms backoff), non-retryable 4xx counted immediately. Circuit opens after `max_failures` (default 3) consecutive failures and resets on the next `RunStarted`.

**Hardened remote incremental state** — state v2 with CAS `claims` map; `FileLock` for local atomic writes; claim scope restricted to owning runner; same-`run_id` re-claiming blocked; conditional deletes even when `expected_version` is `None`.

**Kubernetes manifest runner fields** — `floe manifest generate` with a k8s profile now populates `image`, `namespace`, `service_account`, `resources`, `env`, and structured `secrets` in the manifest. Secrets shape changed from `Vec<String>` to `Vec<{name, secret_name, key}>`.

**Internal hardening** — `PolicySeverity` enum, `AcceptedWriteReportState` removed, `thiserror` for error types, `SinkFormat` trait unified, state module deduplicated.

**macOS wheels** — universal2 replaces separate aarch64 + x86_64 artifacts.

## Checklist

- [x] All three `Cargo.toml` versions updated
- [x] `Cargo.lock` updated via `cargo check`
- [x] `CHANGELOG.md` entry written
- [x] Docs updated (`docs/lineage.md`, `context/orchestrators.md`)
- [x] `context/bump-release.md` added for future bump PRs