### PR TITLE
fix(validate): include -p flag in suggested Next command when profile is used

### DIFF
--- a/crates/floe-cli/src/main.rs
+++ b/crates/floe-cli/src/main.rs
@@ -404,7 +404,17 @@ fn main() -> FloeResult<()> {
                         }
                         println!("  Severity: {}", entity.policy.severity);
                     }
-                    println!("Next: floe run -c {}", config_location.display);
+                    if let Some(ref p) = profile {
+                        let profile_display = std::fs::canonicalize(p)
+                            .map(|c| c.display().to_string())
+                            .unwrap_or_else(|_| p.clone());
+                        println!(
+                            "Next: floe run -c {} -p {}",
+                            config_location.display, profile_display
+                        );
+                    } else {
+                        println!("Next: floe run -c {}", config_location.display);
+                    }
                     let _ = std::io::stdout().lock().flush();
                     Ok(())
                 }

--- a/crates/floe-cli/tests/validate_output.rs
+++ b/crates/floe-cli/tests/validate_output.rs
@@ -20,6 +20,22 @@ fn validate_default_output_is_human_text() {
 }
 
 #[test]
+fn validate_with_profile_includes_profile_in_next_command() {
+    let config_path = repo_root().join("example/config.yml");
+    let profile_path = repo_root().join("example/profiles/dev.yml");
+
+    let mut cmd = Command::new(assert_cmd::cargo::cargo_bin!("floe"));
+    cmd.args(["validate", "-c"])
+        .arg(&config_path)
+        .args(["--profile"])
+        .arg(&profile_path)
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Next: floe run -c "))
+        .stdout(predicate::str::contains(" -p "));
+}
+
+#[test]
 fn validate_with_output_flag_is_rejected() {
     let config_path = repo_root().join("example/config.yml");
 


### PR DESCRIPTION
## Summary

- Fixes the `Next:` suggestion printed after `floe validate` to include `-p <profile_path>` when a profile was provided
- The profile path is canonicalized to an absolute path, matching how the config path is displayed
- Adds a new test `validate_with_profile_includes_profile_in_next_command` covering the case

## Before / After

**Before:**
```
Next: floe run -c /abs/path/config.iceberg_glue.generated.yml
```

**After:**
```
Next: floe run -c /abs/path/config.iceberg_glue.generated.yml -p /abs/path/aws_glue.generated.yml
```

## Test plan

- [x] `cargo test -p floe-cli -- validate` — all 5 tests pass including new one
- [x] `cargo clippy -p floe-cli -- -D warnings` — clean

Closes #319