### PR TITLE
chore: bump floe to v0.4.2 and dagster-floe to v0.1.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,24 @@
 
 All notable changes to Floe are documented in this file.
 
-## Unreleased
+## v0.4.2
 
 - **OpenLineage: source and sink datasets emitted separately** (`docs/lineage.md`, fixes #317):
   - Entity `COMPLETE`/`FAIL` events now set `inputs` to the **source dataset** (named after `source.path`) and `outputs` to the **accepted sink dataset** (named after `sink.accepted.path`).
   - When a rejected sink is configured, a second output dataset (named after `sink.rejected.path`) is appended to `outputs`.
   - Schema (`SchemaDataset`), `DataQualityMetrics`, and `FloeQualityRun` facets are attached to the source input dataset, which is the correct OpenLineage placement for input facets.
   - Previously, `inputs` contained a single dataset named after the entity (not the path) and `outputs` was always empty, causing Marquez to show a dead-end lineage graph.
+
+- **OpenLineage observer now installed from profile `lineage` block** (fixes #316):
+  - `floe run --profile` now uses `load_config_with_profile_overrides` for the early config load that wires up the OpenLineage observer. Previously it used `load_config_with_profile_vars`, which substituted `{{VAR}}` placeholders but did not merge the `lineage` section from the profile. Users who declared `lineage:` only in their profile file saw no lineage events emitted.
+
+- **Profile support for `floe state inspect` and `floe state reset`** (fixes #320):
+  - Both state subcommands now accept `-p / --profile <path>`. Without a profile, configs that reference `{{VAR}}` placeholders would fail with "unknown variable" errors. The same profile-loading path used by `validate` and `run` (variable resolution + storages/catalogs/lineage merging) is now applied before reading or resetting entity state.
+
+- **Incremental state committed for rejected terminal outcomes** (fixes #327):
+  - In `incremental_mode: file`, files whose rows are fully or partially rejected under `severity: reject` are now committed to state after the run. Previously, any `RunStatus::Rejected` caused state to be released, making Floe reprocess the same file on every subsequent run and duplicate accepted/rejected sink outputs. `Aborted` and `Failed` outcomes still release state, as those represent incomplete processing where reprocessing is safe.
+
+- **`dagster-floe` 0.1.6**: version bump accompanying the floe 0.4.2 release.
 
 ## v0.4.1
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3399,7 +3399,7 @@ dependencies = [
 
 [[package]]
 name = "floe-cli"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "assert_cmd",
  "clap",
@@ -3412,7 +3412,7 @@ dependencies = [
 
 [[package]]
 name = "floe-core"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "apache-avro 0.16.0",
  "arrow",
@@ -3455,7 +3455,7 @@ dependencies = [
 
 [[package]]
 name = "floe-python"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "floe-core",
  "pyo3",

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ floe run      -c config.yml   # run the pipeline
 | S3 storage | [docs/storages/s3.md](docs/storages/s3.md) |
 | ADLS storage | [docs/storages/adls.md](docs/storages/adls.md) |
 | GCS storage | [docs/storages/gcs.md](docs/storages/gcs.md) |
-| Incremental ingestion | [docs/profiles.md](docs/profiles.md) |
+| Environement specific profile config | [docs/profiles.md](docs/profiles.md) [docs/variables.md](docs/variables.md) |
 | Run reports | [docs/report.md](docs/report.md) |
 | CLI reference | [docs/cli.md](docs/cli.md) |
 | Orchestration (Dagster / Airflow) | [docs/summary.md](docs/summary.md) |

--- a/crates/floe-cli/Cargo.toml
+++ b/crates/floe-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "floe-cli"
-version = "0.4.1"
+version = "0.4.2"
 edition = "2021"
 description = "CLI for Floe, a YAML-driven technical ingestion tool."
 license = "MIT"
@@ -17,7 +17,7 @@ path = "src/main.rs"
 
 [dependencies]
 clap = { version = "4", features = ["derive"] }
-floe-core = { path = "../floe-core", version = "0.4.1" }
+floe-core = { path = "../floe-core", version = "0.4.2" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 

--- a/crates/floe-core/Cargo.toml
+++ b/crates/floe-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "floe-core"
-version = "0.4.1"
+version = "0.4.2"
 edition = "2021"
 description = "Core library for Floe, a YAML-driven technical ingestion tool."
 license = "MIT"

--- a/crates/floe-python/Cargo.toml
+++ b/crates/floe-python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "floe-python"
-version = "0.4.1"
+version = "0.4.2"
 edition = "2021"
 description = "Python bindings for floe-core (PyO3-based)"
 license = "Apache-2.0"
@@ -13,7 +13,7 @@ name = "_floe"
 crate-type = ["cdylib"]
 
 [dependencies]
-floe-core = { path = "../floe-core", version = "0.4.1" }
+floe-core = { path = "../floe-core", version = "0.4.2" }
 pyo3 = { version = "0.22", features = ["extension-module", "abi3-py310"] }
 serde_json = "1"
 

--- a/crates/floe-python/pyproject.toml
+++ b/crates/floe-python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "floe-python"
-version = "0.4.1"
+version = "0.4.2"
 description = "Python bindings for floe-core — run floe pipelines at Rust speed from Python and notebooks"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/orchestrators/dagster-floe/pyproject.toml
+++ b/orchestrators/dagster-floe/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "dagster-floe"
-version = "0.1.5"
+version = "0.1.6"
 description = "Dagster connector for Floe CLI (config-driven ingestion)"
 requires-python = ">=3.10"
 readme = "README.md"


### PR DESCRIPTION
## Summary

- `floe-core`, `floe-cli`, `floe-python`: `0.4.1` → `0.4.2`
- `dagster-floe`: `0.1.5` → `0.1.6`
- Updated `floe-core` dependency version in `floe-cli` and `floe-python` to match

## Changes since v0.4.1

- fix(lineage): emit source and sink datasets separately (#317 / #318)
- feat(profile): support storages and lineage sections in profiles (#314)
- fix(iceberg): register S3/GCS storage factory (#312)
- fix(validate): reject remote report.path when storage is local (#311)
- fix(lineage): install OpenLineage observer from profile lineage block (#316 / PR #324)
- fix(state): accept `-p/--profile` on `state inspect` and `state reset` (#320 / PR #326)
- fix(incremental): commit file state after rejected terminal outcomes (#327 / PR #329)