### PR TITLE
fix(lineage): emit source and sink datasets separately

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to Floe are documented in this file.
 
+## Unreleased
+
+- **OpenLineage: source and sink datasets emitted separately** (`docs/lineage.md`, fixes #317):
+  - Entity `COMPLETE`/`FAIL` events now set `inputs` to the **source dataset** (named after `source.path`) and `outputs` to the **accepted sink dataset** (named after `sink.accepted.path`).
+  - When a rejected sink is configured, a second output dataset (named after `sink.rejected.path`) is appended to `outputs`.
+  - Schema (`SchemaDataset`), `DataQualityMetrics`, and `FloeQualityRun` facets are attached to the source input dataset, which is the correct OpenLineage placement for input facets.
+  - Previously, `inputs` contained a single dataset named after the entity (not the path) and `outputs` was always empty, causing Marquez to show a dead-end lineage graph.
+
 ## v0.4.1
 
 - **Profile `storages` and `lineage` overrides** (`docs/profiles.md`):

--- a/crates/floe-core/src/lineage/mod.rs
+++ b/crates/floe-core/src/lineage/mod.rs
@@ -8,6 +8,12 @@ use serde_json::{json, Value};
 use crate::config::{EntityConfig, LineageConfig};
 use crate::run::events::{RunEvent, RunObserver};
 
+struct EntityUris {
+    source: String,
+    accepted: String,
+    rejected: Option<String>,
+}
+
 pub struct OpenLineageObserver {
     client: reqwest::blocking::Client,
     config: LineageConfig,
@@ -15,6 +21,7 @@ pub struct OpenLineageObserver {
     entity_run_ids: Mutex<HashMap<String, String>>,
     run_start_ms: Mutex<Option<u128>>,
     entity_schemas: HashMap<String, Vec<(String, String)>>,
+    entity_uris: HashMap<String, EntityUris>,
     consecutive_failures: AtomicUsize,
     circuit_open: AtomicBool,
 }
@@ -44,6 +51,20 @@ impl OpenLineageObserver {
             })
             .collect();
 
+        let entity_uris = entities
+            .iter()
+            .map(|e| {
+                (
+                    e.name.clone(),
+                    EntityUris {
+                        source: e.source.path.clone(),
+                        accepted: e.sink.accepted.path.clone(),
+                        rejected: e.sink.rejected.as_ref().map(|r| r.path.clone()),
+                    },
+                )
+            })
+            .collect();
+
         Ok(Self {
             client,
             config: config.clone(),
@@ -51,6 +72,7 @@ impl OpenLineageObserver {
             entity_run_ids: Mutex::new(HashMap::new()),
             run_start_ms: Mutex::new(None),
             entity_schemas,
+            entity_uris,
             consecutive_failures: AtomicUsize::new(0),
             circuit_open: AtomicBool::new(false),
         })
@@ -180,6 +202,7 @@ impl OpenLineageObserver {
         event_type: &str,
         ts_ms: u128,
         stats: Option<EntityStats>,
+        uris: Option<&EntityUris>,
     ) {
         let event_time = ms_to_iso8601(ts_ms);
         let job_name = format!("{}.{name}", self.config.namespace);
@@ -189,50 +212,71 @@ impl OpenLineageObserver {
             run_facets["parent"] = parent;
         }
 
-        // Build inputs with all facets for COMPLETE events; empty for START.
-        let inputs = if let Some(ref s) = stats {
-            let rejection_rate = if s.rows > 0 {
-                s.rejected as f64 / s.rows as f64
-            } else {
-                0.0
-            };
-            let schema_facet = json!({
-                "fields": s.schema_fields.iter().map(|(col_name, col_type)| {
-                    json!({ "name": col_name, "type": col_type })
-                }).collect::<Vec<_>>(),
-                "_producer": self.producer(),
-                "_schemaURL": "https://openlineage.io/spec/facets/1-1-1/SchemaDatasetFacet.json"
-            });
-            let dq_facet = json!({
-                "rowCount": s.rows,
-                "validCount": s.accepted,
-                "invalidCount": s.rejected,
-                "_producer": self.producer(),
-                "_schemaURL": "https://openlineage.io/spec/facets/1-0-2/DataQualityMetricsInputDatasetFacet.json"
-            });
-            let floe_facet = json!({
-                "entity": name,
-                "rejectionRate": rejection_rate,
-                "files": s.files,
-                "rows": s.rows,
-                "accepted": s.accepted,
-                "rejected": s.rejected,
-                "warnings": s.warnings,
-                "errors": s.errors,
-                "_producer": self.producer(),
-                "_schemaURL": "https://github.com/malon64/floe/schemas/FloeQualityRunFacet.json"
-            });
-            json!([{
-                "namespace": self.config.namespace,
-                "name": name,
-                "facets": {
-                    "schema": schema_facet,
-                    "dataQualityMetrics": dq_facet,
-                    "floeQualityRun": floe_facet
+        // Build inputs: source dataset with schema and quality facets on COMPLETE/FAIL.
+        let inputs = match (stats.as_ref(), uris) {
+            (Some(s), Some(u)) => {
+                let rejection_rate = if s.rows > 0 {
+                    s.rejected as f64 / s.rows as f64
+                } else {
+                    0.0
+                };
+                let schema_facet = json!({
+                    "fields": s.schema_fields.iter().map(|(col_name, col_type)| {
+                        json!({ "name": col_name, "type": col_type })
+                    }).collect::<Vec<_>>(),
+                    "_producer": self.producer(),
+                    "_schemaURL": "https://openlineage.io/spec/facets/1-1-1/SchemaDatasetFacet.json"
+                });
+                let dq_facet = json!({
+                    "rowCount": s.rows,
+                    "validCount": s.accepted,
+                    "invalidCount": s.rejected,
+                    "_producer": self.producer(),
+                    "_schemaURL": "https://openlineage.io/spec/facets/1-0-2/DataQualityMetricsInputDatasetFacet.json"
+                });
+                let floe_facet = json!({
+                    "entity": name,
+                    "rejectionRate": rejection_rate,
+                    "files": s.files,
+                    "rows": s.rows,
+                    "accepted": s.accepted,
+                    "rejected": s.rejected,
+                    "warnings": s.warnings,
+                    "errors": s.errors,
+                    "_producer": self.producer(),
+                    "_schemaURL": "https://github.com/malon64/floe/schemas/FloeQualityRunFacet.json"
+                });
+                json!([{
+                    "namespace": self.config.namespace,
+                    "name": u.source,
+                    "facets": {
+                        "schema": schema_facet,
+                        "dataQualityMetrics": dq_facet,
+                        "floeQualityRun": floe_facet
+                    }
+                }])
+            }
+            _ => json!([]),
+        };
+
+        // Build outputs: accepted sink always present; rejected sink when configured.
+        let outputs = match uris {
+            Some(u) => {
+                let mut out = vec![json!({
+                    "namespace": self.config.namespace,
+                    "name": u.accepted,
+                    "facets": {}
+                })];
+                if let Some(ref rej) = u.rejected {
+                    out.push(json!({
+                        "namespace": self.config.namespace,
+                        "name": rej,
+                        "facets": {}
+                    }));
                 }
-            }])
-        } else {
-            json!([])
+                json!(out)
+            }
+            None => json!([]),
         };
 
         let body = json!({
@@ -248,7 +292,7 @@ impl OpenLineageObserver {
                 "facets": {}
             },
             "inputs": inputs,
-            "outputs": [],
+            "outputs": outputs,
             "producer": self.producer(),
             "schemaURL": "https://openlineage.io/spec/1-0-5/OpenLineage.json#/$defs/RunEvent"
         });
@@ -329,7 +373,7 @@ impl RunObserver for OpenLineageObserver {
                 if let Ok(mut guard) = self.entity_run_ids.lock() {
                     guard.insert(name.clone(), entity_run_id.clone());
                 }
-                self.emit_entity_run_event(&entity_run_id, &name, "START", ts_ms, None);
+                self.emit_entity_run_event(&entity_run_id, &name, "START", ts_ms, None, None);
             }
             RunEvent::EntityFinished {
                 run_id,
@@ -364,7 +408,15 @@ impl RunObserver for OpenLineageObserver {
                     errors,
                     schema_fields,
                 };
-                self.emit_entity_run_event(&entity_run_id, &name, event_type, ts_ms, Some(stats));
+                let uris = self.entity_uris.get(&name);
+                self.emit_entity_run_event(
+                    &entity_run_id,
+                    &name,
+                    event_type,
+                    ts_ms,
+                    Some(stats),
+                    uris,
+                );
             }
             RunEvent::RunFinished {
                 run_id,

--- a/crates/floe-core/tests/unit/run/lineage.rs
+++ b/crates/floe-core/tests/unit/run/lineage.rs
@@ -1,6 +1,10 @@
-use floe_core::config::LineageConfig;
+use floe_core::config::{
+    EntityConfig, IncrementalMode, LineageConfig, PolicyConfig, PolicySeverity, SchemaConfig,
+    SinkConfig, SinkTarget, SourceConfig, WriteMode,
+};
 use floe_core::lineage::OpenLineageObserver;
 use floe_core::run::events::{RunEvent, RunObserver};
+use serde_json::json;
 
 fn make_config(server_url: &str, max_failures: Option<u32>) -> LineageConfig {
     LineageConfig {
@@ -166,6 +170,157 @@ fn circuit_stays_closed_after_recovery() {
     );
     assert!(!obs.is_circuit_open());
     success_mock.assert();
+}
+
+fn make_entity(
+    name: &str,
+    source_path: &str,
+    accepted_path: &str,
+    rejected_path: Option<&str>,
+) -> EntityConfig {
+    EntityConfig {
+        name: name.to_string(),
+        metadata: None,
+        domain: None,
+        incremental_mode: IncrementalMode::None,
+        state: None,
+        source: SourceConfig {
+            format: "csv".to_string(),
+            path: source_path.to_string(),
+            storage: None,
+            options: None,
+            cast_mode: None,
+        },
+        sink: SinkConfig {
+            write_mode: WriteMode::Overwrite,
+            accepted: SinkTarget {
+                format: "parquet".to_string(),
+                path: accepted_path.to_string(),
+                storage: None,
+                options: None,
+                merge: None,
+                iceberg: None,
+                delta: None,
+                partition_by: None,
+                partition_spec: None,
+                write_mode: WriteMode::Overwrite,
+            },
+            rejected: rejected_path.map(|p| SinkTarget {
+                format: "csv".to_string(),
+                path: p.to_string(),
+                storage: None,
+                options: None,
+                merge: None,
+                iceberg: None,
+                delta: None,
+                partition_by: None,
+                partition_spec: None,
+                write_mode: WriteMode::Overwrite,
+            }),
+            archive: None,
+        },
+        policy: PolicyConfig {
+            severity: PolicySeverity::Warn,
+        },
+        schema: SchemaConfig {
+            normalize_columns: None,
+            mismatch: None,
+            schema_evolution: None,
+            primary_key: None,
+            unique_keys: None,
+            columns: Vec::new(),
+        },
+        pii: None,
+    }
+}
+
+fn entity_finished_event(name: &str, status: &str) -> RunEvent {
+    RunEvent::EntityFinished {
+        run_id: "test-run-1".to_string(),
+        name: name.to_string(),
+        status: status.to_string(),
+        files: 2,
+        rows: 100,
+        accepted: 90,
+        rejected: 10,
+        warnings: 1,
+        errors: 0,
+        ts_ms: 1_002_000,
+    }
+}
+
+// COMPLETE entity event uses source URI as input dataset name and accepted path as output.
+#[test]
+fn entity_complete_event_has_source_input_and_accepted_output() {
+    let mut server = mockito::Server::new();
+
+    // EntityStarted (START) + EntityFinished (COMPLETE) = 2 posts.
+    let _start_mock = server
+        .mock("POST", "/api/v1/lineage")
+        .with_status(200)
+        .expect(1)
+        .create();
+
+    let _complete_mock = server
+        .mock("POST", "/api/v1/lineage")
+        .match_body(mockito::Matcher::AllOf(vec![
+            mockito::Matcher::PartialJson(json!({
+                "eventType": "COMPLETE",
+                "inputs": [{ "name": "/data/in/" }],
+                "outputs": [{ "name": "/data/out/" }]
+            })),
+        ]))
+        .with_status(200)
+        .expect(1)
+        .create();
+
+    let entity = make_entity("orders", "/data/in/", "/data/out/", None);
+    let config = make_config(&server.url(), None);
+    let obs = OpenLineageObserver::new(&config, &[entity]).unwrap();
+
+    obs.on_event(entity_started_event());
+    obs.on_event(entity_finished_event("orders", "success"));
+
+    _start_mock.assert();
+    _complete_mock.assert();
+}
+
+// COMPLETE entity event with a rejected sink includes both accepted and rejected in outputs.
+#[test]
+fn entity_complete_event_includes_rejected_output_when_configured() {
+    let mut server = mockito::Server::new();
+
+    let _start_mock = server
+        .mock("POST", "/api/v1/lineage")
+        .with_status(200)
+        .expect(1)
+        .create();
+
+    let _complete_mock = server
+        .mock("POST", "/api/v1/lineage")
+        .match_body(mockito::Matcher::AllOf(vec![
+            mockito::Matcher::PartialJson(json!({
+                "eventType": "COMPLETE",
+                "inputs": [{ "name": "/data/in/" }],
+                "outputs": [
+                    { "name": "/data/out/" },
+                    { "name": "/data/rejected/" }
+                ]
+            })),
+        ]))
+        .with_status(200)
+        .expect(1)
+        .create();
+
+    let entity = make_entity("orders", "/data/in/", "/data/out/", Some("/data/rejected/"));
+    let config = make_config(&server.url(), None);
+    let obs = OpenLineageObserver::new(&config, &[entity]).unwrap();
+
+    obs.on_event(entity_started_event());
+    obs.on_event(entity_finished_event("orders", "success"));
+
+    _start_mock.assert();
+    _complete_mock.assert();
 }
 
 // Circuit state is reset at the start of each new run (RunStarted) so a

--- a/docs/lineage.md
+++ b/docs/lineage.md
@@ -34,20 +34,36 @@ env-vars mechanism used for the rest of the config.
 For each Floe run, Floe posts OpenLineage `RunEvent` objects to
 `POST <url>/api/v1/lineage`:
 
-| Floe lifecycle       | OpenLineage event type | Notes                                                   |
-|----------------------|------------------------|---------------------------------------------------------|
-| Run begins           | `START`                | Top-level run job                                       |
-| Entity begins        | `START`                | Per-entity job `<namespace>.<entity>`                   |
-| Entity finishes (ok) | `COMPLETE`             | Includes `DataQualityMetrics`, `FloeQualityRun`, `SchemaDataset` facets |
-| Entity finishes (err)| `FAIL`                 | When entity status is `failed` or `aborted`             |
-| Run finishes (ok)    | `COMPLETE`             | Top-level run job                                       |
-| Run finishes (err)   | `FAIL`                 | Top-level run job                                       |
+| Floe lifecycle        | OpenLineage event type | Notes                                                                  |
+|-----------------------|------------------------|------------------------------------------------------------------------|
+| Run begins            | `START`                | Top-level run job                                                      |
+| Entity begins         | `START`                | Per-entity job `<namespace>.<entity>`                                  |
+| Entity finishes (ok)  | `COMPLETE`             | Inputs = source dataset; outputs = accepted (+ rejected) sink datasets |
+| Entity finishes (err) | `FAIL`                 | Same input/output structure as COMPLETE                                |
+| Run finishes (ok)     | `COMPLETE`             | Top-level run job                                                      |
+| Run finishes (err)    | `FAIL`                 | Top-level run job                                                      |
 
-### Facets on entity COMPLETE events
+### Datasets on entity COMPLETE/FAIL events
+
+Each entity event carries the actual data movement as OpenLineage datasets:
+
+- **`inputs`** — one dataset named after `source.path`; carries schema, data quality, and Floe quality run facets
+- **`outputs`** — one dataset named after `sink.accepted.path`; plus one named after `sink.rejected.path` when a rejected sink is configured
+
+This produces a lineage graph in Marquez (and compatible tools) of the form:
+
+```text
+source path  →  <namespace>.<entity> job  →  accepted sink path
+                                          →  rejected sink path (when present)
+```
+
+### Facets on entity COMPLETE/FAIL events
+
+Attached to the **source input dataset**:
 
 - **`DataQualityMetrics`** (`dataQualityMetrics`) — `rowCount`, `validCount`, `invalidCount`
 - **`FloeQualityRun`** — `entity`, `rejectionRate`, `files`, `rows`, `accepted`, `rejected`, `warnings`, `errors`
-- **`SchemaDataset`** — column names and types from `schema.columns`
+- **`SchemaDataset`** (`schema`) — column names and types from `schema.columns`
 
 ### ParentRun facet (Airflow / Dagster)
 


### PR DESCRIPTION
Fixes #317.

## Problem

Entity `COMPLETE`/`FAIL` events had `inputs` containing a dataset named after the **entity** (e.g. `"customers"`) rather than the source path, and `outputs` was hardcoded to `[]`. In Marquez this rendered as a dead-end graph — `customers → floe-demo-local.customers` with no output nodes.

## Solution

Pre-load entity source/sink paths into `OpenLineageObserver` at init time (an `EntityUris` map, following the same pattern as the existing `entity_schemas` map). Pass the URIs into `emit_entity_run_event` and build proper datasets:

- **`inputs`** — one dataset named after `source.path`, carrying `schema`, `dataQualityMetrics`, and `floeQualityRun` facets
- **`outputs`** — one dataset named after `sink.accepted.path`; a second dataset named after `sink.rejected.path` appended when a rejected sink is configured

The lineage graph in Marquez now reads:
```
source path  →  <namespace>.<entity> job  →  accepted sink path
                                          →  rejected sink path (when present)
```

## Changes

- `crates/floe-core/src/lineage/mod.rs` — `EntityUris` struct, pre-load at `new()`, restructured `emit_entity_run_event` with `uris` parameter
- `crates/floe-core/tests/unit/run/lineage.rs` — 2 new tests asserting `inputs`/`outputs` payload shape with `mockito::Matcher::PartialJson`
- `docs/lineage.md` — updated events table and new "Datasets" section explaining the graph shape
- `CHANGELOG.md` — unreleased entry

## Checklist

- [x] `inputs` uses source URI as dataset name
- [x] `outputs` contains accepted sink (and rejected when configured)
- [x] Schema and quality facets attached to source input dataset
- [x] FAIL events also carry inputs/outputs
- [x] 2 new unit tests pass
- [x] `cargo clippy -D warnings` clean