### PR TITLE
fix(run): install OpenLineage observer from profile lineage block

### DIFF
--- a/crates/floe-cli/src/main.rs
+++ b/crates/floe-cli/src/main.rs
@@ -1,10 +1,10 @@
 use clap::{Parser, Subcommand, ValueEnum};
 use floe_core::{
     add_entity_to_config, build_common_manifest_json, inspect_entity_state_with_base,
-    load_config_with_profile_overrides, load_config_with_profile_vars, parse_profile,
-    reset_entity_state_with_base, resolve_config_location, run_with_base, run_with_manifest_path,
-    set_observer, validate_profile, validate_with_base, AddEntityOptions, FloeResult,
-    MultiObserver, RunEvent, RunOptions, ValidateOptions,
+    load_config_with_profile_overrides, parse_profile, reset_entity_state_with_base,
+    resolve_config_location, run_with_base, run_with_manifest_path, set_observer, validate_profile,
+    validate_with_base, AddEntityOptions, FloeResult, MultiObserver, RunEvent, RunOptions,
+    ValidateOptions,
 };
 use std::io::Write;
 
@@ -604,9 +604,16 @@ fn main() -> FloeResult<()> {
 
             // Load config early to check for lineage block so we can install
             // a composed observer before run_with_base. Apply profile vars so
-            // that {{VAR}} placeholders in lineage.url / lineage.api_key are expanded.
-            let early_config =
-                load_config_with_profile_vars(&config_location.path, &profile_vars_for_lineage);
+            // that {{VAR}} placeholders in lineage.url / lineage.api_key are expanded,
+            // and apply profile overrides so that a lineage block defined only in the
+            // profile is visible here.
+            let early_config = load_config_with_profile_overrides(
+                &config_location.path,
+                &profile_vars_for_lineage,
+                options.profile.as_ref().and_then(|p| p.catalogs.as_ref()),
+                options.profile.as_ref().and_then(|p| p.storages.as_ref()),
+                options.profile.as_ref().and_then(|p| p.lineage.as_ref()),
+            );
             let lineage_observer = early_config
                 .as_ref()
                 .ok()

--- a/crates/floe-core/tests/unit/config/lineage_validation.rs
+++ b/crates/floe-core/tests/unit/config/lineage_validation.rs
@@ -1,4 +1,5 @@
-use floe_core::{validate, ValidateOptions};
+use floe_core::config::LineageConfig;
+use floe_core::{load_config_with_profile_overrides, validate, ValidateOptions};
 
 use super::super::common::write_temp_config;
 
@@ -151,4 +152,50 @@ entities:
 "#;
     let path = write_temp_config(config);
     validate(&path, ValidateOptions::default()).expect("max_failures: 5 should be valid");
+}
+
+// Regression test for issue #316: load_config_with_profile_overrides must merge
+// a lineage block that exists only in the profile, not the base config.
+#[test]
+fn profile_lineage_overrides_empty_config() {
+    let base = r#"version: "0.1"
+report:
+  path: "/tmp/reports"
+entities:
+  - name: "orders"
+    source:
+      format: "csv"
+      path: "/tmp/input"
+    sink:
+      accepted:
+        format: "parquet"
+        path: "/tmp/out"
+    policy:
+      severity: "warn"
+    schema:
+      columns:
+        - name: "id"
+          type: "string"
+"#;
+    let path = write_temp_config(base);
+    let profile_lineage = LineageConfig {
+        url: "http://localhost:5000".to_string(),
+        namespace: "floe-demo-local".to_string(),
+        api_key: None,
+        timeout_secs: Some(2),
+        producer: None,
+        max_failures: None,
+    };
+    let config = load_config_with_profile_overrides(
+        &path,
+        &std::collections::HashMap::new(),
+        None,
+        None,
+        Some(&profile_lineage),
+    )
+    .expect("config with profile lineage override should parse");
+
+    let lineage = config.lineage.expect("lineage should be set from profile");
+    assert_eq!(lineage.url, "http://localhost:5000");
+    assert_eq!(lineage.namespace, "floe-demo-local");
 }


### PR DESCRIPTION
## Summary

- `floe run -c config.yml -p profile.yml` was silently skipping OpenLineage event emission when the `lineage` block existed only in the profile YAML, not the base config.
- Root cause: the early config load in the `Run` command called `load_config_with_profile_vars`, which only substitutes `{{VAR}}` placeholders but does **not** merge profile sections (`lineage`, `storages`, `catalogs`). So `early_config.lineage` was always `None` when lineage came from the profile, and no observer was built.
- Fix: switch to `load_config_with_profile_overrides` (the same function used by `validate`) so the profile's lineage block is merged before the observer is constructed.
- Also removes the now-unused `load_config_with_profile_vars` import from `floe-cli`.

## Test plan

- [x] `cargo test -p floe-core --test unit` passes (498 tests, including new `profile_lineage_overrides_empty_config` regression test in `lineage_validation.rs`)
- [x] `cargo clippy -p floe-cli -p floe-core -- -D warnings` passes with no warnings
- [x] `cargo fmt --check` passes clean
- [x] Manual: `floe run -c config.yml -p profile.yml` where only the profile has a `lineage` block now emits events to Marquez

Fixes #316