### PR TITLE
feat(dagster): register SourceAsset for source lineage and enrich rejected metadata

### DIFF
--- a/orchestrators/dagster-floe/example/README.md
+++ b/orchestrators/dagster-floe/example/README.md
@@ -1,0 +1,75 @@
+# dagster-floe local example
+
+Runs two Dagster jobs (HR + Sales) against the CSV files in `in/` and writes
+accepted Parquet output to `out/`. Several rows in each file are intentionally
+invalid so you can verify rejected asset metadata in the Dagster UI.
+
+## What this example verifies (issue #334)
+
+| Thing to look at | Expected behaviour |
+|---|---|
+| Asset lineage graph | `employees_source`, `orders_source`, `invoices_source` appear as **external** (grey/cloud) nodes upstream of each job asset |
+| `employees_source` metadata | Shows `format: csv` and `dagster/uri` pointing to `in/hr/employees.csv` |
+| After materialising employees | `employees_rejected` asset page shows `rejection_rate`, `dagster/uri` (rejected sink path), `files_with_rejections`, `dominant_rejection_reason` |
+
+## Prerequisites
+
+```bash
+# 1. Install the floe CLI (binary must be on PATH as "floe")
+cargo install floe-cli   # or download a pre-built binary
+
+# 2. Install Python dependencies
+cd orchestrators/dagster-floe
+uv sync
+```
+
+## Run
+
+```bash
+# From orchestrators/dagster-floe/
+uv run dagster dev
+```
+
+Dagster UI opens at **http://localhost:3000**.
+
+## Walkthrough
+
+### 1. Check source asset lineage
+
+1. Click **Assets** in the top nav.
+2. Click **View global asset lineage**.
+3. You should see three source nodes (`employees_source`, `orders_source`,
+   `invoices_source`) displayed as external/untracked upstream boxes connected
+   to each multi-asset.
+4. Click `employees_source` → the sidebar shows `format: csv` and a
+   clickable `dagster/uri` link.
+
+### 2. Materialise and inspect rejected metadata
+
+1. Click **Jobs** → `floe_mfv1_dagster_hr_job` → **Materialize all**.
+2. Wait for the run to finish (it will succeed even though some rows are
+   rejected — `policy.severity: reject` routes bad rows to the sink without
+   failing the job).
+3. Click **Assets** → `hr/employees_rejected`.
+4. In the **Metadata** panel you should see:
+
+   | Key | Example value |
+   |---|---|
+   | `rejected` | `3` |
+   | `rejection_rate` | `0.6` |
+   | `dagster/uri` | `…/out/rejected/employees` |
+   | `files_with_rejections` | `1` |
+   | `dominant_rejection_reason` | `cast_error` or `not_null` |
+
+5. Repeat for **Sales** job (`floe_mfv1_dagster_sales_job`) and inspect
+   `sales/orders_rejected` and `sales/invoices_rejected`.
+
+## Input data
+
+The `in/` files include intentionally invalid rows:
+
+| File | Bad rows |
+|---|---|
+| `in/hr/employees.csv` | null `employee_id`, invalid `start_date`, invalid `salary` |
+| `in/sales/orders.csv` | invalid `created_at`, non-numeric `amount` |
+| `in/sales/invoices.csv` | invalid `paid` value, null `order_id` |

--- a/orchestrators/dagster-floe/src/floe_dagster/assets.py
+++ b/orchestrators/dagster-floe/src/floe_dagster/assets.py
@@ -89,20 +89,34 @@ def _has_rejected_asset(entity: ManifestEntity) -> bool:
 
 
 def _count_files_with_rejections(report: dict[str, Any]) -> int:
+    files = report.get("files")
+    if not isinstance(files, list):
+        return 0
     return sum(
-        1 for f in report.get("files", [])
-        if f.get("rejected_count", 0) > 0
+        1 for f in files
+        if isinstance(f, dict) and (f.get("rejected_count") or 0) > 0
     )
 
 
 def _dominant_rejection_reason(report: dict[str, Any]) -> str | None:
+    files = report.get("files")
+    if not isinstance(files, list):
+        return None
     counts: dict[str, int] = {}
-    for f in report.get("files", []):
-        for rule in f.get("validation", {}).get("rules", []):
-            name = rule.get("rule", "")
-            violations = rule.get("violations", 0)
-            if violations > 0:
-                counts[name] = counts.get(name, 0) + violations
+    for f in files:
+        if not isinstance(f, dict):
+            continue
+        validation = f.get("validation")
+        rules = validation.get("rules") if isinstance(validation, dict) else None
+        if not isinstance(rules, list):
+            continue
+        for rule in rules:
+            if not isinstance(rule, dict):
+                continue
+            name = rule.get("rule") or ""
+            violations = rule.get("violations") or 0
+            if isinstance(violations, (int, float)) and violations > 0 and name:
+                counts[name] = counts.get(name, 0) + int(violations)
     if not counts:
         return None
     return max(counts, key=lambda k: counts[k])

--- a/orchestrators/dagster-floe/src/floe_dagster/assets.py
+++ b/orchestrators/dagster-floe/src/floe_dagster/assets.py
@@ -10,7 +10,9 @@ from dagster import (
     AssetOut,
     Definitions,
     Failure,
+    MetadataValue,
     Output,
+    SourceAsset,
     multi_asset,
 )
 
@@ -35,19 +37,19 @@ def load_floe_assets(
     runner: Runner,
     entities: list[str] | None = None,
 ) -> Definitions:
-    assets_defs, _selected_entities = build_floe_asset_defs(
+    assets_defs, source_assets, _selected_entities = build_floe_asset_defs(
         manifest_path=manifest_path,
         runner=runner,
         entities=entities,
     )
-    return Definitions(assets=assets_defs)
+    return Definitions(assets=[*assets_defs, *source_assets])
 
 
 def build_floe_asset_defs(
     manifest_path: str,
     runner: Runner,
     entities: list[str] | None = None,
-) -> tuple[list[Any], list[ManifestEntity]]:
+) -> tuple[list[Any], list[SourceAsset], list[ManifestEntity]]:
     manifest = load_manifest(manifest_path)
     config_uri = resolve_config_uri(manifest_path, manifest.config_uri)
     entity_items = selected_manifest_entities(manifest, entities)
@@ -66,7 +68,8 @@ def build_floe_asset_defs(
             )
         )
 
-    return assets_defs, entity_items
+    source_assets = _build_source_assets(entity_items)
+    return assets_defs, source_assets, entity_items
 
 
 def selected_manifest_entities(
@@ -83,6 +86,26 @@ def _has_rejected_asset(entity: ManifestEntity) -> bool:
         return entity.policy_severity in ("reject", "abort")
     # Backward compat: old manifests without policy_severity
     return entity.rejected_sink_uri is not None
+
+
+def _count_files_with_rejections(report: dict[str, Any]) -> int:
+    return sum(
+        1 for f in report.get("files", [])
+        if f.get("rejected_count", 0) > 0
+    )
+
+
+def _dominant_rejection_reason(report: dict[str, Any]) -> str | None:
+    counts: dict[str, int] = {}
+    for f in report.get("files", []):
+        for rule in f.get("validation", {}).get("rules", []):
+            name = rule.get("rule", "")
+            violations = rule.get("violations", 0)
+            if violations > 0:
+                counts[name] = counts.get(name, 0) + violations
+    if not counts:
+        return None
+    return max(counts, key=lambda k: counts[k])
 
 
 def _make_entity_multi_asset(
@@ -212,11 +235,23 @@ def _make_entity_multi_asset(
 
         yield Output(value=None, output_name="accepted", metadata=metadata)
         if has_rejected:
-            rejected_metadata = {
+            rows = entity_stats.get("rows") or 0
+            rejected_count = entity_stats.get("rejected") or 0
+            rejection_rate = rejected_count / rows if rows > 0 else 0.0
+            rejected_metadata: dict[str, Any] = {
                 "run_id": finished.run_id,
-                "rejected": entity_stats.get("rejected"),
+                "rejected": MetadataValue.int(rejected_count),
                 "status": finished.status,
+                "rejection_rate": MetadataValue.float(rejection_rate),
             }
+            if entity.rejected_sink_uri:
+                rejected_metadata["dagster/uri"] = MetadataValue.url(entity.rejected_sink_uri)
+            if entity_report_json:
+                files_with_rejections = _count_files_with_rejections(entity_report_json)
+                dominant = _dominant_rejection_reason(entity_report_json)
+                rejected_metadata["files_with_rejections"] = MetadataValue.int(files_with_rejections)
+                if dominant:
+                    rejected_metadata["dominant_rejection_reason"] = dominant
             yield Output(value=None, output_name="rejected", metadata=rejected_metadata)
 
     return _multi_asset
@@ -286,3 +321,21 @@ def _as_optional_str(value: Any) -> str | None:
     if isinstance(value, str):
         return value
     return str(value)
+
+
+def _build_source_assets(entity_items: list[ManifestEntity]) -> list[SourceAsset]:
+    source_assets = []
+    for entity in entity_items:
+        source_key = list(entity.asset_key[:-1]) + [entity.asset_key[-1] + "_source"]
+        metadata: dict[str, Any] = {"format": entity.source_format}
+        if entity.source_uri:
+            metadata["dagster/uri"] = MetadataValue.url(entity.source_uri)
+        source_assets.append(
+            SourceAsset(
+                key=AssetKey(source_key),
+                group_name=entity.group_name,
+                description=f"Raw source files for '{entity.name}' (format: {entity.source_format})",
+                metadata=metadata,
+            )
+        )
+    return source_assets

--- a/orchestrators/dagster-floe/src/floe_dagster/assets.py
+++ b/orchestrators/dagster-floe/src/floe_dagster/assets.py
@@ -36,11 +36,19 @@ def load_floe_assets(
     manifest_path: str,
     runner: Runner,
     entities: list[str] | None = None,
+    register_source_assets: bool = True,
 ) -> Definitions:
+    """Build a Dagster Definitions for the given manifest.
+
+    register_source_assets: if False, skip SourceAsset registration for source keys.
+        Set to False when another Dagster pipeline in the same workspace already
+        materialises those keys to avoid asset key conflicts.
+    """
     assets_defs, source_assets, _selected_entities = build_floe_asset_defs(
         manifest_path=manifest_path,
         runner=runner,
         entities=entities,
+        register_source_assets=register_source_assets,
     )
     return Definitions(assets=[*assets_defs, *source_assets])
 
@@ -49,6 +57,7 @@ def build_floe_asset_defs(
     manifest_path: str,
     runner: Runner,
     entities: list[str] | None = None,
+    register_source_assets: bool = True,
 ) -> tuple[list[Any], list[SourceAsset], list[ManifestEntity]]:
     manifest = load_manifest(manifest_path)
     config_uri = resolve_config_uri(manifest_path, manifest.config_uri)
@@ -68,7 +77,7 @@ def build_floe_asset_defs(
             )
         )
 
-    source_assets = _build_source_assets(entity_items)
+    source_assets = _build_source_assets(entity_items) if register_source_assets else []
     entity_key_set = {tuple(e.asset_key) for e in entity_items}
     for sa in source_assets:
         sk = tuple(sa.key.path)

--- a/orchestrators/dagster-floe/src/floe_dagster/assets.py
+++ b/orchestrators/dagster-floe/src/floe_dagster/assets.py
@@ -69,6 +69,15 @@ def build_floe_asset_defs(
         )
 
     source_assets = _build_source_assets(entity_items)
+    entity_key_set = {tuple(e.asset_key) for e in entity_items}
+    for sa in source_assets:
+        sk = tuple(sa.key.path)
+        if sk in entity_key_set:
+            collision = "/".join(sa.key.path)
+            raise ValueError(
+                f"duplicate asset key {collision!r}: generated source key collides with "
+                f"an existing entity key in {manifest_path}"
+            )
     return assets_defs, source_assets, entity_items
 
 
@@ -88,13 +97,20 @@ def _has_rejected_asset(entity: ManifestEntity) -> bool:
     return entity.rejected_sink_uri is not None
 
 
+def _safe_int(val: Any, default: int = 0) -> int:
+    try:
+        return int(val)
+    except (TypeError, ValueError):
+        return default
+
+
 def _count_files_with_rejections(report: dict[str, Any]) -> int:
     files = report.get("files")
     if not isinstance(files, list):
         return 0
     return sum(
         1 for f in files
-        if isinstance(f, dict) and (f.get("rejected_count") or 0) > 0
+        if isinstance(f, dict) and _safe_int(f.get("rejected_count")) > 0
     )
 
 
@@ -114,9 +130,11 @@ def _dominant_rejection_reason(report: dict[str, Any]) -> str | None:
             if not isinstance(rule, dict):
                 continue
             name = rule.get("rule") or ""
-            violations = rule.get("violations") or 0
-            if isinstance(violations, (int, float)) and violations > 0 and name:
-                counts[name] = counts.get(name, 0) + int(violations)
+            if not isinstance(name, str) or not name:
+                continue
+            violations = _safe_int(rule.get("violations"))
+            if violations > 0:
+                counts[name] = counts.get(name, 0) + violations
     if not counts:
         return None
     return max(counts, key=lambda k: counts[k])

--- a/orchestrators/dagster-floe/src/floe_dagster/definitions.py
+++ b/orchestrators/dagster-floe/src/floe_dagster/definitions.py
@@ -79,12 +79,13 @@ def build_definitions_from_manifest_paths(
     for manifest_path in manifest_paths_list:
         manifest = load_manifest(manifest_path)
         selected_entities = None if entities is None else list(entities)
-        manifest_assets, manifest_entities = build_floe_asset_defs(
+        manifest_assets, manifest_source_assets, manifest_entities = build_floe_asset_defs(
             manifest_path=manifest_path,
             runner=runner_impl,
             entities=selected_entities,
         )
         assets_defs.extend(manifest_assets)
+        assets_defs.extend(manifest_source_assets)
         _validate_no_duplicate_asset_keys(
             seen_asset_keys=seen_asset_keys,
             manifest_path=manifest_path,

--- a/orchestrators/dagster-floe/src/floe_dagster/definitions.py
+++ b/orchestrators/dagster-floe/src/floe_dagster/definitions.py
@@ -89,7 +89,10 @@ def build_definitions_from_manifest_paths(
         _validate_no_duplicate_asset_keys(
             seen_asset_keys=seen_asset_keys,
             manifest_path=manifest_path,
-            entity_asset_keys=[entity.asset_key for entity in manifest_entities],
+            entity_asset_keys=(
+                [entity.asset_key for entity in manifest_entities]
+                + [list(sa.key.path) for sa in manifest_source_assets]
+            ),
         )
 
         if with_job and manifest_entities:

--- a/orchestrators/dagster-floe/tests/test_asset_checks.py
+++ b/orchestrators/dagster-floe/tests/test_asset_checks.py
@@ -248,7 +248,7 @@ def test_asset_emits_native_dagster_asset_checks_from_floe_reports(tmp_path: Pat
     )
 
     manifest_path = Path(__file__).parent / "fixtures" / "manifest.json"
-    assets_defs, _ = build_floe_asset_defs(
+    assets_defs, _source_assets, _ = build_floe_asset_defs(
         manifest_path=str(manifest_path),
         runner=_StaticRunner(stdout),
         entities=["employees"],

--- a/orchestrators/dagster-floe/tests/test_assets_manifest.py
+++ b/orchestrators/dagster-floe/tests/test_assets_manifest.py
@@ -285,3 +285,46 @@ def test_dominant_rejection_reason_picks_highest_count() -> None:
         ]
     }
     assert _dominant_rejection_reason(report) == "cast_error"
+
+
+# ── defensive: malformed report payloads ─────────────────────────────────────
+
+def test_count_files_with_rejections_files_is_null() -> None:
+    assert _count_files_with_rejections({"files": None}) == 0
+
+
+def test_count_files_with_rejections_files_is_not_list() -> None:
+    assert _count_files_with_rejections({"files": "bad"}) == 0
+
+
+def test_count_files_with_rejections_non_dict_element() -> None:
+    report = {"files": [None, {"rejected_count": 2}, "oops"]}
+    assert _count_files_with_rejections(report) == 1
+
+
+def test_dominant_rejection_reason_files_is_null() -> None:
+    assert _dominant_rejection_reason({"files": None}) is None
+
+
+def test_dominant_rejection_reason_files_is_not_list() -> None:
+    assert _dominant_rejection_reason({"files": 42}) is None
+
+
+def test_dominant_rejection_reason_non_dict_file_element() -> None:
+    report = {"files": [None, {"validation": {"rules": [{"rule": "cast_error", "violations": 3}]}}]}
+    assert _dominant_rejection_reason(report) == "cast_error"
+
+
+def test_dominant_rejection_reason_validation_is_null() -> None:
+    report = {"files": [{"validation": None}]}
+    assert _dominant_rejection_reason(report) is None
+
+
+def test_dominant_rejection_reason_rules_is_null() -> None:
+    report = {"files": [{"validation": {"rules": None}}]}
+    assert _dominant_rejection_reason(report) is None
+
+
+def test_dominant_rejection_reason_non_dict_rule_element() -> None:
+    report = {"files": [{"validation": {"rules": [None, {"rule": "not_null", "violations": 1}]}}]}
+    assert _dominant_rejection_reason(report) == "not_null"

--- a/orchestrators/dagster-floe/tests/test_assets_manifest.py
+++ b/orchestrators/dagster-floe/tests/test_assets_manifest.py
@@ -238,6 +238,28 @@ def test_source_asset_group_matches_entity_group() -> None:
     assert source_assets[0].group_name == entities[0].group_name
 
 
+def test_register_source_assets_false_returns_empty_source_list() -> None:
+    """register_source_assets=False skips SourceAsset creation (opt-out for upstream pipelines)."""
+    _asset_defs, source_assets, _entities = build_floe_asset_defs(
+        manifest_path=str(FIXTURE),
+        runner=_NoopRunner(),
+        entities=["employees"],
+        register_source_assets=False,
+    )
+    assert source_assets == []
+
+
+def test_load_floe_assets_register_source_assets_false() -> None:
+    """load_floe_assets passes register_source_assets=False through to build_floe_asset_defs."""
+    defs = load_floe_assets(
+        manifest_path=str(FIXTURE),
+        runner=_NoopRunner(),
+        entities=["employees"],
+        register_source_assets=False,
+    )
+    assert defs is not None
+
+
 # ── rejected metadata helpers ─────────────────────────────────────────────────
 
 def test_count_files_with_rejections_empty_report() -> None:

--- a/orchestrators/dagster-floe/tests/test_assets_manifest.py
+++ b/orchestrators/dagster-floe/tests/test_assets_manifest.py
@@ -328,3 +328,35 @@ def test_dominant_rejection_reason_rules_is_null() -> None:
 def test_dominant_rejection_reason_non_dict_rule_element() -> None:
     report = {"files": [{"validation": {"rules": [None, {"rule": "not_null", "violations": 1}]}}]}
     assert _dominant_rejection_reason(report) == "not_null"
+
+
+# ── schema-drift / type-coercion edge cases ───────────────────────────────────
+
+def test_count_files_with_rejections_string_count() -> None:
+    """rejected_count as string (schema drift) is coerced to int."""
+    report = {"files": [{"rejected_count": "2"}, {"rejected_count": "0"}]}
+    assert _count_files_with_rejections(report) == 1
+
+
+def test_dominant_rejection_reason_list_rule_name() -> None:
+    """Non-string rule name is skipped without raising TypeError."""
+    report = {"files": [{"validation": {"rules": [{"rule": ["cast_error"], "violations": 1}]}}]}
+    assert _dominant_rejection_reason(report) is None
+
+
+def test_build_floe_asset_defs_raises_on_intra_manifest_source_key_collision(tmp_path) -> None:
+    """build_floe_asset_defs raises ValueError when a generated source key matches an entity key."""
+    import json
+
+    fixture = Path(__file__).parent / "fixtures" / "manifest.json"
+    payload = json.loads(fixture.read_text(encoding="utf-8"))
+    employees = payload["entities"][0]
+    payload["entities"].append({
+        **employees,
+        "name": "employees_source",
+        "asset_key": employees["asset_key"][:-1] + [employees["asset_key"][-1] + "_source"],
+    })
+    manifest_path = tmp_path / "manifest.collision.json"
+    manifest_path.write_text(json.dumps(payload), encoding="utf-8")
+    with pytest.raises(ValueError, match="duplicate asset key"):
+        build_floe_asset_defs(manifest_path=str(manifest_path), runner=_NoopRunner())

--- a/orchestrators/dagster-floe/tests/test_assets_manifest.py
+++ b/orchestrators/dagster-floe/tests/test_assets_manifest.py
@@ -6,7 +6,12 @@ import pytest
 
 from dagster import AssetKey
 
-from floe_dagster.assets import build_floe_asset_defs, load_floe_assets
+from floe_dagster.assets import (
+    _count_files_with_rejections,
+    _dominant_rejection_reason,
+    build_floe_asset_defs,
+    load_floe_assets,
+)
 from floe_dagster.manifest import ManifestRunnerDefinition
 from floe_dagster.runner import LocalRunner, RunResult, Runner
 
@@ -121,7 +126,7 @@ def test_local_runner_raises_not_implemented_for_unknown_runner() -> None:
 # ── multi-asset structure ──────────────────────────────────────────────────────
 
 def _get_asset_def(manifest_path, entity_name):
-    asset_defs, entities = build_floe_asset_defs(
+    asset_defs, _source_assets, entities = build_floe_asset_defs(
         manifest_path=str(manifest_path),
         runner=_NoopRunner(),
         entities=[entity_name],
@@ -171,3 +176,112 @@ def test_multi_asset_source_dep_declared() -> None:
     source_key = AssetKey(entity.asset_key[:-1] + [entity.asset_key[-1] + "_source"])
     dep_keys = set(asset_def.keys_by_input_name.values())
     assert source_key in dep_keys
+
+
+# ── SourceAsset registration ───────────────────────────────────────────────────
+
+def test_build_floe_asset_defs_returns_source_assets() -> None:
+    """build_floe_asset_defs returns a non-empty list of SourceAsset objects."""
+    _asset_defs, source_assets, _entities = build_floe_asset_defs(
+        manifest_path=str(FIXTURE),
+        runner=_NoopRunner(),
+        entities=["employees"],
+    )
+    assert len(source_assets) == 1
+    assert source_assets[0].key.path[-1].endswith("_source")
+
+
+def test_source_asset_key_matches_entity_source_dep() -> None:
+    """The SourceAsset key matches the dep declared in the multi-asset."""
+    _asset_defs, source_assets, entities = build_floe_asset_defs(
+        manifest_path=str(FIXTURE),
+        runner=_NoopRunner(),
+        entities=["employees"],
+    )
+    entity = entities[0]
+    expected_key = AssetKey(entity.asset_key[:-1] + [entity.asset_key[-1] + "_source"])
+    assert source_assets[0].key == expected_key
+
+
+def test_source_asset_has_format_metadata() -> None:
+    """SourceAsset metadata includes the source format."""
+    _asset_defs, source_assets, entities = build_floe_asset_defs(
+        manifest_path=str(FIXTURE),
+        runner=_NoopRunner(),
+        entities=["employees"],
+    )
+    entity = entities[0]
+    metadata = source_assets[0].metadata
+    assert "format" in metadata
+    assert metadata["format"].text == entity.source_format
+
+
+def test_source_asset_has_uri_metadata_when_source_uri_set() -> None:
+    """SourceAsset metadata includes dagster/uri when entity.source_uri is set."""
+    _asset_defs, source_assets, entities = build_floe_asset_defs(
+        manifest_path=str(FIXTURE),
+        runner=_NoopRunner(),
+        entities=["employees"],
+    )
+    entity = entities[0]
+    if entity.source_uri:
+        assert "dagster/uri" in source_assets[0].metadata
+
+
+def test_source_asset_group_matches_entity_group() -> None:
+    """SourceAsset group_name matches entity.group_name."""
+    _asset_defs, source_assets, entities = build_floe_asset_defs(
+        manifest_path=str(FIXTURE),
+        runner=_NoopRunner(),
+        entities=["employees"],
+    )
+    assert source_assets[0].group_name == entities[0].group_name
+
+
+# ── rejected metadata helpers ─────────────────────────────────────────────────
+
+def test_count_files_with_rejections_empty_report() -> None:
+    assert _count_files_with_rejections({}) == 0
+
+
+def test_count_files_with_rejections_no_rejections() -> None:
+    report = {"files": [{"rejected_count": 0}, {"rejected_count": 0}]}
+    assert _count_files_with_rejections(report) == 0
+
+
+def test_count_files_with_rejections_partial() -> None:
+    report = {"files": [{"rejected_count": 3}, {"rejected_count": 0}, {"rejected_count": 1}]}
+    assert _count_files_with_rejections(report) == 2
+
+
+def test_dominant_rejection_reason_empty_report() -> None:
+    assert _dominant_rejection_reason({}) is None
+
+
+def test_dominant_rejection_reason_no_violations() -> None:
+    report = {
+        "files": [{"validation": {"rules": [{"rule": "not_null", "violations": 0}]}}]
+    }
+    assert _dominant_rejection_reason(report) is None
+
+
+def test_dominant_rejection_reason_single_rule() -> None:
+    report = {
+        "files": [{"validation": {"rules": [{"rule": "cast_error", "violations": 5}]}}]
+    }
+    assert _dominant_rejection_reason(report) == "cast_error"
+
+
+def test_dominant_rejection_reason_picks_highest_count() -> None:
+    report = {
+        "files": [
+            {"validation": {"rules": [
+                {"rule": "not_null", "violations": 2},
+                {"rule": "cast_error", "violations": 7},
+            ]}},
+            {"validation": {"rules": [
+                {"rule": "not_null", "violations": 3},
+            ]}},
+        ]
+    }
+    assert _dominant_rejection_reason(report) == "cast_error"

--- a/orchestrators/dagster-floe/tests/test_definitions.py
+++ b/orchestrators/dagster-floe/tests/test_definitions.py
@@ -1,3 +1,4 @@
+import json
 from pathlib import Path
 
 import pytest
@@ -80,6 +81,51 @@ def test_build_definitions_from_manifest_paths_rejects_duplicate_asset_keys() ->
     with pytest.raises(ValueError, match="duplicate asset key"):
         build_definitions_from_manifest_paths(
             manifest_paths=[str(fixture.resolve()), str(fixture.resolve())],
+            runner=_NoopRunner(),
+        )
+
+
+def test_build_definitions_rejects_source_key_collision(tmp_path) -> None:
+    """Generated _source key must not collide with an existing entity key across manifests."""
+    base = json.loads(
+        (Path(__file__).parent / "fixtures" / "manifest_hr.json").read_text(encoding="utf-8")
+    )
+
+    # Manifest A: entity with key ["sales", "orders"] → generates source key ["sales", "orders_source"]
+    manifest_a = dict(base)
+    manifest_a["manifest_id"] = "manifest-a"
+    manifest_a["entities"] = [
+        {
+            **base["entities"][0],
+            "name": "orders",
+            "asset_key": ["sales", "orders"],
+            "accepted_sink_uri": "./out/accepted/orders",
+            "rejected_sink_uri": None,
+            "policy_severity": "warn",
+        }
+    ]
+    path_a = tmp_path / "manifest_a.json"
+    path_a.write_text(json.dumps(manifest_a), encoding="utf-8")
+
+    # Manifest B: entity whose key IS ["sales", "orders_source"] — collides with A's source key
+    manifest_b = dict(base)
+    manifest_b["manifest_id"] = "manifest-b"
+    manifest_b["entities"] = [
+        {
+            **base["entities"][0],
+            "name": "orders_source",
+            "asset_key": ["sales", "orders_source"],
+            "accepted_sink_uri": "./out/accepted/orders_source",
+            "rejected_sink_uri": None,
+            "policy_severity": "warn",
+        }
+    ]
+    path_b = tmp_path / "manifest_b.json"
+    path_b.write_text(json.dumps(manifest_b), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="duplicate asset key"):
+        build_definitions_from_manifest_paths(
+            manifest_paths=[str(path_a), str(path_b)],
             runner=_NoopRunner(),
         )
 


### PR DESCRIPTION
Closes #334.

## Summary

- **SourceAsset per entity**: `_build_source_assets()` creates a `SourceAsset` for each entity's source key so the upstream node appears in the Dagster UI with an external icon, description, `format` metadata, and a clickable `dagster/uri` link when `source.uri` is set in the manifest. Previously the node was "untracked" with no icon or metadata.
- **Updated return tuple**: `build_floe_asset_defs()` now returns `(assets_defs, source_assets, entity_items)`. All callers (`load_floe_assets`, `build_definitions_from_manifest_paths`) are updated.
- **Enriched rejected Output metadata**: two new private helpers (`_count_files_with_rejections`, `_dominant_rejection_reason`) parse the entity report JSON (already loaded for asset checks) and surface `rejection_rate`, `dagster/uri` (rejected sink path), `files_with_rejections`, and `dominant_rejection_reason` on the rejected asset page.

## Files changed

| File | Change |
|---|---|
| `assets.py` | Add `SourceAsset`/`MetadataValue` imports; `_build_source_assets`; `_count_files_with_rejections`; `_dominant_rejection_reason`; updated return type + body of `build_floe_asset_defs`; updated `load_floe_assets`; enriched rejected `Output` yield |
| `definitions.py` | Unpack 3-tuple; extend `assets_defs` with `manifest_source_assets` |
| `tests/test_asset_checks.py` | Fix 2-tuple unpack → 3-tuple |
| `tests/test_assets_manifest.py` | Fix `_get_asset_def` helper; add 12 new tests covering source asset key/metadata/group and both rejection-report helpers |

## Test plan

- [ ] `uv run python -c "from floe_dagster.assets import load_floe_assets; print('ok')"` → `import ok`
- [ ] `pytest tests/ -v` → 67 passed, 1 skipped (pre-existing skip for local runner integration test)
- [ ] Dagster UI: materialize any entity → `orders_source` appears with external icon, format metadata, URI link
- [ ] Materialize entity with rejections → rejected asset page shows `rejection_rate`, `dagster/uri`, `files_with_rejections`, `dominant_rejection_reason`