### PR TITLE
feat(profile): support storages and lineage sections

### DIFF
--- a/crates/floe-cli/src/main.rs
+++ b/crates/floe-cli/src/main.rs
@@ -341,6 +341,12 @@ fn main() -> FloeResult<()> {
                 profile_catalogs: parsed_profile
                     .as_ref()
                     .and_then(|profile| profile.catalogs.clone()),
+                profile_storages: parsed_profile
+                    .as_ref()
+                    .and_then(|profile| profile.storages.clone()),
+                profile_lineage: parsed_profile
+                    .as_ref()
+                    .and_then(|profile| profile.lineage.clone()),
             };
 
             let validation_result =
@@ -354,6 +360,12 @@ fn main() -> FloeResult<()> {
                         parsed_profile
                             .as_ref()
                             .and_then(|profile| profile.catalogs.as_ref()),
+                        parsed_profile
+                            .as_ref()
+                            .and_then(|profile| profile.storages.as_ref()),
+                        parsed_profile
+                            .as_ref()
+                            .and_then(|profile| profile.lineage.as_ref()),
                     )?;
                     println!("Config valid: {}", config_location.display);
                     println!("Version: {}", config.version);
@@ -615,6 +627,12 @@ fn main() -> FloeResult<()> {
                     profile_catalogs: profile_config
                         .as_ref()
                         .and_then(|profile| profile.catalogs.clone()),
+                    profile_storages: profile_config
+                        .as_ref()
+                        .and_then(|profile| profile.storages.clone()),
+                    profile_lineage: profile_config
+                        .as_ref()
+                        .and_then(|profile| profile.lineage.clone()),
                 };
                 if let Err(err) =
                     validate_with_base(&config_location.path, config_location.base.clone(), options)
@@ -628,6 +646,12 @@ fn main() -> FloeResult<()> {
                     profile_config
                         .as_ref()
                         .and_then(|profile| profile.catalogs.as_ref()),
+                    profile_config
+                        .as_ref()
+                        .and_then(|profile| profile.storages.as_ref()),
+                    profile_config
+                        .as_ref()
+                        .and_then(|profile| profile.lineage.as_ref()),
                 )?;
                 let manifest_json = build_common_manifest_json(
                     &config_location,

--- a/crates/floe-core/src/config/mod.rs
+++ b/crates/floe-core/src/config/mod.rs
@@ -13,6 +13,9 @@ pub use storage::{resolve_local_path, ConfigBase, ResolvedPath, StorageResolver}
 pub use types::*;
 
 pub use parse::extract_raw_env_vars;
-pub(crate) use parse::{parse_catalogs_with_context, parse_config, parse_config_with_vars};
+pub(crate) use parse::{
+    parse_catalogs_with_context, parse_config, parse_config_with_vars, parse_lineage_config,
+    parse_storages,
+};
 pub(crate) use template::apply_templates_with_vars;
 pub(crate) use validate::{extract_first_n, extract_last_n, validate_config};

--- a/crates/floe-core/src/config/parse.rs
+++ b/crates/floe-core/src/config/parse.rs
@@ -658,7 +658,7 @@ fn parse_sink_delta_options(value: &Yaml, ctx: &str) -> FloeResult<DeltaSinkTarg
     })
 }
 
-fn parse_storages(value: &Yaml) -> FloeResult<StoragesConfig> {
+pub(crate) fn parse_storages(value: &Yaml) -> FloeResult<StoragesConfig> {
     let hash = yaml_hash(value, "storages")?;
     validate_known_keys(hash, "storages", &["default", "definitions"])?;
     let definitions_yaml = match hash_get(hash, "definitions") {
@@ -1129,7 +1129,7 @@ fn parse_pii_column(value: &Yaml) -> FloeResult<PiiColumnConfig> {
     })
 }
 
-fn parse_lineage_config(value: &Yaml) -> FloeResult<LineageConfig> {
+pub(crate) fn parse_lineage_config(value: &Yaml) -> FloeResult<LineageConfig> {
     let hash = yaml_hash(value, "lineage")?;
     validate_known_keys(
         hash,

--- a/crates/floe-core/src/lib.rs
+++ b/crates/floe-core/src/lib.rs
@@ -40,6 +40,8 @@ pub struct ValidateOptions {
     pub entities: Vec<String>,
     pub profile_vars: std::collections::HashMap<String, String>,
     pub profile_catalogs: Option<config::CatalogsConfig>,
+    pub profile_storages: Option<config::StoragesConfig>,
+    pub profile_lineage: Option<config::LineageConfig>,
 }
 
 #[derive(Debug, Default)]
@@ -62,6 +64,8 @@ pub fn validate_with_base(
 ) -> FloeResult<()> {
     let mut config = config::parse_config_with_vars(config_path, &options.profile_vars)?;
     apply_profile_catalogs(&mut config, options.profile_catalogs.as_ref());
+    apply_profile_storages(&mut config, options.profile_storages.as_ref());
+    apply_profile_lineage(&mut config, options.profile_lineage.as_ref());
     config::validate_config(&config)?;
 
     if !options.entities.is_empty() {
@@ -86,9 +90,13 @@ pub fn load_config_with_profile_overrides(
     config_path: &Path,
     profile_vars: &std::collections::HashMap<String, String>,
     profile_catalogs: Option<&config::CatalogsConfig>,
+    profile_storages: Option<&config::StoragesConfig>,
+    profile_lineage: Option<&config::LineageConfig>,
 ) -> FloeResult<config::RootConfig> {
     let mut config = config::parse_config_with_vars(config_path, profile_vars)?;
     apply_profile_catalogs(&mut config, profile_catalogs);
+    apply_profile_storages(&mut config, profile_storages);
+    apply_profile_lineage(&mut config, profile_lineage);
     Ok(config)
 }
 
@@ -104,6 +112,24 @@ pub(crate) fn apply_profile_catalogs(
 ) {
     if let Some(catalogs) = profile_catalogs {
         config.catalogs = Some(catalogs.clone());
+    }
+}
+
+pub(crate) fn apply_profile_storages(
+    config: &mut config::RootConfig,
+    profile_storages: Option<&config::StoragesConfig>,
+) {
+    if let Some(storages) = profile_storages {
+        config.storages = Some(storages.clone());
+    }
+}
+
+pub(crate) fn apply_profile_lineage(
+    config: &mut config::RootConfig,
+    profile_lineage: Option<&config::LineageConfig>,
+) {
+    if let Some(lineage) = profile_lineage {
+        config.lineage = Some(lineage.clone());
     }
 }
 

--- a/crates/floe-core/src/profile/parse.rs
+++ b/crates/floe-core/src/profile/parse.rs
@@ -56,6 +56,8 @@ fn parse_profile_doc(doc: &Yaml) -> FloeResult<ProfileConfig> {
             "execution",
             "variables",
             "catalogs",
+            "storages",
+            "lineage",
             "validation",
         ],
     )?;
@@ -98,6 +100,16 @@ fn parse_profile_doc(doc: &Yaml) -> FloeResult<ProfileConfig> {
         None => None,
     };
 
+    let storages = match hash_get(root, "storages") {
+        Some(value) => Some(crate::config::parse_storages(value)?),
+        None => None,
+    };
+
+    let lineage = match hash_get(root, "lineage") {
+        Some(value) => Some(crate::config::parse_lineage_config(value)?),
+        None => None,
+    };
+
     let validation = match hash_get(root, "validation") {
         Some(value) => Some(parse_validation(value)?),
         None => None,
@@ -110,6 +122,8 @@ fn parse_profile_doc(doc: &Yaml) -> FloeResult<ProfileConfig> {
         execution,
         variables,
         catalogs,
+        storages,
+        lineage,
         validation,
     })
 }

--- a/crates/floe-core/src/profile/types.rs
+++ b/crates/floe-core/src/profile/types.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use crate::config::CatalogsConfig;
+use crate::config::{CatalogsConfig, LineageConfig, StoragesConfig};
 
 /// Top-level profile document (apiVersion + kind + sections).
 #[derive(Debug, Clone)]
@@ -11,6 +11,8 @@ pub struct ProfileConfig {
     pub execution: Option<ProfileExecution>,
     pub variables: HashMap<String, String>,
     pub catalogs: Option<CatalogsConfig>,
+    pub storages: Option<StoragesConfig>,
+    pub lineage: Option<LineageConfig>,
     pub validation: Option<ProfileValidation>,
 }
 

--- a/crates/floe-core/src/profile/validate.rs
+++ b/crates/floe-core/src/profile/validate.rs
@@ -1,5 +1,6 @@
 use std::collections::{HashMap, HashSet};
 
+use crate::config::{LineageConfig, StoragesConfig};
 use crate::profile::types::{ProfileConfig, ProfileRunner};
 use crate::{ConfigError, FloeResult};
 
@@ -25,6 +26,12 @@ pub fn validate_profile(profile: &ProfileConfig) -> FloeResult<()> {
 
     validate_no_malformed_vars(&profile.variables)?;
     validate_profile_catalogs(profile)?;
+    if let Some(storages) = &profile.storages {
+        validate_profile_storages(storages)?;
+    }
+    if let Some(lineage) = &profile.lineage {
+        validate_profile_lineage(lineage)?;
+    }
 
     Ok(())
 }
@@ -63,6 +70,45 @@ fn validate_profile_catalogs(profile: &ProfileConfig) -> FloeResult<()> {
         }
     }
 
+    Ok(())
+}
+
+fn validate_profile_storages(storages: &StoragesConfig) -> FloeResult<()> {
+    if storages.definitions.is_empty() {
+        return Err(Box::new(ConfigError(
+            "profile.storages.definitions must not be empty".to_string(),
+        )));
+    }
+    let mut names = HashSet::new();
+    for definition in &storages.definitions {
+        if definition.name.trim().is_empty() {
+            return Err(Box::new(ConfigError(
+                "profile.storages.definitions.name must not be empty".to_string(),
+            )));
+        }
+        if !names.insert(definition.name.as_str()) {
+            return Err(Box::new(ConfigError(format!(
+                "profile.storages.definitions name={} is duplicated",
+                definition.name
+            ))));
+        }
+    }
+    if let Some(default_name) = &storages.default {
+        if !names.contains(default_name.as_str()) {
+            return Err(Box::new(ConfigError(format!(
+                "profile.storages.default={default_name} does not match any definition"
+            ))));
+        }
+    }
+    Ok(())
+}
+
+fn validate_profile_lineage(lineage: &LineageConfig) -> FloeResult<()> {
+    if lineage.url.trim().is_empty() {
+        return Err(Box::new(ConfigError(
+            "profile.lineage.url must not be empty".to_string(),
+        )));
+    }
     Ok(())
 }
 

--- a/crates/floe-core/src/profile/validate.rs
+++ b/crates/floe-core/src/profile/validate.rs
@@ -79,6 +79,7 @@ fn validate_profile_storages(storages: &StoragesConfig) -> FloeResult<()> {
             "profile.storages.definitions must not be empty".to_string(),
         )));
     }
+    const ALLOWED_STORAGE_TYPES: &[&str] = &["local", "s3", "adls", "gcs"];
     let mut names = HashSet::new();
     for definition in &storages.definitions {
         if definition.name.trim().is_empty() {
@@ -89,6 +90,48 @@ fn validate_profile_storages(storages: &StoragesConfig) -> FloeResult<()> {
         if !names.insert(definition.name.as_str()) {
             return Err(Box::new(ConfigError(format!(
                 "profile.storages.definitions name={} is duplicated",
+                definition.name
+            ))));
+        }
+        if !ALLOWED_STORAGE_TYPES.contains(&definition.fs_type.as_str()) {
+            return Err(Box::new(ConfigError(format!(
+                "profile.storages.definitions name={} type={} is unsupported (allowed: {})",
+                definition.name,
+                definition.fs_type,
+                ALLOWED_STORAGE_TYPES.join(", ")
+            ))));
+        }
+        if definition.fs_type == "s3" {
+            if definition.bucket.is_none() {
+                return Err(Box::new(ConfigError(format!(
+                    "profile.storages.definitions name={} requires bucket for type s3",
+                    definition.name
+                ))));
+            }
+            if definition.region.is_none() {
+                return Err(Box::new(ConfigError(format!(
+                    "profile.storages.definitions name={} requires region for type s3",
+                    definition.name
+                ))));
+            }
+        }
+        if definition.fs_type == "adls" {
+            if definition.account.is_none() {
+                return Err(Box::new(ConfigError(format!(
+                    "profile.storages.definitions name={} requires account for type adls",
+                    definition.name
+                ))));
+            }
+            if definition.container.is_none() {
+                return Err(Box::new(ConfigError(format!(
+                    "profile.storages.definitions name={} requires container for type adls",
+                    definition.name
+                ))));
+            }
+        }
+        if definition.fs_type == "gcs" && definition.bucket.is_none() {
+            return Err(Box::new(ConfigError(format!(
+                "profile.storages.definitions name={} requires bucket for type gcs",
                 definition.name
             ))));
         }

--- a/crates/floe-core/src/profile/validate.rs
+++ b/crates/floe-core/src/profile/validate.rs
@@ -112,6 +112,16 @@ fn validate_profile_lineage(lineage: &LineageConfig) -> FloeResult<()> {
             "profile.lineage.url must not be empty".to_string(),
         )));
     }
+    if lineage.namespace.trim().is_empty() {
+        return Err(Box::new(ConfigError(
+            "profile.lineage.namespace must not be empty".to_string(),
+        )));
+    }
+    if lineage.max_failures == Some(0) {
+        return Err(Box::new(ConfigError(
+            "profile.lineage.max_failures must be at least 1".to_string(),
+        )));
+    }
     Ok(())
 }
 

--- a/crates/floe-core/src/profile/validate.rs
+++ b/crates/floe-core/src/profile/validate.rs
@@ -93,12 +93,15 @@ fn validate_profile_storages(storages: &StoragesConfig) -> FloeResult<()> {
             ))));
         }
     }
-    if let Some(default_name) = &storages.default {
-        if !names.contains(default_name.as_str()) {
-            return Err(Box::new(ConfigError(format!(
-                "profile.storages.default={default_name} does not match any definition"
-            ))));
-        }
+    let Some(default_name) = &storages.default else {
+        return Err(Box::new(ConfigError(
+            "profile.storages.default is required when storages is set".to_string(),
+        )));
+    };
+    if !names.contains(default_name.as_str()) {
+        return Err(Box::new(ConfigError(format!(
+            "profile.storages.default={default_name} does not match any definition"
+        ))));
     }
     Ok(())
 }

--- a/crates/floe-core/src/run/context.rs
+++ b/crates/floe-core/src/run/context.rs
@@ -33,6 +33,20 @@ impl RunContext {
                 .as_ref()
                 .and_then(|profile| profile.catalogs.as_ref()),
         );
+        crate::apply_profile_storages(
+            &mut config,
+            options
+                .profile
+                .as_ref()
+                .and_then(|profile| profile.storages.as_ref()),
+        );
+        crate::apply_profile_lineage(
+            &mut config,
+            options
+                .profile
+                .as_ref()
+                .and_then(|profile| profile.lineage.as_ref()),
+        );
         let storage_resolver = config::StorageResolver::new(&config, config_base)?;
         let catalog_resolver = config::CatalogResolver::new(&config)?;
         let config_dir =

--- a/crates/floe-core/src/run/mod.rs
+++ b/crates/floe-core/src/run/mod.rs
@@ -120,6 +120,14 @@ pub fn run_with_runtime(
             .profile
             .as_ref()
             .and_then(|profile| profile.catalogs.clone()),
+        profile_storages: options
+            .profile
+            .as_ref()
+            .and_then(|profile| profile.storages.clone()),
+        profile_lineage: options
+            .profile
+            .as_ref()
+            .and_then(|profile| profile.lineage.clone()),
     };
     crate::validate_with_base(config_path, config_base.clone(), validate_options)?;
     let context = RunContext::new(config_path, config_base, &options, profile_vars)?;

--- a/crates/floe-python/src/functions.rs
+++ b/crates/floe-python/src/functions.rs
@@ -38,6 +38,8 @@ fn load_optional_profile(
             variables: vars,
             validation: None,
             catalogs: None,
+            storages: None,
+            lineage: None,
         })),
     }
 }
@@ -59,7 +61,9 @@ pub fn validate(
             .as_ref()
             .map(|p| p.variables.clone())
             .unwrap_or_default(),
-        profile_catalogs: profile.and_then(|p| p.catalogs),
+        profile_catalogs: profile.as_ref().and_then(|p| p.catalogs.clone()),
+        profile_storages: profile.as_ref().and_then(|p| p.storages.clone()),
+        profile_lineage: profile.and_then(|p| p.lineage),
     };
     py.allow_threads(|| floe_core::validate(&path, options))
         .map_err(to_py_err)


### PR DESCRIPTION
## Summary

- Adds `storages` and `lineage` as valid top-level sections in profile YAML files, mirroring the existing `catalogs` override
- Both sections are parsed (reusing `parse_storages` / `parse_lineage_config` from the config parser), validated, and applied as wholesale config overrides before validation and run
- All three apply call sites are updated: `validate_with_base`, `load_config_with_profile_overrides`, and `RunContext::new`
- CLI (`validate` and `manifest generate` commands) and Python bindings pass the new fields through

## Test plan

- [x] `cargo test -p floe-core` — all 495 tests pass
- [x] `cargo clippy -p floe-core -p floe-cli -p floe-python -- -D warnings` — no warnings
- [x] `cargo fmt --check` — no formatting issues
- [x] Manual: profile YAML with `storages`/`lineage` blocks no longer rejected as unknown keys and values are reflected in the merged config

Closes #313

🤖 Generated with [Claude Code](https://claude.com/claude-code)