### PR TITLE
chore: bump all crates to v0.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to Floe are documented in this file.
 
+## v0.4.1
+
+- **Profile `storages` and `lineage` overrides** (`docs/profiles.md`):
+  - Profile files can now declare a `storages` section and a `lineage` section alongside the existing `catalogs` override. Both are applied as wholesale config replacements before validation and run, following the same pattern as `catalogs`.
+  - `floe validate --profile`, `floe run --profile`, and `floe manifest generate --profile` all honour the new sections.
+  - Python bindings (`floe.validate`) pass storages and lineage through to the merged config.
+  - Profile validation now enforces the same semantic constraints as config validation:
+    - `storages.default` is required whenever `storages` is declared.
+    - Storage definitions must use a supported type (`local`, `s3`, `adls`, `gcs`) and supply type-required fields (`s3`: bucket + region; `adls`: account + container; `gcs`: bucket).
+    - `lineage.namespace` must not be empty; `lineage.max_failures` must be ≥ 1 when set.
+
 ## v0.4.0
 
 - **OpenLineage circuit breaker and retry** (`docs/lineage.md`):

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3399,7 +3399,7 @@ dependencies = [
 
 [[package]]
 name = "floe-cli"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "assert_cmd",
  "clap",
@@ -3412,7 +3412,7 @@ dependencies = [
 
 [[package]]
 name = "floe-core"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "apache-avro 0.16.0",
  "arrow",
@@ -3455,7 +3455,7 @@ dependencies = [
 
 [[package]]
 name = "floe-python"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "floe-core",
  "pyo3",

--- a/context/bump-release.md
+++ b/context/bump-release.md
@@ -27,7 +27,7 @@ git checkout -b chore/bump-v<NEW_VERSION>
 
 ---
 
-## 3. Bump versions in all three `Cargo.toml` files
+## 3. Bump versions in all three `Cargo.toml` files and `pyproject.toml`
 
 Files to update — change `version = "..."` **and** the `floe-core` dependency version in the crates that reference it:
 
@@ -36,8 +36,9 @@ Files to update — change `version = "..."` **and** the `floe-core` dependency 
 | `crates/floe-core/Cargo.toml` | `version` |
 | `crates/floe-cli/Cargo.toml` | `version`, `floe-core` dependency version |
 | `crates/floe-python/Cargo.toml` | `version`, `floe-core` dependency version |
+| `crates/floe-python/pyproject.toml` | `version` (the `[project]` version — controls the PyPI wheel version) |
 
-There is no workspace-level `version` field — each crate is bumped independently but all three must stay in sync.
+There is no workspace-level `version` field — each crate is bumped independently but all four files must stay in sync.
 
 ---
 
@@ -101,6 +102,7 @@ cargo test -p floe-core
 git add crates/floe-core/Cargo.toml \
         crates/floe-cli/Cargo.toml \
         crates/floe-python/Cargo.toml \
+        crates/floe-python/pyproject.toml \
         Cargo.lock \
         CHANGELOG.md \
         docs/ \
@@ -124,7 +126,8 @@ PR body template:
 - Update docs: <list doc files touched>.
 
 ## Checklist
-- [ ] All three `Cargo.toml` versions updated
+- [ ] All three `Cargo.toml` versions updated (floe-core, floe-cli, floe-python)
+- [ ] `crates/floe-python/pyproject.toml` version updated
 - [ ] `Cargo.lock` updated via `cargo check`
 - [ ] `CHANGELOG.md` entry written
 - [ ] Docs updated for all user-visible changes

--- a/crates/floe-cli/Cargo.toml
+++ b/crates/floe-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "floe-cli"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2021"
 description = "CLI for Floe, a YAML-driven technical ingestion tool."
 license = "MIT"
@@ -17,7 +17,7 @@ path = "src/main.rs"
 
 [dependencies]
 clap = { version = "4", features = ["derive"] }
-floe-core = { path = "../floe-core", version = "0.4.0" }
+floe-core = { path = "../floe-core", version = "0.4.1" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 

--- a/crates/floe-core/Cargo.toml
+++ b/crates/floe-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "floe-core"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2021"
 description = "Core library for Floe, a YAML-driven technical ingestion tool."
 license = "MIT"

--- a/crates/floe-python/Cargo.toml
+++ b/crates/floe-python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "floe-python"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2021"
 description = "Python bindings for floe-core (PyO3-based)"
 license = "Apache-2.0"
@@ -13,7 +13,7 @@ name = "_floe"
 crate-type = ["cdylib"]
 
 [dependencies]
-floe-core = { path = "../floe-core", version = "0.4.0" }
+floe-core = { path = "../floe-core", version = "0.4.1" }
 pyo3 = { version = "0.22", features = ["extension-module", "abi3-py310"] }
 serde_json = "1"
 

--- a/crates/floe-python/pyproject.toml
+++ b/crates/floe-python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "floe-python"
-version = "0.4.0"
+version = "0.4.1"
 description = "Python bindings for floe-core — run floe pipelines at Rust speed from Python and notebooks"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary

- Bump `floe-core`, `floe-cli`, `floe-python` `Cargo.toml` and `floe-python/pyproject.toml` from `0.4.0` to `0.4.1`.
- Update `Cargo.lock` via `cargo check`.
- Update `CHANGELOG.md` with v0.4.1 entry covering the profile storages/lineage feature and validation hardening from #314.
- Update `context/bump-release.md` to include `pyproject.toml` in the bump checklist and steps.

## Checklist

- [x] All three `Cargo.toml` versions updated (floe-core, floe-cli, floe-python)
- [x] `crates/floe-python/pyproject.toml` version updated
- [x] `Cargo.lock` updated via `cargo check`
- [x] `CHANGELOG.md` entry written
- [x] `cargo fmt`, `clippy`, `cargo test -p floe-core` all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)