### PR TITLE
feat(state): add -p/--profile support to state inspect and state reset

### DIFF
--- a/crates/floe-cli/src/main.rs
+++ b/crates/floe-cli/src/main.rs
@@ -1,10 +1,9 @@
 use clap::{Parser, Subcommand, ValueEnum};
 use floe_core::{
-    add_entity_to_config, build_common_manifest_json, inspect_entity_state_with_base,
-    load_config_with_profile_overrides, parse_profile, reset_entity_state_with_base,
-    resolve_config_location, run_with_base, run_with_manifest_path, set_observer, validate_profile,
-    validate_with_base, AddEntityOptions, FloeResult, MultiObserver, RunEvent, RunOptions,
-    ValidateOptions,
+    add_entity_to_config, build_common_manifest_json, inspect_entity_state,
+    load_config_with_profile_overrides, parse_profile, reset_entity_state, resolve_config_location,
+    run_with_base, run_with_manifest_path, set_observer, validate_profile, validate_with_base,
+    AddEntityOptions, FloeResult, MultiObserver, RunEvent, RunOptions, ValidateOptions,
 };
 use std::io::Write;
 
@@ -91,7 +90,9 @@ const STATE_LONG_ABOUT: &str = concat!(
     "\n",
     "Examples:\n",
     "  floe state inspect -c example/config.yml --entity customers\n",
+    "  floe state inspect -c example/config.yml -p profiles/local.yml --entity customers\n",
     "  floe state reset -c example/config.yml --entity customers --yes\n",
+    "  floe state reset -c example/config.yml -p profiles/local.yml --entity customers --yes\n",
 );
 
 mod logging;
@@ -226,6 +227,12 @@ enum StateCommand {
         config: String,
         #[arg(long, help = "Entity name")]
         entity: String,
+        #[arg(
+            short = 'p',
+            long,
+            help = "Optional path to a Floe environment profile YAML file"
+        )]
+        profile: Option<String>,
     },
     #[command(about = "Reset entity state")]
     Reset {
@@ -235,6 +242,12 @@ enum StateCommand {
         entity: String,
         #[arg(long, help = "Required confirmation to delete the state object")]
         yes: bool,
+        #[arg(
+            short = 'p',
+            long,
+            help = "Optional path to a Floe environment profile YAML file"
+        )]
+        profile: Option<String>,
     },
 }
 
@@ -846,10 +859,17 @@ fn main() -> FloeResult<()> {
             Ok(())
         }
         Command::State { command } => match command {
-            StateCommand::Inspect { config, entity } => {
+            StateCommand::Inspect {
+                config,
+                entity,
+                profile,
+            } => {
+                let parsed_profile = load_state_profile(profile);
                 let config_location = resolve_or_exit(&config);
-                let inspection = match inspect_entity_state_with_base(
-                    &config_location.path,
+                let effective_config =
+                    load_effective_config_for_state(&config_location, parsed_profile);
+                let inspection = match inspect_entity_state(
+                    &effective_config,
                     config_location.base.clone(),
                     &entity,
                 ) {
@@ -892,6 +912,7 @@ fn main() -> FloeResult<()> {
                 config,
                 entity,
                 yes,
+                profile,
             } => {
                 if !yes {
                     exit_with_error(Box::new(std::io::Error::new(
@@ -900,17 +921,20 @@ fn main() -> FloeResult<()> {
                     )));
                 }
 
+                let parsed_profile = load_state_profile(profile);
                 let config_location = resolve_or_exit(&config);
-                let removed = match reset_entity_state_with_base(
-                    &config_location.path,
+                let effective_config =
+                    load_effective_config_for_state(&config_location, parsed_profile);
+                let removed = match reset_entity_state(
+                    &effective_config,
                     config_location.base.clone(),
                     &entity,
                 ) {
                     Ok(removed) => removed,
                     Err(err) => exit_with_error(err),
                 };
-                let inspection = match inspect_entity_state_with_base(
-                    &config_location.path,
+                let inspection = match inspect_entity_state(
+                    &effective_config,
                     config_location.base.clone(),
                     &entity,
                 ) {
@@ -945,4 +969,47 @@ fn exit_with_error(err: Box<dyn std::error::Error + Send + Sync>) -> ! {
     let _ = writeln!(err_out, "Error: {err}");
     let _ = err_out.flush();
     std::process::exit(1);
+}
+
+fn load_state_profile(profile: Option<String>) -> Option<floe_core::ProfileConfig> {
+    let profile_path = profile?;
+    let path = std::path::Path::new(&profile_path);
+    let parsed = match parse_profile(path) {
+        Ok(p) => p,
+        Err(err) => exit_with_error(err),
+    };
+    if let Err(err) = validate_profile(&parsed) {
+        exit_with_error(err);
+    }
+    Some(parsed)
+}
+
+fn load_effective_config_for_state(
+    config_location: &floe_core::ConfigLocation,
+    parsed_profile: Option<floe_core::ProfileConfig>,
+) -> floe_core::config::RootConfig {
+    let profile_vars = if let Some(ref parsed) = parsed_profile {
+        let config_env_vars =
+            floe_core::extract_config_env_vars(&config_location.path).unwrap_or_default();
+        match floe_core::resolve_vars(floe_core::VarSources {
+            profile: &parsed.variables,
+            cli: &std::collections::HashMap::new(),
+            config: &config_env_vars,
+        }) {
+            Ok(vars) => vars,
+            Err(err) => exit_with_error(err),
+        }
+    } else {
+        std::collections::HashMap::new()
+    };
+    match load_config_with_profile_overrides(
+        &config_location.path,
+        &profile_vars,
+        parsed_profile.as_ref().and_then(|p| p.catalogs.as_ref()),
+        parsed_profile.as_ref().and_then(|p| p.storages.as_ref()),
+        parsed_profile.as_ref().and_then(|p| p.lineage.as_ref()),
+    ) {
+        Ok(config) => config,
+        Err(err) => exit_with_error(err),
+    }
 }

--- a/crates/floe-core/src/lib.rs
+++ b/crates/floe-core/src/lib.rs
@@ -17,7 +17,10 @@ pub mod state;
 pub mod vars;
 pub mod warnings;
 
-pub use crate::state::{inspect_entity_state_with_base, reset_entity_state_with_base};
+pub use crate::state::{
+    inspect_entity_state, inspect_entity_state_with_base, reset_entity_state,
+    reset_entity_state_with_base,
+};
 pub use add_entity::{add_entity_to_config, AddEntityOptions, AddEntityOutcome};
 pub use checks as check;
 pub use config::{resolve_config_location, ConfigLocation};

--- a/crates/floe-core/src/state/mod.rs
+++ b/crates/floe-core/src/state/mod.rs
@@ -376,13 +376,12 @@ pub fn inspect_entity_state(
     })
 }
 
-pub fn reset_entity_state_with_base(
-    config_path: &Path,
+pub fn reset_entity_state(
+    config: &RootConfig,
     config_base: ConfigBase,
     entity_name: &str,
 ) -> FloeResult<bool> {
-    let config = crate::load_config(config_path)?;
-    let (entity, path) = resolve_entity_state_target(&config, config_base.clone(), entity_name)?;
+    let (entity, path) = resolve_entity_state_target(config, config_base.clone(), entity_name)?;
     let target = state_target_from_resolved(&path)?;
     match target {
         EntityStateTarget::Local { path, .. } => {
@@ -394,7 +393,7 @@ pub fn reset_entity_state_with_base(
         }
         EntityStateTarget::Remote { storage, uri } => {
             let mut cloud = CloudClient::new();
-            let resolver = StorageResolver::new(&config, config_base)?;
+            let resolver = StorageResolver::new(config, config_base)?;
             let client = cloud.client_for_context(
                 &resolver,
                 &storage,
@@ -412,6 +411,15 @@ pub fn reset_entity_state_with_base(
             }
         }
     }
+}
+
+pub fn reset_entity_state_with_base(
+    config_path: &Path,
+    config_base: ConfigBase,
+    entity_name: &str,
+) -> FloeResult<bool> {
+    let config = crate::load_config(config_path)?;
+    reset_entity_state(&config, config_base, entity_name)
 }
 
 fn resolve_entity_state_target<'a>(


### PR DESCRIPTION
## Summary

- `floe state inspect` and `floe state reset` now accept `-p/--profile`, resolving the effective config the same way `validate` and `run` do (variable substitution + profile section overrides).
- Without this, any config that uses profile variables (e.g. `CUSTOMER_INPUT_DIR`) fails state commands with "unknown variable".
- The implementation follows the existing validate/run pattern exactly: parse profile → resolve vars → `load_config_with_profile_overrides` → call state function with the effective config.

**Core change in `floe-core`:**
- Extracted `reset_entity_state(&RootConfig, …)` from `reset_entity_state_with_base` (mirrors the existing `inspect_entity_state` pattern). `reset_entity_state_with_base` now delegates to it.
- Re-exported `inspect_entity_state` and `reset_entity_state` from `lib.rs`.

**CLI change in `floe-cli`:**
- Added `profile: Option<String>` to `StateCommand::Inspect` and `StateCommand::Reset`.
- Added `load_state_profile` and `load_effective_config_for_state` helpers (deduplicates the profile-loading pattern).
- Both handlers now load the effective config before calling the state functions.
- Updated `STATE_LONG_ABOUT` with profile examples.

## Test plan

- [x] `cargo test -p floe-core` passes (498 tests)
- [x] `cargo clippy -p floe-cli -p floe-core -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [ ] `floe state inspect -c config.yml -p profiles/local.yml --entity customers` resolves profile variables correctly
- [ ] `floe state reset -c config.yml -p profiles/local.yml --entity customers --yes` works correctly
- [ ] Both commands still work without `-p` (no regression)

Fixes #320