### PR TITLE
feat: self-contained manifest + Dagster multi-asset model

### DIFF
--- a/crates/floe-cli/src/main.rs
+++ b/crates/floe-cli/src/main.rs
@@ -2,9 +2,9 @@ use clap::{Parser, Subcommand, ValueEnum};
 use floe_core::{
     add_entity_to_config, build_common_manifest_json, inspect_entity_state_with_base,
     load_config_with_profile_overrides, load_config_with_profile_vars, parse_profile,
-    reset_entity_state_with_base, resolve_config_location, run_with_base, set_observer,
-    validate_profile, validate_with_base, AddEntityOptions, FloeResult, MultiObserver, RunEvent,
-    RunOptions, ValidateOptions,
+    reset_entity_state_with_base, resolve_config_location, run_with_base, run_with_manifest_path,
+    set_observer, validate_profile, validate_with_base, AddEntityOptions, FloeResult,
+    MultiObserver, RunEvent, RunOptions, ValidateOptions,
 };
 use std::io::Write;
 
@@ -131,8 +131,10 @@ enum Command {
     },
     #[command(about = "Run the ingestion pipeline", long_about = RUN_LONG_ABOUT)]
     Run {
-        #[arg(short, long, help = "Path or URI to the Floe config file")]
-        config: String,
+        #[arg(short, long, conflicts_with = "manifest", help = "Path or URI to the Floe config file")]
+        config: Option<String>,
+        #[arg(long, conflicts_with = "config", help = "Path to a self-contained Floe manifest JSON file")]
+        manifest: Option<String>,
         #[arg(long, help = "Optional run id (defaults to a generated value)")]
         run_id: Option<String>,
         #[arg(
@@ -402,6 +404,7 @@ fn main() -> FloeResult<()> {
         }
         Command::Run {
             config,
+            manifest,
             run_id,
             entities,
             quiet,
@@ -413,6 +416,107 @@ fn main() -> FloeResult<()> {
             let started_at = floe_core::report::now_rfc3339();
             let computed_run_id =
                 run_id.unwrap_or_else(|| floe_core::report::run_id_from_timestamp(&started_at));
+
+            // Build log observer early so failure paths can emit directly to it.
+            let log_obs = logging::build_log_observer(log_format.clone());
+
+            if let Some(manifest_path_str) = manifest {
+                // --- Manifest mode: no config file, no profile ---
+                let manifest_path = std::path::PathBuf::from(&manifest_path_str);
+
+                // Wire up lineage from manifest's embedded lineage block.
+                let lineage_observer = {
+                    let json = std::fs::read_to_string(&manifest_path).ok();
+                    json.and_then(|j| floe_core::config_from_manifest_json(&j).ok())
+                        .and_then(|(cfg, _)| cfg.lineage)
+                        .and_then(|lineage_cfg| {
+                            match floe_core::lineage::build_observer(&lineage_cfg, &[]) {
+                                Ok(obs) => Some(obs),
+                                Err(err) => {
+                                    eprintln!("Warning: lineage observer disabled: {err}");
+                                    None
+                                }
+                            }
+                        })
+                };
+                let mut obs_vec = Vec::new();
+                let has_log_obs = log_obs.is_some();
+                if let Some(log) = log_obs {
+                    obs_vec.push(log);
+                }
+                if let Some(lin) = lineage_observer {
+                    obs_vec.push(lin);
+                }
+                if !has_log_obs && !obs_vec.is_empty() {
+                    obs_vec.push(logging::build_warn_sink());
+                }
+                if !obs_vec.is_empty() {
+                    let _ = set_observer(std::sync::Arc::new(MultiObserver::new(obs_vec)));
+                }
+
+                let options = RunOptions {
+                    run_id: Some(computed_run_id.clone()),
+                    entities,
+                    dry_run,
+                    profile: None,
+                };
+
+                let outcome = match run_with_manifest_path(&manifest_path, options) {
+                    Ok(outcome) => outcome,
+                    Err(err) => {
+                        if !floe_core::run::events::is_run_started() {
+                            floe_core::run::events::default_observer().on_event(
+                                RunEvent::RunStarted {
+                                    run_id: computed_run_id.clone(),
+                                    config: manifest_path_str.clone(),
+                                    report_base: None,
+                                    ts_ms: floe_core::run::events::event_time_ms(),
+                                },
+                            );
+                        }
+                        logging::emit_failed_run_events(&computed_run_id, err.as_ref());
+                        let mut err_out = std::io::stderr().lock();
+                        let _ = writeln!(err_out, "Error: {err}");
+                        let _ = err_out.flush();
+                        std::process::exit(1);
+                    }
+                };
+                let mode = if quiet {
+                    output::OutputMode::Quiet
+                } else if verbose {
+                    output::OutputMode::Verbose
+                } else {
+                    output::OutputMode::Default
+                };
+                let summary = output::format_run_output(&outcome, mode, dry_run);
+                match log_format {
+                    LogFormat::Json => {
+                        let mut err = std::io::stderr().lock();
+                        let _ = writeln!(err, "{summary}");
+                        let _ = err.flush();
+                    }
+                    LogFormat::Text | LogFormat::Off => {
+                        let mut out = std::io::stdout().lock();
+                        let _ = writeln!(out, "{summary}");
+                        let _ = out.flush();
+                    }
+                }
+                std::process::exit(outcome.summary.run.exit_code);
+            }
+
+            // --- Config mode (default) ---
+            let config = match config {
+                Some(c) => c,
+                None => {
+                    let mut err_out = std::io::stderr().lock();
+                    let _ = writeln!(
+                        err_out,
+                        "Error: one of --config or --manifest is required"
+                    );
+                    let _ = err_out.flush();
+                    std::process::exit(1);
+                }
+            };
 
             let profile_config = if let Some(ref profile_path) = profile {
                 let path = std::path::Path::new(profile_path);
@@ -443,10 +547,6 @@ fn main() -> FloeResult<()> {
                 .as_ref()
                 .map(|p| p.variables.clone())
                 .unwrap_or_default();
-
-            // Build log observer early (before set_observer) so early failure
-            // paths can emit directly to it without going through the global observer.
-            let log_obs = logging::build_log_observer(log_format.clone());
 
             let options = RunOptions {
                 run_id: Some(computed_run_id.clone()),

--- a/crates/floe-cli/src/main.rs
+++ b/crates/floe-cli/src/main.rs
@@ -131,9 +131,18 @@ enum Command {
     },
     #[command(about = "Run the ingestion pipeline", long_about = RUN_LONG_ABOUT)]
     Run {
-        #[arg(short, long, conflicts_with = "manifest", help = "Path or URI to the Floe config file")]
+        #[arg(
+            short,
+            long,
+            conflicts_with = "manifest",
+            help = "Path or URI to the Floe config file"
+        )]
         config: Option<String>,
-        #[arg(long, conflicts_with = "config", help = "Path to a self-contained Floe manifest JSON file")]
+        #[arg(
+            long,
+            conflicts_with = "config",
+            help = "Path to a self-contained Floe manifest JSON file"
+        )]
         manifest: Option<String>,
         #[arg(long, help = "Optional run id (defaults to a generated value)")]
         run_id: Option<String>,
@@ -509,10 +518,7 @@ fn main() -> FloeResult<()> {
                 Some(c) => c,
                 None => {
                     let mut err_out = std::io::stderr().lock();
-                    let _ = writeln!(
-                        err_out,
-                        "Error: one of --config or --manifest is required"
-                    );
+                    let _ = writeln!(err_out, "Error: one of --config or --manifest is required");
                     let _ = err_out.flush();
                     std::process::exit(1);
                 }

--- a/crates/floe-cli/tests/manifest_output.rs
+++ b/crates/floe-cli/tests/manifest_output.rs
@@ -6,6 +6,42 @@ use std::io::Write;
 use std::path::PathBuf;
 use tempfile::tempdir;
 
+fn write_minimal_config(dir: &std::path::Path, policy: &str) -> PathBuf {
+    let config_path = dir.join("config.yml");
+    fs::write(
+        &config_path,
+        format!(
+            r#"version: "0.1"
+entities:
+  - name: orders
+    source:
+      format: csv
+      path: ./in/orders
+      options:
+        header: true
+        separator: ","
+    sink:
+      write_mode: overwrite
+      accepted:
+        format: parquet
+        path: ./out/orders/
+      rejected:
+        format: csv
+        path: ./out/rejected/orders/
+    policy:
+      severity: {policy}
+    schema:
+      columns:
+        - name: order_id
+          type: string
+          nullable: false
+"#
+        ),
+    )
+    .expect("write config");
+    config_path
+}
+
 fn repo_root() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../..")
 }
@@ -287,4 +323,165 @@ variables:
         .as_str()
         .expect("accepted path")
         .contains("out-dev"));
+}
+
+#[test]
+fn manifest_entity_includes_policy_severity_and_write_mode() {
+    let tmp = tempdir().expect("create temp dir");
+    let config_path = write_minimal_config(tmp.path(), "reject");
+
+    let mut cmd = Command::new(assert_cmd::cargo::cargo_bin!("floe"));
+    let assert = cmd
+        .args(["manifest", "generate", "-c"])
+        .arg(&config_path)
+        .args(["--output", "-"])
+        .assert()
+        .success();
+
+    let stdout = String::from_utf8_lossy(&assert.get_output().stdout);
+    let value: Value = serde_json::from_str(stdout.trim()).expect("stdout should be json");
+    let entity = &value["entities"][0];
+    assert_eq!(entity["policy_severity"], "reject");
+    assert_eq!(entity["write_mode"], "overwrite");
+    assert_eq!(entity["incremental_mode"], "none");
+}
+
+#[test]
+fn manifest_entity_includes_schema_columns() {
+    let tmp = tempdir().expect("create temp dir");
+    let config_path = write_minimal_config(tmp.path(), "warn");
+
+    let mut cmd = Command::new(assert_cmd::cargo::cargo_bin!("floe"));
+    let assert = cmd
+        .args(["manifest", "generate", "-c"])
+        .arg(&config_path)
+        .args(["--output", "-"])
+        .assert()
+        .success();
+
+    let stdout = String::from_utf8_lossy(&assert.get_output().stdout);
+    let value: Value = serde_json::from_str(stdout.trim()).expect("stdout should be json");
+    let schema = &value["entities"][0]["schema"];
+    let columns = schema["columns"].as_array().expect("columns array");
+    assert_eq!(columns.len(), 1);
+    assert_eq!(columns[0]["name"], "order_id");
+    assert_eq!(columns[0]["column_type"], "string");
+    assert_eq!(columns[0]["nullable"], false);
+}
+
+#[test]
+fn manifest_includes_storages_when_profile_has_storages() {
+    let tmp = tempdir().expect("create temp dir");
+    let config_path = write_minimal_config(tmp.path(), "warn");
+    let profile_path = tmp.path().join("profile.yml");
+
+    fs::write(
+        &profile_path,
+        r#"apiVersion: floe/v1
+kind: EnvironmentProfile
+metadata:
+  name: test-s3
+storages:
+  default: my-s3
+  definitions:
+    - name: my-s3
+      type: s3
+      bucket: my-bucket
+      region: us-east-1
+"#,
+    )
+    .expect("write profile");
+
+    let mut cmd = Command::new(assert_cmd::cargo::cargo_bin!("floe"));
+    let assert = cmd
+        .args(["manifest", "generate", "-c"])
+        .arg(&config_path)
+        .arg("--profile")
+        .arg(&profile_path)
+        .args(["--output", "-"])
+        .assert()
+        .success();
+
+    let stdout = String::from_utf8_lossy(&assert.get_output().stdout);
+    let value: Value = serde_json::from_str(stdout.trim()).expect("stdout should be json");
+    assert!(value["storages"].is_object(), "storages should be embedded");
+    assert_eq!(value["storages"]["default"], "my-s3");
+}
+
+#[test]
+fn manifest_execution_uses_manifest_uri_arg() {
+    let config_path = repo_root().join("example/config.yml");
+
+    let mut cmd = Command::new(assert_cmd::cargo::cargo_bin!("floe"));
+    let assert = cmd
+        .args(["manifest", "generate", "-c"])
+        .arg(&config_path)
+        .args(["--output", "-"])
+        .assert()
+        .success();
+
+    let stdout = String::from_utf8_lossy(&assert.get_output().stdout);
+    let value: Value = serde_json::from_str(stdout.trim()).expect("stdout should be json");
+    let base_args = value["execution"]["base_args"]
+        .as_array()
+        .expect("base_args");
+    let args_str: Vec<&str> = base_args.iter().map(|v| v.as_str().unwrap()).collect();
+    assert!(
+        args_str.contains(&"--manifest"),
+        "base_args should contain --manifest"
+    );
+    assert!(
+        args_str.contains(&"{manifest_uri}"),
+        "base_args should contain {{manifest_uri}} token"
+    );
+}
+
+#[test]
+fn run_with_manifest_file_executes_entity() {
+    let tmp = tempdir().expect("create temp dir");
+    let config_path = write_minimal_config(tmp.path(), "warn");
+    let manifest_path = tmp.path().join("manifest.json");
+    let input_dir = tmp.path().join("in/orders");
+    fs::create_dir_all(&input_dir).expect("create input dir");
+    fs::write(
+        input_dir.join("orders.csv"),
+        "order_id\n001\n002\n",
+    )
+    .expect("write csv");
+
+    // Generate the manifest first.
+    Command::new(assert_cmd::cargo::cargo_bin!("floe"))
+        .args(["manifest", "generate", "-c"])
+        .arg(&config_path)
+        .args(["--output"])
+        .arg(&manifest_path)
+        .assert()
+        .success();
+
+    // Patch the manifest to point paths to the temp dir.
+    let manifest_str = fs::read_to_string(&manifest_path).expect("read manifest");
+    let mut manifest: Value = serde_json::from_str(&manifest_str).expect("parse manifest");
+    let entity = &mut manifest["entities"][0];
+    entity["source"]["path"] = Value::String(input_dir.display().to_string());
+    entity["source"]["uri"] = Value::String(input_dir.display().to_string());
+    entity["sinks"]["accepted"]["path"] = Value::String(
+        tmp.path().join("out/orders").display().to_string(),
+    );
+    entity["sinks"]["accepted"]["uri"] = Value::String(
+        tmp.path().join("out/orders").display().to_string(),
+    );
+    entity["sinks"]["rejected"]["path"] = Value::String(
+        tmp.path().join("out/rejected").display().to_string(),
+    );
+    entity["sinks"]["rejected"]["uri"] = Value::String(
+        tmp.path().join("out/rejected").display().to_string(),
+    );
+    fs::write(&manifest_path, serde_json::to_string_pretty(&manifest).unwrap()).expect("rewrite manifest");
+
+    Command::new(assert_cmd::cargo::cargo_bin!("floe"))
+        .args(["run", "--manifest"])
+        .arg(&manifest_path)
+        .args(["--entities", "orders"])
+        .assert()
+        .success();
 }

--- a/crates/floe-cli/tests/manifest_output.rs
+++ b/crates/floe-cli/tests/manifest_output.rs
@@ -443,11 +443,7 @@ fn run_with_manifest_file_executes_entity() {
     let manifest_path = tmp.path().join("manifest.json");
     let input_dir = tmp.path().join("in/orders");
     fs::create_dir_all(&input_dir).expect("create input dir");
-    fs::write(
-        input_dir.join("orders.csv"),
-        "order_id\n001\n002\n",
-    )
-    .expect("write csv");
+    fs::write(input_dir.join("orders.csv"), "order_id\n001\n002\n").expect("write csv");
 
     // Generate the manifest first.
     Command::new(assert_cmd::cargo::cargo_bin!("floe"))
@@ -464,19 +460,19 @@ fn run_with_manifest_file_executes_entity() {
     let entity = &mut manifest["entities"][0];
     entity["source"]["path"] = Value::String(input_dir.display().to_string());
     entity["source"]["uri"] = Value::String(input_dir.display().to_string());
-    entity["sinks"]["accepted"]["path"] = Value::String(
-        tmp.path().join("out/orders").display().to_string(),
-    );
-    entity["sinks"]["accepted"]["uri"] = Value::String(
-        tmp.path().join("out/orders").display().to_string(),
-    );
-    entity["sinks"]["rejected"]["path"] = Value::String(
-        tmp.path().join("out/rejected").display().to_string(),
-    );
-    entity["sinks"]["rejected"]["uri"] = Value::String(
-        tmp.path().join("out/rejected").display().to_string(),
-    );
-    fs::write(&manifest_path, serde_json::to_string_pretty(&manifest).unwrap()).expect("rewrite manifest");
+    entity["sinks"]["accepted"]["path"] =
+        Value::String(tmp.path().join("out/orders").display().to_string());
+    entity["sinks"]["accepted"]["uri"] =
+        Value::String(tmp.path().join("out/orders").display().to_string());
+    entity["sinks"]["rejected"]["path"] =
+        Value::String(tmp.path().join("out/rejected").display().to_string());
+    entity["sinks"]["rejected"]["uri"] =
+        Value::String(tmp.path().join("out/rejected").display().to_string());
+    fs::write(
+        &manifest_path,
+        serde_json::to_string_pretty(&manifest).unwrap(),
+    )
+    .expect("rewrite manifest");
 
     Command::new(assert_cmd::cargo::cargo_bin!("floe"))
         .args(["run", "--manifest"])

--- a/crates/floe-core/src/config/types.rs
+++ b/crates/floe-core/src/config/types.rs
@@ -1,6 +1,8 @@
 use std::collections::HashMap;
 use std::path::Path;
 
+use serde::{Deserialize, Serialize};
+
 use polars::polars_utils::pl_str::PlSmallStr;
 use polars::prelude::{
     CsvEncoding, CsvParseOptions, CsvReadOptions, DataType, NullValues, TimeUnit,
@@ -21,7 +23,7 @@ pub struct RootConfig {
     pub entities: Vec<EntityConfig>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct LineageConfig {
     pub url: String,
     pub api_key: Option<String>,
@@ -66,12 +68,12 @@ pub struct EntityConfig {
     pub pii: Option<PiiConfig>,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct PiiConfig {
     pub columns: Vec<PiiColumnConfig>,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct PiiColumnConfig {
     pub name: String,
     pub strategy: PiiStrategy,
@@ -79,7 +81,8 @@ pub struct PiiColumnConfig {
     pub redact_value: Option<String>,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
 pub enum PiiStrategy {
     Hash,
     Drop,
@@ -103,7 +106,8 @@ impl EntityConfig {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
 pub enum IncrementalMode {
     #[default]
     None,
@@ -146,7 +150,7 @@ pub struct SourceConfig {
     pub cast_mode: Option<String>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Deserialize)]
 pub struct SourceOptions {
     pub header: Option<bool>,
     pub separator: Option<String>,
@@ -262,7 +266,8 @@ pub struct SinkConfig {
     pub archive: Option<ArchiveTarget>,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
 pub enum WriteMode {
     #[default]
     Overwrite,
@@ -300,34 +305,34 @@ pub const DEFAULT_SCD2_CURRENT_FLAG_COLUMN: &str = "__floe_is_current";
 pub const DEFAULT_SCD2_VALID_FROM_COLUMN: &str = "__floe_valid_from";
 pub const DEFAULT_SCD2_VALID_TO_COLUMN: &str = "__floe_valid_to";
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct MergeOptionsConfig {
     pub ignore_columns: Option<Vec<String>>,
     pub compare_columns: Option<Vec<String>>,
     pub scd2: Option<MergeScd2OptionsConfig>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct MergeScd2OptionsConfig {
     pub current_flag_column: Option<String>,
     pub valid_from_column: Option<String>,
     pub valid_to_column: Option<String>,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct SinkOptions {
     pub compression: Option<String>,
     pub row_group_size: Option<u64>,
     pub max_size_per_file: Option<u64>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct IcebergPartitionFieldConfig {
     pub column: String,
     pub transform: String,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct IcebergSinkTargetConfig {
     pub catalog: Option<String>,
     pub namespace: Option<String>,
@@ -335,7 +340,7 @@ pub struct IcebergSinkTargetConfig {
     pub location: Option<String>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DeltaSinkTargetConfig {
     /// Name of the catalog definition to use (falls back to `catalogs.default`).
     pub catalog: Option<String>,
@@ -345,13 +350,13 @@ pub struct DeltaSinkTargetConfig {
     pub table: Option<String>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct StoragesConfig {
     pub default: Option<String>,
     pub definitions: Vec<StorageDefinition>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct StorageDefinition {
     pub name: String,
     pub fs_type: String,
@@ -362,7 +367,7 @@ pub struct StorageDefinition {
     pub prefix: Option<String>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CatalogsConfig {
     pub default: Option<String>,
     pub definitions: Vec<CatalogDefinition>,
@@ -371,7 +376,8 @@ pub struct CatalogsConfig {
 /// Type-specific configuration for a catalog definition.
 /// Each variant carries only the fields relevant to that catalog type.
 /// Add a new variant here when supporting a new catalog type.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "lowercase")]
 pub enum CatalogTypeConfig {
     Glue {
         region: String,
@@ -419,7 +425,7 @@ impl CatalogTypeConfig {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CatalogDefinition {
     pub name: String,
     pub type_config: CatalogTypeConfig,
@@ -440,7 +446,8 @@ pub struct ArchiveTarget {
     pub storage: Option<String>,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
 pub enum PolicySeverity {
     #[default]
     Warn,
@@ -469,7 +476,7 @@ pub struct PolicyConfig {
     pub severity: PolicySeverity,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct SchemaConfig {
     pub normalize_columns: Option<NormalizeColumnsConfig>,
     pub mismatch: Option<SchemaMismatchConfig>,
@@ -485,19 +492,20 @@ impl SchemaConfig {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct NormalizeColumnsConfig {
     pub enabled: Option<bool>,
     pub strategy: Option<String>,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
 pub struct SchemaEvolutionConfig {
     pub mode: SchemaEvolutionMode,
     pub on_incompatible: SchemaEvolutionIncompatibleAction,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
 pub enum SchemaEvolutionMode {
     #[default]
     Strict,
@@ -513,7 +521,8 @@ impl SchemaEvolutionMode {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
 pub enum SchemaEvolutionIncompatibleAction {
     #[default]
     Fail,
@@ -527,13 +536,13 @@ impl SchemaEvolutionIncompatibleAction {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct SchemaMismatchConfig {
     pub missing_columns: Option<String>,
     pub extra_columns: Option<String>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize)]
 pub struct ColumnConfig {
     pub name: String,
     pub source: Option<String>,

--- a/crates/floe-core/src/lib.rs
+++ b/crates/floe-core/src/lib.rs
@@ -28,7 +28,9 @@ pub use profile::{
     parse_profile_from_str, validate_merged_vars, validate_profile, ProfileConfig,
 };
 pub use run::events::{set_observer, MultiObserver, RunEvent, RunObserver};
-pub use run::{run, run_with_base, run_with_manifest_path, DryRunEntityPreview, EntityOutcome, RunOutcome};
+pub use run::{
+    run, run_with_base, run_with_manifest_path, DryRunEntityPreview, EntityOutcome, RunOutcome,
+};
 pub use runner::{parse_run_status_from_logs, ConnectorRunStatus};
 pub use runtime::{DefaultRuntime, Runtime};
 pub use vars::{resolve_vars, VarSources};

--- a/crates/floe-core/src/lib.rs
+++ b/crates/floe-core/src/lib.rs
@@ -22,13 +22,13 @@ pub use add_entity::{add_entity_to_config, AddEntityOptions, AddEntityOutcome};
 pub use checks as check;
 pub use config::{resolve_config_location, ConfigLocation};
 pub use errors::ConfigError;
-pub use manifest::build_common_manifest_json;
+pub use manifest::{build_common_manifest_json, config_from_manifest_json};
 pub use profile::{
     detect_malformed_placeholder, detect_unresolved_placeholders, parse_profile,
     parse_profile_from_str, validate_merged_vars, validate_profile, ProfileConfig,
 };
 pub use run::events::{set_observer, MultiObserver, RunEvent, RunObserver};
-pub use run::{run, run_with_base, DryRunEntityPreview, EntityOutcome, RunOutcome};
+pub use run::{run, run_with_base, run_with_manifest_path, DryRunEntityPreview, EntityOutcome, RunOutcome};
 pub use runner::{parse_run_status_from_logs, ConnectorRunStatus};
 pub use runtime::{DefaultRuntime, Runtime};
 pub use vars::{resolve_vars, VarSources};

--- a/crates/floe-core/src/manifest/builder.rs
+++ b/crates/floe-core/src/manifest/builder.rs
@@ -3,10 +3,10 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use crate::config::{ConfigLocation, RootConfig, SourceOptions, StorageResolver};
 use crate::manifest::model::{
-    CommonManifest, ManifestArchiveTarget, ManifestDomain, ManifestEntity, ManifestExecution,
-    ManifestExecutionDefaults, ManifestResultContract, ManifestRunnerAuth,
-    ManifestRunnerDefinition, ManifestRunnerResources, ManifestRunnerSecret, ManifestRunners,
-    ManifestSinkTarget, ManifestSinks, ManifestSource,
+    CommonManifest, ManifestArchiveTarget, ManifestColumnDef, ManifestDomain, ManifestEntity,
+    ManifestEntitySchema, ManifestExecution, ManifestExecutionDefaults, ManifestResultContract,
+    ManifestRunnerAuth, ManifestRunnerDefinition, ManifestRunnerResources, ManifestRunnerSecret,
+    ManifestRunners, ManifestSinkTarget, ManifestSinks, ManifestSource,
 };
 use crate::profile::ProfileConfig;
 use crate::FloeResult;
@@ -128,6 +128,45 @@ fn build_common_manifest(
         }
         let tags = if tags.is_empty() { None } else { Some(tags) };
 
+        let schema = ManifestEntitySchema {
+            columns: entity
+                .schema
+                .columns
+                .iter()
+                .map(|c| ManifestColumnDef {
+                    name: c.name.clone(),
+                    column_type: c.column_type.clone(),
+                    source: c.source.clone(),
+                    nullable: c.nullable,
+                    unique: c.unique,
+                    width: c.width,
+                    trim: c.trim,
+                })
+                .collect(),
+            primary_key: entity.schema.primary_key.clone().unwrap_or_default(),
+            unique_keys: entity.schema.unique_keys.clone().unwrap_or_default(),
+            normalize_columns: entity
+                .schema
+                .normalize_columns
+                .as_ref()
+                .and_then(|v| serde_json::to_value(v).ok()),
+            mismatch: entity
+                .schema
+                .mismatch
+                .as_ref()
+                .and_then(|v| serde_json::to_value(v).ok()),
+            schema_evolution: entity
+                .schema
+                .schema_evolution
+                .as_ref()
+                .and_then(|v| serde_json::to_value(v).ok()),
+        };
+
+        let pii = entity
+            .pii
+            .as_ref()
+            .and_then(|v| serde_json::to_value(v).ok());
+
         manifest_entities.push(ManifestEntity {
             name: entity.name.clone(),
             domain: entity.domain.clone(),
@@ -153,23 +192,56 @@ fn build_common_manifest(
                     uri: accepted.uri,
                     path: entity.sink.accepted.path.clone(),
                     resolved: accepted.resolved,
+                    options: entity
+                        .sink
+                        .accepted
+                        .options
+                        .as_ref()
+                        .and_then(|v| serde_json::to_value(v).ok()),
+                    partition_by: entity.sink.accepted.partition_by.clone(),
+                    merge: entity
+                        .sink
+                        .accepted
+                        .merge
+                        .as_ref()
+                        .and_then(|v| serde_json::to_value(v).ok()),
+                    iceberg: entity
+                        .sink
+                        .accepted
+                        .iceberg
+                        .as_ref()
+                        .and_then(|v| serde_json::to_value(v).ok()),
+                    delta: entity
+                        .sink
+                        .accepted
+                        .delta
+                        .as_ref()
+                        .and_then(|v| serde_json::to_value(v).ok()),
                 },
-                rejected: rejected.map(|value| ManifestSinkTarget {
-                    format: entity
-                        .sink
-                        .rejected
-                        .as_ref()
-                        .map(|target| target.format.clone())
-                        .unwrap_or_else(|| "csv".to_string()),
-                    storage: value.storage,
-                    uri: value.uri,
-                    path: entity
-                        .sink
-                        .rejected
-                        .as_ref()
-                        .map(|target| target.path.clone())
-                        .unwrap_or_default(),
-                    resolved: value.resolved,
+                rejected: rejected.map(|value| {
+                    let rej = entity.sink.rejected.as_ref();
+                    ManifestSinkTarget {
+                        format: rej
+                            .map(|t| t.format.clone())
+                            .unwrap_or_else(|| "csv".to_string()),
+                        storage: value.storage,
+                        uri: value.uri,
+                        path: rej.map(|t| t.path.clone()).unwrap_or_default(),
+                        resolved: value.resolved,
+                        options: rej
+                            .and_then(|t| t.options.as_ref())
+                            .and_then(|v| serde_json::to_value(v).ok()),
+                        partition_by: rej.and_then(|t| t.partition_by.clone()),
+                        merge: rej
+                            .and_then(|t| t.merge.as_ref())
+                            .and_then(|v| serde_json::to_value(v).ok()),
+                        iceberg: rej
+                            .and_then(|t| t.iceberg.as_ref())
+                            .and_then(|v| serde_json::to_value(v).ok()),
+                        delta: rej
+                            .and_then(|t| t.delta.as_ref())
+                            .and_then(|v| serde_json::to_value(v).ok()),
+                    }
                 }),
                 archive: archive.map(|value| ManifestArchiveTarget {
                     storage: value.storage,
@@ -184,11 +256,28 @@ fn build_common_manifest(
                 }),
             },
             runner: None,
+            policy_severity: entity.policy.severity.as_str().to_string(),
+            write_mode: entity.sink.write_mode.as_str().to_string(),
+            incremental_mode: entity.incremental_mode.as_str().to_string(),
+            schema,
+            pii,
+            state_path: entity.state.as_ref().and_then(|s| s.path.clone()),
         });
     }
 
     let config_uri = canonical_config_uri(&config_location.display);
     let config_checksum = None;
+
+    // Serialize profile sections as opaque JSON values so they can be re-applied at run time.
+    let storages = profile
+        .and_then(|p| p.storages.as_ref())
+        .and_then(|v| serde_json::to_value(v).ok());
+    let catalogs = profile
+        .and_then(|p| p.catalogs.as_ref())
+        .and_then(|v| serde_json::to_value(v).ok());
+    let lineage = profile
+        .and_then(|p| p.lineage.as_ref())
+        .and_then(|v| serde_json::to_value(v).ok());
 
     CommonManifest {
         schema: "floe.manifest.v1",
@@ -213,6 +302,9 @@ fn build_common_manifest(
         execution: default_execution_contract(),
         runners: runners_contract(profile),
         entities: manifest_entities,
+        storages,
+        catalogs,
+        lineage,
     }
 }
 
@@ -315,8 +407,8 @@ fn default_execution_contract() -> ManifestExecution {
         entrypoint: "floe",
         base_args: vec![
             "run",
-            "-c",
-            "{config_uri}",
+            "--manifest",
+            "{manifest_uri}",
             "--log-format",
             "json",
             "--quiet",

--- a/crates/floe-core/src/manifest/mod.rs
+++ b/crates/floe-core/src/manifest/mod.rs
@@ -1,4 +1,6 @@
 mod builder;
 mod model;
+pub mod reconstruct;
 
 pub use builder::build_common_manifest_json;
+pub use reconstruct::config_from_manifest_json;

--- a/crates/floe-core/src/manifest/model.rs
+++ b/crates/floe-core/src/manifest/model.rs
@@ -15,6 +15,15 @@ pub struct CommonManifest {
     pub execution: ManifestExecution,
     pub runners: ManifestRunners,
     pub entities: Vec<ManifestEntity>,
+    /// Storage backend definitions from the profile (if a profile was supplied).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub storages: Option<serde_json::Value>,
+    /// Catalog definitions from the profile (if a profile was supplied).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub catalogs: Option<serde_json::Value>,
+    /// Lineage configuration from the profile (if a profile was supplied).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub lineage: Option<serde_json::Value>,
 }
 
 #[derive(Debug, Serialize)]
@@ -107,6 +116,49 @@ pub struct ManifestEntity {
     pub source: ManifestSource,
     pub sinks: ManifestSinks,
     pub runner: Option<String>,
+    /// Policy severity: "warn" | "reject" | "abort".
+    pub policy_severity: String,
+    /// Sink write mode: "overwrite" | "append" | "merge_scd1" | "merge_scd2".
+    pub write_mode: String,
+    /// Incremental processing mode: "none" | "archive" | "file" | "row".
+    pub incremental_mode: String,
+    /// Full schema definition for this entity.
+    pub schema: ManifestEntitySchema,
+    /// PII masking configuration, if configured.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub pii: Option<serde_json::Value>,
+    /// Incremental state file path, if configured.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub state_path: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ManifestEntitySchema {
+    pub columns: Vec<ManifestColumnDef>,
+    pub primary_key: Vec<String>,
+    pub unique_keys: Vec<Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub normalize_columns: Option<serde_json::Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub mismatch: Option<serde_json::Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub schema_evolution: Option<serde_json::Value>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ManifestColumnDef {
+    pub name: String,
+    pub column_type: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub source: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub nullable: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub unique: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub width: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub trim: Option<bool>,
 }
 
 #[derive(Debug, Serialize)]
@@ -134,6 +186,16 @@ pub struct ManifestSinkTarget {
     pub uri: String,
     pub path: String,
     pub resolved: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub options: Option<serde_json::Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub partition_by: Option<Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub merge: Option<serde_json::Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub iceberg: Option<serde_json::Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub delta: Option<serde_json::Value>,
 }
 
 #[derive(Debug, Serialize)]

--- a/crates/floe-core/src/manifest/reconstruct.rs
+++ b/crates/floe-core/src/manifest/reconstruct.rs
@@ -94,8 +94,8 @@ pub struct ManifestColumnDefForRun {
 /// Parse a manifest JSON string and reconstruct a minimal RootConfig.
 /// Returns (config, report_base_uri).
 pub fn config_from_manifest_json(json: &str) -> FloeResult<(crate::config::RootConfig, String)> {
-    let manifest: ManifestForRun = serde_json::from_str(json)
-        .map_err(|err| -> Box<dyn std::error::Error + Send + Sync> {
+    let manifest: ManifestForRun =
+        serde_json::from_str(json).map_err(|err| -> Box<dyn std::error::Error + Send + Sync> {
             Box::new(ConfigError(format!("manifest parse error: {err}")))
         })?;
 
@@ -136,8 +136,7 @@ pub fn config_from_manifest_json(json: &str) -> FloeResult<(crate::config::RootC
 fn entity_from_manifest(m: &ManifestEntityForRun) -> FloeResult<EntityConfig> {
     let policy_severity = parse_policy_severity(m.policy_severity.as_deref().unwrap_or("warn"));
     let write_mode = parse_write_mode(m.write_mode.as_deref().unwrap_or("overwrite"));
-    let incremental_mode =
-        parse_incremental_mode(m.incremental_mode.as_deref().unwrap_or("none"));
+    let incremental_mode = parse_incremental_mode(m.incremental_mode.as_deref().unwrap_or("none"));
 
     let source_options: Option<SourceOptions> = m
         .source
@@ -203,7 +202,10 @@ fn entity_from_manifest(m: &ManifestEntityForRun) -> FloeResult<EntityConfig> {
     })
 }
 
-fn sink_target_from_manifest(m: &ManifestSinkTargetForRun, default_write_mode: WriteMode) -> SinkTarget {
+fn sink_target_from_manifest(
+    m: &ManifestSinkTargetForRun,
+    default_write_mode: WriteMode,
+) -> SinkTarget {
     let write_mode = m
         .write_mode
         .as_deref()

--- a/crates/floe-core/src/manifest/reconstruct.rs
+++ b/crates/floe-core/src/manifest/reconstruct.rs
@@ -1,0 +1,317 @@
+use serde::Deserialize;
+
+use crate::config::{
+    ArchiveTarget, CatalogsConfig, ColumnConfig, EntityConfig, EntityStateConfig, IncrementalMode,
+    LineageConfig, MergeOptionsConfig, PiiConfig, PolicyConfig, PolicySeverity, SchemaConfig,
+    SchemaMismatchConfig, SinkConfig, SinkOptions, SinkTarget, SourceConfig, SourceOptions,
+    StoragesConfig, WriteMode,
+};
+use crate::{ConfigError, FloeResult};
+
+// Minimal deserializable mirror of CommonManifest — only the fields needed to reconstruct
+// a RootConfig and run an entity.
+#[derive(Debug, Deserialize)]
+pub struct ManifestForRun {
+    pub spec_version: String,
+    pub report_base_uri: String,
+    pub entities: Vec<ManifestEntityForRun>,
+    pub storages: Option<serde_json::Value>,
+    pub catalogs: Option<serde_json::Value>,
+    pub lineage: Option<serde_json::Value>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct ManifestEntityForRun {
+    pub name: String,
+    pub domain: Option<String>,
+    pub source: ManifestSourceForRun,
+    pub sinks: ManifestSinksForRun,
+    pub policy_severity: Option<String>,
+    pub write_mode: Option<String>,
+    pub incremental_mode: Option<String>,
+    pub schema: ManifestEntitySchemaForRun,
+    pub pii: Option<serde_json::Value>,
+    pub state_path: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct ManifestSourceForRun {
+    pub format: String,
+    pub storage: String,
+    pub uri: String,
+    pub path: String,
+    pub cast_mode: Option<String>,
+    pub options: Option<serde_json::Value>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct ManifestSinksForRun {
+    pub accepted: ManifestSinkTargetForRun,
+    pub rejected: Option<ManifestSinkTargetForRun>,
+    pub archive: Option<ManifestArchiveTargetForRun>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct ManifestSinkTargetForRun {
+    pub format: String,
+    pub storage: String,
+    pub path: String,
+    pub options: Option<serde_json::Value>,
+    pub partition_by: Option<Vec<String>>,
+    pub merge: Option<serde_json::Value>,
+    pub iceberg: Option<serde_json::Value>,
+    pub delta: Option<serde_json::Value>,
+    pub write_mode: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct ManifestArchiveTargetForRun {
+    pub storage: String,
+    pub path: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct ManifestEntitySchemaForRun {
+    pub columns: Vec<ManifestColumnDefForRun>,
+    pub primary_key: Vec<String>,
+    pub unique_keys: Vec<Vec<String>>,
+    pub normalize_columns: Option<serde_json::Value>,
+    pub mismatch: Option<serde_json::Value>,
+    pub schema_evolution: Option<serde_json::Value>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct ManifestColumnDefForRun {
+    pub name: String,
+    pub column_type: String,
+    pub source: Option<String>,
+    pub nullable: Option<bool>,
+    pub unique: Option<bool>,
+    pub width: Option<u64>,
+    pub trim: Option<bool>,
+}
+
+/// Parse a manifest JSON string and reconstruct a minimal RootConfig.
+/// Returns (config, report_base_uri).
+pub fn config_from_manifest_json(json: &str) -> FloeResult<(crate::config::RootConfig, String)> {
+    let manifest: ManifestForRun = serde_json::from_str(json)
+        .map_err(|err| -> Box<dyn std::error::Error + Send + Sync> {
+            Box::new(ConfigError(format!("manifest parse error: {err}")))
+        })?;
+
+    let storages = manifest
+        .storages
+        .as_ref()
+        .and_then(|v| serde_json::from_value::<StoragesConfig>(v.clone()).ok());
+    let catalogs = manifest
+        .catalogs
+        .as_ref()
+        .and_then(|v| serde_json::from_value::<CatalogsConfig>(v.clone()).ok());
+    let lineage = manifest
+        .lineage
+        .as_ref()
+        .and_then(|v| serde_json::from_value::<LineageConfig>(v.clone()).ok());
+
+    let entities = manifest
+        .entities
+        .iter()
+        .map(entity_from_manifest)
+        .collect::<FloeResult<Vec<_>>>()?;
+
+    let config = crate::config::RootConfig {
+        version: manifest.spec_version,
+        metadata: None,
+        storages,
+        catalogs,
+        env: None,
+        domains: Vec::new(),
+        report: None,
+        lineage,
+        entities,
+    };
+
+    Ok((config, manifest.report_base_uri))
+}
+
+fn entity_from_manifest(m: &ManifestEntityForRun) -> FloeResult<EntityConfig> {
+    let policy_severity = parse_policy_severity(m.policy_severity.as_deref().unwrap_or("warn"));
+    let write_mode = parse_write_mode(m.write_mode.as_deref().unwrap_or("overwrite"));
+    let incremental_mode =
+        parse_incremental_mode(m.incremental_mode.as_deref().unwrap_or("none"));
+
+    let source_options: Option<SourceOptions> = m
+        .source
+        .options
+        .as_ref()
+        .and_then(|v| serde_json::from_value(v.clone()).ok());
+
+    let source = SourceConfig {
+        format: m.source.format.clone(),
+        path: m.source.path.clone(),
+        storage: if m.source.storage == "local" {
+            None
+        } else {
+            Some(m.source.storage.clone())
+        },
+        options: source_options,
+        cast_mode: m.source.cast_mode.clone(),
+    };
+
+    let accepted = sink_target_from_manifest(&m.sinks.accepted, write_mode);
+    let rejected = m
+        .sinks
+        .rejected
+        .as_ref()
+        .map(|t| sink_target_from_manifest(t, write_mode));
+    let archive = m.sinks.archive.as_ref().map(|a| ArchiveTarget {
+        path: a.path.clone(),
+        storage: if a.storage == "local" {
+            None
+        } else {
+            Some(a.storage.clone())
+        },
+    });
+
+    let schema = schema_from_manifest(&m.schema)?;
+    let pii: Option<PiiConfig> = m
+        .pii
+        .as_ref()
+        .and_then(|v| serde_json::from_value(v.clone()).ok());
+
+    let state = m.state_path.as_ref().map(|p| EntityStateConfig {
+        path: Some(p.clone()),
+    });
+
+    Ok(EntityConfig {
+        name: m.name.clone(),
+        metadata: None,
+        domain: m.domain.clone(),
+        incremental_mode,
+        state,
+        source,
+        sink: SinkConfig {
+            write_mode,
+            accepted,
+            rejected,
+            archive,
+        },
+        policy: PolicyConfig {
+            severity: policy_severity,
+        },
+        schema,
+        pii,
+    })
+}
+
+fn sink_target_from_manifest(m: &ManifestSinkTargetForRun, default_write_mode: WriteMode) -> SinkTarget {
+    let write_mode = m
+        .write_mode
+        .as_deref()
+        .map(parse_write_mode)
+        .unwrap_or(default_write_mode);
+    let options: Option<SinkOptions> = m
+        .options
+        .as_ref()
+        .and_then(|v| serde_json::from_value(v.clone()).ok());
+    let merge: Option<MergeOptionsConfig> = m
+        .merge
+        .as_ref()
+        .and_then(|v| serde_json::from_value(v.clone()).ok());
+    let iceberg = m
+        .iceberg
+        .as_ref()
+        .and_then(|v| serde_json::from_value(v.clone()).ok());
+    let delta = m
+        .delta
+        .as_ref()
+        .and_then(|v| serde_json::from_value(v.clone()).ok());
+
+    SinkTarget {
+        format: m.format.clone(),
+        path: m.path.clone(),
+        storage: if m.storage == "local" {
+            None
+        } else {
+            Some(m.storage.clone())
+        },
+        options,
+        merge,
+        iceberg,
+        delta,
+        partition_by: m.partition_by.clone(),
+        partition_spec: None,
+        write_mode,
+    }
+}
+
+fn schema_from_manifest(m: &ManifestEntitySchemaForRun) -> FloeResult<SchemaConfig> {
+    let columns = m
+        .columns
+        .iter()
+        .map(|c| ColumnConfig {
+            name: c.name.clone(),
+            source: c.source.clone(),
+            column_type: c.column_type.clone(),
+            nullable: c.nullable,
+            unique: c.unique,
+            width: c.width,
+            trim: c.trim,
+        })
+        .collect();
+
+    let normalize_columns: Option<crate::config::NormalizeColumnsConfig> = m
+        .normalize_columns
+        .as_ref()
+        .and_then(|v| serde_json::from_value(v.clone()).ok());
+    let mismatch: Option<SchemaMismatchConfig> = m
+        .mismatch
+        .as_ref()
+        .and_then(|v| serde_json::from_value(v.clone()).ok());
+    let schema_evolution = m
+        .schema_evolution
+        .as_ref()
+        .and_then(|v| serde_json::from_value(v.clone()).ok());
+
+    Ok(SchemaConfig {
+        columns,
+        normalize_columns,
+        mismatch,
+        schema_evolution,
+        primary_key: if m.primary_key.is_empty() {
+            None
+        } else {
+            Some(m.primary_key.clone())
+        },
+        unique_keys: if m.unique_keys.is_empty() {
+            None
+        } else {
+            Some(m.unique_keys.clone())
+        },
+    })
+}
+
+fn parse_policy_severity(s: &str) -> PolicySeverity {
+    match s {
+        "reject" => PolicySeverity::Reject,
+        "abort" => PolicySeverity::Abort,
+        _ => PolicySeverity::Warn,
+    }
+}
+
+fn parse_write_mode(s: &str) -> WriteMode {
+    match s {
+        "append" => WriteMode::Append,
+        "merge_scd1" => WriteMode::MergeScd1,
+        "merge_scd2" => WriteMode::MergeScd2,
+        _ => WriteMode::Overwrite,
+    }
+}
+
+fn parse_incremental_mode(s: &str) -> IncrementalMode {
+    match s {
+        "archive" => IncrementalMode::Archive,
+        "file" => IncrementalMode::File,
+        "row" => IncrementalMode::Row,
+        _ => IncrementalMode::None,
+    }
+}

--- a/crates/floe-core/src/run/context.rs
+++ b/crates/floe-core/src/run/context.rs
@@ -84,4 +84,68 @@ impl RunContext {
             run_timer: Instant::now(),
         })
     }
+
+    /// Build a RunContext from a pre-parsed RootConfig (manifest mode).
+    /// `manifest_path` is used for the config_path field (reporting only).
+    pub fn from_config(
+        config: config::RootConfig,
+        config_base: config::ConfigBase,
+        manifest_path: &Path,
+        report_base_uri: &str,
+        options: &RunOptions,
+    ) -> FloeResult<Self> {
+        let storage_resolver = config::StorageResolver::new(&config, config_base)?;
+        let catalog_resolver = config::CatalogResolver::new(&config)?;
+        let config_dir =
+            crate::io::storage::paths::normalize_local_path(storage_resolver.config_dir());
+        let config_path = crate::io::storage::paths::normalize_local_path(manifest_path);
+
+        // The manifest embeds report_base_uri; resolve it to a target if it looks local.
+        let (report_target, report_base_path) = if !report_base_uri.is_empty()
+            && report_base_uri != "report"
+        {
+            let local_path = if let Some(stripped) = report_base_uri.strip_prefix("local://") {
+                Some(std::path::PathBuf::from(stripped))
+            } else if !report_base_uri.contains("://") {
+                Some(std::path::PathBuf::from(report_base_uri))
+            } else {
+                None
+            };
+            let base_path = local_path
+                .as_ref()
+                .map(|p| p.display().to_string())
+                .unwrap_or_else(|| report_base_uri.to_string());
+            // Only attempt to create a Target for local paths; skip for remote URIs.
+            let report_target = local_path.as_ref().and_then(|path| {
+                let resolved = config::ResolvedPath {
+                    storage: "local".to_string(),
+                    uri: report_base_uri.to_string(),
+                    local_path: Some(path.clone()),
+                };
+                Target::from_resolved(&resolved).ok()
+            });
+            (report_target, Some(base_path))
+        } else {
+            (None, None)
+        };
+
+        let started_at = report::now_rfc3339();
+        let run_id = options
+            .run_id
+            .clone()
+            .unwrap_or_else(|| report::run_id_from_timestamp(&started_at));
+
+        Ok(Self {
+            config,
+            config_path,
+            config_dir,
+            storage_resolver,
+            catalog_resolver,
+            report_base_path,
+            report_target,
+            run_id,
+            started_at,
+            run_timer: Instant::now(),
+        })
+    }
 }

--- a/crates/floe-core/src/run/context.rs
+++ b/crates/floe-core/src/run/context.rs
@@ -101,33 +101,32 @@ impl RunContext {
         let config_path = crate::io::storage::paths::normalize_local_path(manifest_path);
 
         // The manifest embeds report_base_uri; resolve it to a target if it looks local.
-        let (report_target, report_base_path) = if !report_base_uri.is_empty()
-            && report_base_uri != "report"
-        {
-            let local_path = if let Some(stripped) = report_base_uri.strip_prefix("local://") {
-                Some(std::path::PathBuf::from(stripped))
-            } else if !report_base_uri.contains("://") {
-                Some(std::path::PathBuf::from(report_base_uri))
-            } else {
-                None
-            };
-            let base_path = local_path
-                .as_ref()
-                .map(|p| p.display().to_string())
-                .unwrap_or_else(|| report_base_uri.to_string());
-            // Only attempt to create a Target for local paths; skip for remote URIs.
-            let report_target = local_path.as_ref().and_then(|path| {
-                let resolved = config::ResolvedPath {
-                    storage: "local".to_string(),
-                    uri: report_base_uri.to_string(),
-                    local_path: Some(path.clone()),
+        let (report_target, report_base_path) =
+            if !report_base_uri.is_empty() && report_base_uri != "report" {
+                let local_path = if let Some(stripped) = report_base_uri.strip_prefix("local://") {
+                    Some(std::path::PathBuf::from(stripped))
+                } else if !report_base_uri.contains("://") {
+                    Some(std::path::PathBuf::from(report_base_uri))
+                } else {
+                    None
                 };
-                Target::from_resolved(&resolved).ok()
-            });
-            (report_target, Some(base_path))
-        } else {
-            (None, None)
-        };
+                let base_path = local_path
+                    .as_ref()
+                    .map(|p| p.display().to_string())
+                    .unwrap_or_else(|| report_base_uri.to_string());
+                // Only attempt to create a Target for local paths; skip for remote URIs.
+                let report_target = local_path.as_ref().and_then(|path| {
+                    let resolved = config::ResolvedPath {
+                        storage: "local".to_string(),
+                        uri: report_base_uri.to_string(),
+                        local_path: Some(path.clone()),
+                    };
+                    Target::from_resolved(&resolved).ok()
+                });
+                (report_target, Some(base_path))
+            } else {
+                (None, None)
+            };
 
         let started_at = report::now_rfc3339();
         let run_id = options

--- a/crates/floe-core/src/run/mod.rs
+++ b/crates/floe-core/src/run/mod.rs
@@ -93,6 +93,30 @@ pub fn run_with_base(
     run_with_runtime(config_path, config_base, options, &mut runtime)
 }
 
+pub fn run_with_manifest_path(
+    manifest_path: &Path,
+    options: RunOptions,
+) -> FloeResult<RunOutcome> {
+    let mut runtime = DefaultRuntime::new();
+    run_with_manifest_runtime(manifest_path, options, &mut runtime)
+}
+
+pub(crate) fn run_with_manifest_runtime(
+    manifest_path: &Path,
+    options: RunOptions,
+    runtime: &mut dyn Runtime,
+) -> FloeResult<RunOutcome> {
+    init_thread_pool();
+    let json = std::fs::read_to_string(manifest_path)?;
+    let (config, report_base_uri) = crate::manifest::config_from_manifest_json(&json)?;
+    let config_base = config::ConfigBase::local_from_path(manifest_path);
+    if !options.entities.is_empty() {
+        validate_entities(&config, &options.entities)?;
+    }
+    let context = RunContext::from_config(config, config_base, manifest_path, &report_base_uri, &options)?;
+    run_from_context(context, options, runtime)
+}
+
 pub fn run_with_runtime(
     config_path: &Path,
     config_base: config::ConfigBase,
@@ -135,6 +159,14 @@ pub fn run_with_runtime(
         validate_entities(&context.config, &options.entities)?;
     }
 
+    run_from_context(context, options, runtime)
+}
+
+fn run_from_context(
+    context: RunContext,
+    options: RunOptions,
+    runtime: &mut dyn Runtime,
+) -> FloeResult<RunOutcome> {
     let observer = default_observer();
     let perf_enabled = perf::phase_timing_enabled();
     let selected_entities = select_entities(&context, &options);

--- a/crates/floe-core/src/run/mod.rs
+++ b/crates/floe-core/src/run/mod.rs
@@ -93,10 +93,7 @@ pub fn run_with_base(
     run_with_runtime(config_path, config_base, options, &mut runtime)
 }
 
-pub fn run_with_manifest_path(
-    manifest_path: &Path,
-    options: RunOptions,
-) -> FloeResult<RunOutcome> {
+pub fn run_with_manifest_path(manifest_path: &Path, options: RunOptions) -> FloeResult<RunOutcome> {
     let mut runtime = DefaultRuntime::new();
     run_with_manifest_runtime(manifest_path, options, &mut runtime)
 }
@@ -113,7 +110,13 @@ pub(crate) fn run_with_manifest_runtime(
     if !options.entities.is_empty() {
         validate_entities(&config, &options.entities)?;
     }
-    let context = RunContext::from_config(config, config_base, manifest_path, &report_base_uri, &options)?;
+    let context = RunContext::from_config(
+        config,
+        config_base,
+        manifest_path,
+        &report_base_uri,
+        &options,
+    )?;
     run_from_context(context, options, runtime)
 }
 

--- a/orchestrators/dagster-floe/src/floe_dagster/assets.py
+++ b/orchestrators/dagster-floe/src/floe_dagster/assets.py
@@ -5,7 +5,14 @@ from pathlib import Path
 from typing import Any
 from urllib.parse import unquote, urlparse
 
-from dagster import Definitions, Failure, MaterializeResult, asset
+from dagster import (
+    AssetKey,
+    AssetOut,
+    Definitions,
+    Failure,
+    Output,
+    multi_asset,
+)
 
 from .k8s_status import STATUS_SUCCEEDED
 
@@ -49,12 +56,10 @@ def build_floe_asset_defs(
     for entity in entity_items:
         runner_definition = resolve_entity_runner(manifest, entity)
         assets_defs.append(
-            _make_entity_asset(
-                key_prefix=list(entity.asset_key[:-1]),
-                asset_name=entity.asset_key[-1],
-                group_name=entity.group_name,
-                entity_name=entity.name,
+            _make_entity_multi_asset(
+                entity=entity,
                 config_uri=config_uri,
+                manifest_path=manifest_path,
                 runner=runner,
                 execution=manifest.execution,
                 runner_definition=runner_definition,
@@ -73,32 +78,53 @@ def selected_manifest_entities(
     return [item for item in manifest.entities if item.name in selected]
 
 
-def _make_entity_asset(
+def _has_rejected_asset(entity: ManifestEntity) -> bool:
+    if entity.policy_severity is not None:
+        return entity.policy_severity in ("reject", "abort")
+    # Backward compat: old manifests without policy_severity
+    return entity.rejected_sink_uri is not None
+
+
+def _make_entity_multi_asset(
     *,
-    key_prefix: list[str],
-    asset_name: str,
-    group_name: str,
-    entity_name: str,
+    entity: ManifestEntity,
     config_uri: str,
+    manifest_path: str,
     runner: Runner,
     execution: ManifestExecution,
     runner_definition: ManifestRunnerDefinition,
 ):
-    asset_key = [*key_prefix, asset_name]
+    accepted_key = list(entity.asset_key)
+    source_dep_key = list(entity.asset_key[:-1]) + [entity.asset_key[-1] + "_source"]
+    has_rejected = _has_rejected_asset(entity)
+    rejected_key = list(entity.asset_key[:-1]) + [entity.asset_key[-1] + "_rejected"]
 
-    @asset(
+    asset_name = entity.asset_key[-1]
+    group_name = entity.group_name
+    entity_name = entity.name
+
+    outs: dict[str, AssetOut] = {
+        "accepted": AssetOut(key=AssetKey(accepted_key), is_required=True),
+    }
+    if has_rejected:
+        outs["rejected"] = AssetOut(key=AssetKey(rejected_key), is_required=False)
+
+    @multi_asset(
         name=asset_name,
-        key_prefix=key_prefix,
+        outs=outs,
+        deps=[AssetKey(source_dep_key)],
         group_name=group_name,
-        check_specs=build_asset_check_specs(asset_key),
+        check_specs=build_asset_check_specs(accepted_key),
+        can_subset=False,
     )
-    def _asset(context):
+    def _multi_asset(context):
         run = getattr(context, "run", None)
         run_id = getattr(run, "run_id", None) if run is not None else None
         if run_id is None:
             run_id = getattr(context, "run_id", None)
         result = runner.run_floe_entity(
             config_uri=config_uri,
+            manifest_uri=manifest_path,
             run_id=run_id,
             entity=entity_name,
             log_format=execution.log_format,
@@ -163,7 +189,7 @@ def _make_entity_asset(
             metadata["backend_metadata"] = result.backend_metadata
 
         check_results = build_asset_check_results(
-            asset_key=asset_key,
+            asset_key=accepted_key,
             entity_name=entity_name,
             finished=finished,
             entity_report=entity_report_json,
@@ -184,9 +210,16 @@ def _make_entity_asset(
                 metadata=metadata,
             )
 
-        yield MaterializeResult(metadata=metadata)
+        yield Output(value=None, output_name="accepted", metadata=metadata)
+        if has_rejected:
+            rejected_metadata = {
+                "run_id": finished.run_id,
+                "rejected": entity_stats.get("rejected"),
+                "status": finished.status,
+            }
+            yield Output(value=None, output_name="rejected", metadata=rejected_metadata)
 
-    return _asset
+    return _multi_asset
 
 
 def _load_summary_json(summary_uri: str, config_uri: str) -> dict[str, Any]:

--- a/orchestrators/dagster-floe/src/floe_dagster/definitions.py
+++ b/orchestrators/dagster-floe/src/floe_dagster/definitions.py
@@ -105,7 +105,7 @@ def build_definitions_from_manifest_paths(
             seen_job_names.add(manifest_job_name)
             selection = AssetSelection.assets(
                 *[entity.asset_key for entity in manifest_entities]
-            )
+            ).required_multi_asset_neighbors()
             jobs.append(
                 define_asset_job(
                     name=manifest_job_name,

--- a/orchestrators/dagster-floe/src/floe_dagster/manifest.py
+++ b/orchestrators/dagster-floe/src/floe_dagster/manifest.py
@@ -23,12 +23,18 @@ class ManifestEntity:
     rejected_sink_uri: str | None
     asset_key: list[str]
     runner: str | None
+    source_uri: str | None = None
+    policy_severity: str | None = None
+    write_mode: str | None = None
+    incremental_mode: str | None = None
 
     @staticmethod
     def from_dict(data: dict[str, Any]) -> "ManifestEntity":
         asset_key = _required_string_list(data, "asset_key")
         if not asset_key:
             raise ValueError("entities[].asset_key must contain at least one part")
+        source = data.get("source") or {}
+        source_uri = _optional_str(source, "uri") if isinstance(source, dict) else None
         return ManifestEntity(
             name=_required_str(data, "name"),
             domain=_optional_str(data, "domain"),
@@ -38,6 +44,10 @@ class ManifestEntity:
             rejected_sink_uri=_optional_str(data, "rejected_sink_uri"),
             asset_key=asset_key,
             runner=_optional_str(data, "runner"),
+            source_uri=source_uri,
+            policy_severity=_optional_str(data, "policy_severity"),
+            write_mode=_optional_str(data, "write_mode"),
+            incremental_mode=_optional_str(data, "incremental_mode"),
         )
 
 
@@ -183,6 +193,9 @@ class DagsterManifest:
     execution: ManifestExecution
     runners: ManifestRunners
     entities: list[ManifestEntity]
+    storages: dict[str, Any] | None = None
+    catalogs: dict[str, Any] | None = None
+    lineage: dict[str, Any] | None = None
 
     @staticmethod
     def from_dict(data: dict[str, Any]) -> "DagsterManifest":
@@ -196,6 +209,9 @@ class DagsterManifest:
         if not isinstance(entities_raw, list):
             raise ValueError("entities must be a list")
         entities = [ManifestEntity.from_dict(item) for item in entities_raw]
+        storages = data.get("storages")
+        catalogs = data.get("catalogs")
+        lineage = data.get("lineage")
         return DagsterManifest(
             schema=schema,
             generated_at_ts_ms=generated_at,
@@ -208,6 +224,9 @@ class DagsterManifest:
             execution=ManifestExecution.from_dict(_required_object(data, "execution")),
             runners=ManifestRunners.from_dict(_required_object(data, "runners")),
             entities=entities,
+            storages=storages if isinstance(storages, dict) else None,
+            catalogs=catalogs if isinstance(catalogs, dict) else None,
+            lineage=lineage if isinstance(lineage, dict) else None,
         )
 
 
@@ -238,10 +257,17 @@ def render_execution_args(
     config_uri: str,
     entity_name: str | None,
     run_id: str | None = None,
+    manifest_uri: str | None = None,
 ) -> list[str]:
     args: list[str] = []
     args.extend(
-        _render_token(token, config_uri=config_uri, entity_name=None, run_id=run_id)
+        _render_token(
+            token,
+            config_uri=config_uri,
+            entity_name=None,
+            run_id=run_id,
+            manifest_uri=manifest_uri,
+        )
         for token in execution.base_args
     )
     if entity_name is not None:
@@ -251,6 +277,7 @@ def render_execution_args(
                 config_uri=config_uri,
                 entity_name=entity_name,
                 run_id=run_id,
+                manifest_uri=manifest_uri,
             )
             for token in execution.per_entity_args
         )
@@ -273,8 +300,11 @@ def _render_token(
     config_uri: str,
     entity_name: str | None,
     run_id: str | None,
+    manifest_uri: str | None = None,
 ) -> str:
     rendered = token.replace("{config_uri}", config_uri)
+    if manifest_uri is not None:
+        rendered = rendered.replace("{manifest_uri}", manifest_uri)
     if entity_name is not None:
         rendered = rendered.replace("{entity_name}", entity_name)
     if run_id is not None:

--- a/orchestrators/dagster-floe/src/floe_dagster/runner.py
+++ b/orchestrators/dagster-floe/src/floe_dagster/runner.py
@@ -28,6 +28,7 @@ class Runner:
         log_format: str = "json",
         execution: ManifestExecution | None = None,
         runner_definition: ManifestRunnerDefinition | None = None,
+        manifest_uri: str | None = None,
     ) -> RunResult:
         raise NotImplementedError
 
@@ -44,6 +45,7 @@ class LocalRunner(Runner):
         log_format: str = "json",
         execution: ManifestExecution | None = None,
         runner_definition: ManifestRunnerDefinition | None = None,
+        manifest_uri: str | None = None,
     ) -> RunResult:
         if runner_definition is not None and runner_definition.runner_type == "kubernetes_job":
             if execution is None:
@@ -51,7 +53,11 @@ class LocalRunner(Runner):
             args = [*self._floe_cmd]
             args.extend(
                 render_execution_args(
-                    execution, config_uri=config_uri, entity_name=entity, run_id=run_id
+                    execution,
+                    config_uri=config_uri,
+                    entity_name=entity,
+                    run_id=run_id,
+                    manifest_uri=manifest_uri,
                 )
             )
             from .kubernetes_runner import run_kubernetes_job
@@ -64,7 +70,11 @@ class LocalRunner(Runner):
             args = [*self._floe_cmd]
             args.extend(
                 render_execution_args(
-                    execution, config_uri=config_uri, entity_name=entity, run_id=run_id
+                    execution,
+                    config_uri=config_uri,
+                    entity_name=entity,
+                    run_id=run_id,
+                    manifest_uri=manifest_uri,
                 )
             )
             from .databricks_runner import run_databricks_job
@@ -90,7 +100,11 @@ class LocalRunner(Runner):
             args = [*self._floe_cmd]
             args.extend(
                 render_execution_args(
-                    execution, config_uri=config_uri, entity_name=entity, run_id=run_id
+                    execution,
+                    config_uri=config_uri,
+                    entity_name=entity,
+                    run_id=run_id,
+                    manifest_uri=manifest_uri,
                 )
             )
             if run_id and not _contains_run_id_placeholder(execution):

--- a/orchestrators/dagster-floe/src/floe_dagster/schemas/floe.manifest.v1.json
+++ b/orchestrators/dagster-floe/src/floe_dagster/schemas/floe.manifest.v1.json
@@ -400,6 +400,24 @@
         }
       }
     },
+    "storages": {
+      "type": [
+        "object",
+        "null"
+      ]
+    },
+    "catalogs": {
+      "type": [
+        "object",
+        "null"
+      ]
+    },
+    "lineage": {
+      "type": [
+        "object",
+        "null"
+      ]
+    },
     "entities": {
       "type": "array",
       "items": {
@@ -465,6 +483,83 @@
               "string",
               "null"
             ]
+          },
+          "policy_severity": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "enum": [
+              "warn",
+              "reject",
+              "abort",
+              null
+            ]
+          },
+          "write_mode": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "incremental_mode": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "state_path": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "pii": {
+            "type": [
+              "object",
+              "null"
+            ]
+          },
+          "schema": {
+            "type": [
+              "object",
+              "null"
+            ],
+            "properties": {
+              "columns": {
+                "type": "array",
+                "items": {
+                  "type": "object"
+                }
+              },
+              "primary_key": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "unique_keys": {
+                "type": "array"
+              },
+              "normalize_columns": {
+                "type": [
+                  "object",
+                  "null"
+                ]
+              },
+              "mismatch": {
+                "type": [
+                  "object",
+                  "null"
+                ]
+              },
+              "schema_evolution": {
+                "type": [
+                  "object",
+                  "null"
+                ]
+              }
+            }
           },
           "source": {
             "type": "object",
@@ -576,6 +671,45 @@
         },
         "resolved": {
           "type": "boolean"
+        },
+        "options": {
+          "type": [
+            "object",
+            "null"
+          ]
+        },
+        "partition_by": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          }
+        },
+        "merge": {
+          "type": [
+            "object",
+            "null"
+          ]
+        },
+        "iceberg": {
+          "type": [
+            "object",
+            "null"
+          ]
+        },
+        "delta": {
+          "type": [
+            "object",
+            "null"
+          ]
+        },
+        "write_mode": {
+          "type": [
+            "string",
+            "null"
+          ]
         }
       }
     },

--- a/orchestrators/dagster-floe/tests/fixtures/manifest.json
+++ b/orchestrators/dagster-floe/tests/fixtures/manifest.json
@@ -56,6 +56,9 @@
       "source_format": "csv",
       "accepted_sink_uri": "./out/accepted/employees",
       "rejected_sink_uri": "./out/rejected/employees",
+      "policy_severity": "reject",
+      "write_mode": "overwrite",
+      "incremental_mode": "none",
       "runner": null,
       "source": {
         "format": "csv",
@@ -92,6 +95,9 @@
       "source_format": "csv",
       "accepted_sink_uri": "./out/accepted/orders",
       "rejected_sink_uri": "./out/rejected/orders",
+      "policy_severity": "warn",
+      "write_mode": "append",
+      "incremental_mode": "file",
       "runner": "k8s",
       "source": {
         "format": "csv",

--- a/orchestrators/dagster-floe/tests/fixtures/manifest_hr.json
+++ b/orchestrators/dagster-floe/tests/fixtures/manifest_hr.json
@@ -44,6 +44,9 @@
       "source_format": "csv",
       "accepted_sink_uri": "./out/accepted/employees",
       "rejected_sink_uri": "./out/rejected/employees",
+      "policy_severity": "reject",
+      "write_mode": "overwrite",
+      "incremental_mode": "none",
       "runner": null,
       "source": {
         "format": "csv",

--- a/orchestrators/dagster-floe/tests/fixtures/manifest_sales.json
+++ b/orchestrators/dagster-floe/tests/fixtures/manifest_sales.json
@@ -44,6 +44,9 @@
       "source_format": "csv",
       "accepted_sink_uri": "./out/accepted/orders",
       "rejected_sink_uri": "./out/rejected/orders",
+      "policy_severity": "warn",
+      "write_mode": "append",
+      "incremental_mode": "file",
       "runner": null,
       "source": {
         "format": "csv",

--- a/orchestrators/dagster-floe/tests/test_asset_checks.py
+++ b/orchestrators/dagster-floe/tests/test_asset_checks.py
@@ -24,8 +24,9 @@ class _StaticRunner(Runner):
         log_format: str = "json",
         execution=None,
         runner_definition=None,
+        manifest_uri: str | None = None,
     ) -> RunResult:
-        del config_uri, run_id, entity, log_format, execution, runner_definition
+        del config_uri, run_id, entity, log_format, execution, runner_definition, manifest_uri
         return self._result
 
 

--- a/orchestrators/dagster-floe/tests/test_assets_manifest.py
+++ b/orchestrators/dagster-floe/tests/test_assets_manifest.py
@@ -4,7 +4,9 @@ from unittest.mock import patch
 
 import pytest
 
-from floe_dagster.assets import load_floe_assets
+from dagster import AssetKey
+
+from floe_dagster.assets import build_floe_asset_defs, load_floe_assets
 from floe_dagster.manifest import ManifestRunnerDefinition
 from floe_dagster.runner import LocalRunner, RunResult, Runner
 
@@ -18,8 +20,9 @@ class _NoopRunner(Runner):
         log_format: str = "json",
         execution=None,
         runner_definition=None,
+        manifest_uri: str | None = None,
     ) -> RunResult:
-        del config_uri, run_id, entity, log_format, execution, runner_definition
+        del config_uri, run_id, entity, log_format, execution, runner_definition, manifest_uri
         return RunResult(stdout="", stderr="", exit_code=0)
 
 
@@ -113,3 +116,58 @@ def test_local_runner_raises_not_implemented_for_unknown_runner() -> None:
             runner_definition=definition,
         )
     assert "docker" in str(exc_info.value).lower()
+
+
+# ── multi-asset structure ──────────────────────────────────────────────────────
+
+def _get_asset_def(manifest_path, entity_name):
+    asset_defs, entities = build_floe_asset_defs(
+        manifest_path=str(manifest_path),
+        runner=_NoopRunner(),
+        entities=[entity_name],
+    )
+    return asset_defs[0], entities[0]
+
+
+def test_multi_asset_accepted_key_matches_entity_asset_key() -> None:
+    """Accepted output key == entity.asset_key (backward compatibility)."""
+    asset_def, entity = _get_asset_def(FIXTURE, "employees")
+    assert AssetKey(entity.asset_key) in asset_def.keys
+
+
+def test_multi_asset_rejected_key_present_when_policy_is_reject() -> None:
+    """employees has policy_severity='reject' → rejected output exposed."""
+    asset_def, entity = _get_asset_def(FIXTURE, "employees")
+    rejected_key = AssetKey(entity.asset_key[:-1] + [entity.asset_key[-1] + "_rejected"])
+    assert rejected_key in asset_def.keys
+
+
+def test_multi_asset_no_rejected_key_when_policy_is_warn() -> None:
+    """orders has policy_severity='warn' → no rejected output (rows discarded silently)."""
+    asset_def, entity = _get_asset_def(FIXTURE, "orders")
+    rejected_key = AssetKey(entity.asset_key[:-1] + [entity.asset_key[-1] + "_rejected"])
+    assert rejected_key not in asset_def.keys
+
+
+def test_multi_asset_rejected_key_present_when_policy_is_abort(tmp_path) -> None:
+    """policy_severity='abort' → rejected output exposed (same as reject)."""
+    import json
+
+    fixture = Path(__file__).parent / "fixtures" / "manifest.json"
+    payload = json.loads(fixture.read_text(encoding="utf-8"))
+    # Patch employees to use abort severity
+    payload["entities"][0]["policy_severity"] = "abort"
+    manifest_path = tmp_path / "manifest.abort.json"
+    manifest_path.write_text(json.dumps(payload), encoding="utf-8")
+
+    asset_def, entity = _get_asset_def(manifest_path, "employees")
+    rejected_key = AssetKey(entity.asset_key[:-1] + [entity.asset_key[-1] + "_rejected"])
+    assert rejected_key in asset_def.keys
+
+
+def test_multi_asset_source_dep_declared() -> None:
+    """The _source dep key is declared as an upstream dependency."""
+    asset_def, entity = _get_asset_def(FIXTURE, "employees")
+    source_key = AssetKey(entity.asset_key[:-1] + [entity.asset_key[-1] + "_source"])
+    dep_keys = set(asset_def.keys_by_input_name.values())
+    assert source_key in dep_keys

--- a/orchestrators/dagster-floe/tests/test_definitions.py
+++ b/orchestrators/dagster-floe/tests/test_definitions.py
@@ -19,8 +19,9 @@ class _NoopRunner(Runner):
         log_format: str = "json",
         execution=None,
         runner_definition=None,
+        manifest_uri: str | None = None,
     ) -> RunResult:
-        del config_uri, run_id, entity, log_format, execution, runner_definition
+        del config_uri, run_id, entity, log_format, execution, runner_definition, manifest_uri
         return RunResult(stdout="", stderr="", exit_code=0)
 
 

--- a/orchestrators/dagster-floe/tests/test_manifest.py
+++ b/orchestrators/dagster-floe/tests/test_manifest.py
@@ -115,6 +115,35 @@ def test_manifest_schema_accepts_extended_k8_runner_fields(tmp_path: Path):
     assert k8s_runner.secrets is not None and k8s_runner.secrets[0]["name"] == "API_TOKEN"
 
 
+def test_entity_source_uri_parsed_from_source_object():
+    fixture = Path(__file__).parent / "fixtures" / "manifest.json"
+    manifest = load_manifest(fixture)
+
+    assert manifest.entities[0].source_uri == "./in/hr/employees.csv"
+    assert manifest.entities[1].source_uri == "./in/sales/orders.csv"
+
+
+def test_entity_policy_severity_parsed():
+    fixture = Path(__file__).parent / "fixtures" / "manifest.json"
+    manifest = load_manifest(fixture)
+
+    # employees uses "reject", orders uses "warn"
+    assert manifest.entities[0].policy_severity == "reject"
+    assert manifest.entities[1].policy_severity == "warn"
+
+
+def test_entity_policy_severity_defaults_to_none_when_absent(tmp_path: Path):
+    fixture = Path(__file__).parent / "fixtures" / "manifest.json"
+    payload = json.loads(fixture.read_text(encoding="utf-8"))
+    # Remove policy_severity from first entity
+    del payload["entities"][0]["policy_severity"]
+    manifest_path = tmp_path / "manifest.no_policy.json"
+    manifest_path.write_text(json.dumps(payload), encoding="utf-8")
+
+    manifest = load_manifest(manifest_path)
+    assert manifest.entities[0].policy_severity is None
+
+
 def test_manifest_schema_accepts_databricks_runner_fields(tmp_path: Path):
     fixture = Path(__file__).parent / "fixtures" / "manifest.json"
     payload = json.loads(fixture.read_text(encoding="utf-8"))


### PR DESCRIPTION
## Summary

Closes #321

- **Self-contained manifest**: `floe manifest` now embeds full entity config (schema, policy, write_mode, sink options, pii, etc.) and profile sections (storages, catalogs, lineage) so `floe run --manifest manifest.json` works without a config file — removes the remote dependency when jobs run on K8s or Databricks
- **`floe run --manifest`**: New CLI flag (`--manifest`, conflicts with `-c`) that reconstructs `RootConfig` from the manifest JSON and runs through the standard pipeline
- **Dagster `@multi_asset`**: Each entity is now modeled as a `@multi_asset` with the source file as a `deps`, `accepted` as the primary output, and `rejected` as a conditional output when `policy_severity` is `"reject"` or `"abort"` (not `"warn"`)

## Details

### Rust
- Added `Deserialize` to ~20 config types (for JSON round-trip from manifest)
- `manifest/model.rs`: `ManifestEntity` now has `policy_severity`, `write_mode`, `incremental_mode`, `schema`, `pii`, `state_path`; `ManifestSinkTarget` has `options`, `partition_by`, `merge`, `iceberg`, `delta`; `CommonManifest` has `storages`, `catalogs`, `lineage`
- `manifest/builder.rs`: populates all new fields; switches default `base_args` to `--manifest {manifest_uri}` token
- `manifest/reconstruct.rs` (new): `config_from_manifest_json()` reconstructs `RootConfig` from manifest JSON
- `run/mod.rs`: adds `run_with_manifest_path()` + extracted `run_from_context()` shared core
- `run/context.rs`: adds `RunContext::from_config()` constructor (bypasses YAML file parsing)
- `cli/main.rs`: `--manifest` flag added to `run` subcommand; wires lineage observer from embedded manifest lineage block

### Python (dagster-floe)
- `assets.py`: `@asset` → `@multi_asset`; source dep key = `[..., name+"_source"]`; rejected output when `policy_severity in ("reject", "abort")`
- `manifest.py`: parses `source_uri`, `policy_severity`, `write_mode`, `incremental_mode` from entities; `storages`/`catalogs`/`lineage` from top-level manifest
- `runner.py`: `manifest_uri` parameter threaded through all runner signatures
- `definitions.py`: uses `.required_multi_asset_neighbors()` so non-subsettable multi-assets are always selected together
- `floe.manifest.v1.json`: all new entity, sink, and top-level fields added (all optional for backward compat)

## Test plan

- [x] `cargo test -p floe-core -p floe-cli` — 497 + 14 manifest tests pass
- [x] `cargo clippy -p floe-core -p floe-cli -- -D warnings` — clean
- [x] `uv run --active pytest tests/ -v` — 55 passed, 1 skipped
- [x] `run_with_manifest_file_executes_entity` integration test (manifest-only run, no config file)
- [x] Multi-asset structural tests: accepted key backward-compat, rejected key for reject/abort, no rejected key for warn, source dep declared