### PR TITLE
fix(iceberg): register S3/GCS storage factory so writes reach cloud storage

### DIFF
--- a/crates/floe-core/Cargo.toml
+++ b/crates/floe-core/Cargo.toml
@@ -41,7 +41,7 @@ uuid = "1"
 arrow = "57"
 iceberg = "0.9.0"
 iceberg-catalog-rest = "0.9.0"
-iceberg-storage-opendal = { version = "0.9.1", features = ["opendal-gcs"] }
+iceberg-storage-opendal = { version = "0.9.1", features = ["opendal-s3", "opendal-gcs"] }
 df-interchange = { version = "0.3.2", features = ["arrow_57", "polars_0_52"] }
 orc-rust = "0.7.1"
 

--- a/crates/floe-core/src/io/write/iceberg.rs
+++ b/crates/floe-core/src/io/write/iceberg.rs
@@ -8,6 +8,7 @@ use iceberg::memory::{MemoryCatalogBuilder, MEMORY_CATALOG_WAREHOUSE};
 use iceberg::spec::{Schema, UnboundPartitionSpec};
 use iceberg::transaction::{ApplyTransactionAction, Transaction};
 use iceberg::{Catalog, CatalogBuilder, NamespaceIdent, TableIdent};
+use iceberg_storage_opendal::OpenDalStorageFactory;
 use polars::prelude::DataFrame;
 
 use crate::errors::RunError;
@@ -375,6 +376,7 @@ async fn write_iceberg_table_async(
     catalog_props.insert(MEMORY_CATALOG_WAREHOUSE.to_string(), table_root_uri.clone());
 
     let is_local = !table_root_uri.starts_with("s3://")
+        && !table_root_uri.starts_with("s3a://")
         && !table_root_uri.starts_with("gs://")
         && !table_root_uri.starts_with("az://")
         && !table_root_uri.starts_with("abfss://");
@@ -382,6 +384,20 @@ async fn write_iceberg_table_async(
     if is_local {
         catalog_builder =
             catalog_builder.with_storage_factory(std::sync::Arc::new(LocalFsStorageFactory));
+    } else if table_root_uri.starts_with("s3://") || table_root_uri.starts_with("s3a://") {
+        let scheme = table_root_uri
+            .split("://")
+            .next()
+            .unwrap_or("s3")
+            .to_string();
+        catalog_builder =
+            catalog_builder.with_storage_factory(std::sync::Arc::new(OpenDalStorageFactory::S3 {
+                configured_scheme: scheme,
+                customized_credential_load: None,
+            }));
+    } else if table_root_uri.starts_with("gs://") {
+        catalog_builder =
+            catalog_builder.with_storage_factory(std::sync::Arc::new(OpenDalStorageFactory::Gcs));
     }
     let catalog = catalog_builder
         .load(catalog_name, catalog_props)
@@ -698,17 +714,35 @@ async fn collect_iceberg_batches(
     use iceberg::{Catalog, CatalogBuilder, NamespaceIdent, TableIdent};
 
     let is_local = !warehouse_location.starts_with("s3://")
+        && !warehouse_location.starts_with("s3a://")
         && !warehouse_location.starts_with("gs://")
         && !warehouse_location.starts_with("az://")
         && !warehouse_location.starts_with("abfss://");
 
     let mut props = catalog_props;
-    props.insert(MEMORY_CATALOG_WAREHOUSE.to_string(), warehouse_location);
+    props.insert(
+        MEMORY_CATALOG_WAREHOUSE.to_string(),
+        warehouse_location.clone(),
+    );
 
     let mut catalog_builder = MemoryCatalogBuilder::default();
     if is_local {
         catalog_builder =
             catalog_builder.with_storage_factory(std::sync::Arc::new(LocalFsStorageFactory));
+    } else if warehouse_location.starts_with("s3://") || warehouse_location.starts_with("s3a://") {
+        let scheme = warehouse_location
+            .split("://")
+            .next()
+            .unwrap_or("s3")
+            .to_string();
+        catalog_builder =
+            catalog_builder.with_storage_factory(std::sync::Arc::new(OpenDalStorageFactory::S3 {
+                configured_scheme: scheme,
+                customized_credential_load: None,
+            }));
+    } else if warehouse_location.starts_with("gs://") {
+        catalog_builder =
+            catalog_builder.with_storage_factory(std::sync::Arc::new(OpenDalStorageFactory::Gcs));
     }
     let catalog = catalog_builder.load(ICEBERG_CATALOG_NAME, props).await?;
 


### PR DESCRIPTION
## Summary

Closes #310.

`MemoryCatalog` (iceberg-rust) defaults to an **in-memory** `StorageFactory` when none is supplied. For local paths, `LocalFsStorageFactory` was already wired in via `with_storage_factory()`. For `s3://` and `gs://` URIs nothing was registered, so every data-file write and every metadata-file write silently went to RAM and was discarded at runtime exit.

The computed metadata location (a valid-looking S3 URI such as `s3://bucket/.../metadata/00001-uuid.metadata.json`) was still handed to Glue via `upsert_glue_table()`, leaving Glue pointing at a non-existent object while S3 remained empty.

**Two call-sites fixed:**
- `write_iceberg_table_async()` — the main write path (affects Glue + plain S3/GCS Iceberg)
- `collect_iceberg_batches()` — the seeding path used for dedup against existing Iceberg tables

**Root cause confirmed** by reading `iceberg-0.9.1/src/catalog/memory/catalog.rs:132`:
```rust
let factory = storage_factory.unwrap_or_else(|| Arc::new(MemoryStorageFactory));
```

## Changes

- `crates/floe-core/src/io/write/iceberg.rs` — register `OpenDalStorageFactory::S3` for `s3://`/`s3a://` and `OpenDalStorageFactory::Gcs` for `gs://` in both affected functions
- `crates/floe-core/Cargo.toml` — add `opendal-s3` explicitly to the feature list (was already enabled via defaults; made explicit to guard against `default-features = false` regressions)

## Test plan

- [x] `cargo fmt --check` passes
- [x] `cargo clippy -p floe-core -- -D warnings` passes
- [x] `cargo test -p floe-core` — all 495 tests pass
- [x] Manual: run `FLOE_RUN_MANUAL_GLUE_ICEBERG_TEST=1` with the reporter's AWS credentials — `iceberg_glue_run.rs` lines 254–256 assert S3 contains `/metadata/` and `/data/` objects

🤖 Generated with [Claude Code](https://claude.com/claude-code)