### PR TITLE
fix(lineage): stable run job name, versioned producer, column lineage, dagster job name

### DIFF
--- a/crates/floe-cli/src/main.rs
+++ b/crates/floe-cli/src/main.rs
@@ -462,7 +462,7 @@ fn main() -> FloeResult<()> {
                     json.and_then(|j| floe_core::config_from_manifest_json(&j).ok())
                         .and_then(|(cfg, _)| cfg.lineage)
                         .and_then(|lineage_cfg| {
-                            match floe_core::lineage::build_observer(&lineage_cfg, &[]) {
+                            match floe_core::lineage::build_observer(&lineage_cfg, &[], "") {
                                 Ok(obs) => Some(obs),
                                 Err(err) => {
                                     eprintln!("Warning: lineage observer disabled: {err}");
@@ -632,7 +632,11 @@ fn main() -> FloeResult<()> {
                 .ok()
                 .and_then(|c| c.lineage.as_ref().map(|l| (l, c.entities.as_slice())))
                 .and_then(|(lineage_cfg, entities)| {
-                    match floe_core::lineage::build_observer(lineage_cfg, entities) {
+                    match floe_core::lineage::build_observer(
+                        lineage_cfg,
+                        entities,
+                        config_location.path.to_str().unwrap_or(""),
+                    ) {
                         Ok(obs) => Some(obs),
                         Err(err) => {
                             eprintln!("Warning: lineage observer disabled: {err}");

--- a/crates/floe-core/src/config/parse.rs
+++ b/crates/floe-core/src/config/parse.rs
@@ -1141,6 +1141,7 @@ pub(crate) fn parse_lineage_config(value: &Yaml) -> FloeResult<LineageConfig> {
             "namespace",
             "producer",
             "max_failures",
+            "job_name",
         ],
     )?;
     Ok(LineageConfig {
@@ -1150,5 +1151,6 @@ pub(crate) fn parse_lineage_config(value: &Yaml) -> FloeResult<LineageConfig> {
         namespace: get_string(hash, "namespace", "lineage")?,
         producer: opt_string(hash, "producer", "lineage")?,
         max_failures: opt_u32(hash, "max_failures", "lineage")?,
+        job_name: opt_string(hash, "job_name", "lineage")?,
     })
 }

--- a/crates/floe-core/src/config/types.rs
+++ b/crates/floe-core/src/config/types.rs
@@ -31,6 +31,7 @@ pub struct LineageConfig {
     pub namespace: String,
     pub producer: Option<String>,
     pub max_failures: Option<u32>,
+    pub job_name: Option<String>,
 }
 
 #[derive(Debug)]

--- a/crates/floe-core/src/lineage/mod.rs
+++ b/crates/floe-core/src/lineage/mod.rs
@@ -305,8 +305,8 @@ impl OpenLineageObserver {
                             let src = col.source_field.as_deref().unwrap_or(&col.output_name);
                             let entry = json!({
                                 "inputFields": [{
-                                    "namespace": self.config.namespace,
-                                    "dataset": format!("{name}_source"),
+                                    "namespace": format!("{}.source", self.config.namespace),
+                                    "dataset": name,
                                     "field": src
                                 }]
                             });

--- a/crates/floe-core/src/lineage/mod.rs
+++ b/crates/floe-core/src/lineage/mod.rs
@@ -8,6 +8,18 @@ use serde_json::{json, Value};
 use crate::config::{EntityConfig, LineageConfig};
 use crate::run::events::{RunEvent, RunObserver};
 
+const DEFAULT_PRODUCER: &str = concat!(
+    "https://github.com/malon64/floe/releases/tag/v",
+    env!("CARGO_PKG_VERSION")
+);
+
+#[derive(Clone)]
+struct ColumnMapping {
+    output_name: String,
+    column_type: String,
+    source_field: Option<String>,
+}
+
 struct EntityUris {
     source: String,
     accepted: String,
@@ -20,14 +32,19 @@ pub struct OpenLineageObserver {
     entity_start_ms: Mutex<HashMap<String, u128>>,
     entity_run_ids: Mutex<HashMap<String, String>>,
     run_start_ms: Mutex<Option<u128>>,
-    entity_schemas: HashMap<String, Vec<(String, String)>>,
+    entity_schemas: HashMap<String, Vec<ColumnMapping>>,
     entity_uris: HashMap<String, EntityUris>,
+    run_job_name: String,
     consecutive_failures: AtomicUsize,
     circuit_open: AtomicBool,
 }
 
 impl OpenLineageObserver {
-    pub fn new(config: &LineageConfig, entities: &[EntityConfig]) -> crate::FloeResult<Self> {
+    pub fn new(
+        config: &LineageConfig,
+        entities: &[EntityConfig],
+        config_path: &str,
+    ) -> crate::FloeResult<Self> {
         let timeout = Duration::from_secs(config.timeout_secs.unwrap_or(5));
         let client = reqwest::blocking::Client::builder()
             .timeout(timeout)
@@ -38,14 +55,30 @@ impl OpenLineageObserver {
                 ))) as Box<dyn std::error::Error + Send + Sync>
             })?;
 
+        let run_job_name = config
+            .job_name
+            .clone()
+            .filter(|s| !s.is_empty())
+            .unwrap_or_else(|| {
+                std::path::Path::new(config_path)
+                    .file_stem()
+                    .and_then(|s| s.to_str())
+                    .unwrap_or("floe-run")
+                    .to_string()
+            });
+
         let entity_schemas = entities
             .iter()
             .map(|e| {
-                let fields: Vec<(String, String)> = e
+                let fields: Vec<ColumnMapping> = e
                     .schema
                     .columns
                     .iter()
-                    .map(|c| (c.name.clone(), c.column_type.clone()))
+                    .map(|c| ColumnMapping {
+                        output_name: c.name.clone(),
+                        column_type: c.column_type.clone(),
+                        source_field: c.source.clone(),
+                    })
                     .collect();
                 (e.name.clone(), fields)
             })
@@ -73,6 +106,7 @@ impl OpenLineageObserver {
             run_start_ms: Mutex::new(None),
             entity_schemas,
             entity_uris,
+            run_job_name,
             consecutive_failures: AtomicUsize::new(0),
             circuit_open: AtomicBool::new(false),
         })
@@ -155,10 +189,7 @@ impl OpenLineageObserver {
     }
 
     fn producer(&self) -> &str {
-        self.config
-            .producer
-            .as_deref()
-            .unwrap_or("https://github.com/malon64/floe")
+        self.config.producer.as_deref().unwrap_or(DEFAULT_PRODUCER)
     }
 
     fn parent_run_facet(&self) -> Option<Value> {
@@ -235,8 +266,8 @@ impl OpenLineageObserver {
                 // Accepted output: entity name as logical identifier, TABLE type.
                 let (acc_ns, acc_path) = split_storage_uri(&u.accepted);
                 let schema_facet = json!({
-                    "fields": s.schema_fields.iter().map(|(col_name, col_type)| {
-                        json!({ "name": col_name, "type": col_type })
+                    "fields": s.schema_fields.iter().map(|col| {
+                        json!({ "name": col.output_name, "type": col.column_type })
                     }).collect::<Vec<_>>(),
                     "_producer": self.producer(),
                     "_schemaURL": "https://openlineage.io/spec/facets/1-1-1/SchemaDatasetFacet.json"
@@ -258,15 +289,41 @@ impl OpenLineageObserver {
                     "_producer": self.producer(),
                     "_schemaURL": "https://github.com/malon64/floe/schemas/FloeQualityRunFacet.json"
                 });
+
+                let mut accepted_facets = json!({
+                    "symlinks": symlinks_facet(self.producer(), &acc_ns, &acc_path, "TABLE"),
+                    "schema": schema_facet,
+                    "dataQualityMetrics": accepted_dq_facet,
+                    "floeQualityRun": floe_facet
+                });
+
+                if !s.schema_fields.is_empty() {
+                    let fields_map: serde_json::Map<String, Value> = s
+                        .schema_fields
+                        .iter()
+                        .map(|col| {
+                            let src = col.source_field.as_deref().unwrap_or(&col.output_name);
+                            let entry = json!({
+                                "inputFields": [{
+                                    "namespace": self.config.namespace,
+                                    "dataset": format!("{name}_source"),
+                                    "field": src
+                                }]
+                            });
+                            (col.output_name.clone(), entry)
+                        })
+                        .collect();
+                    accepted_facets["columnLineage"] = json!({
+                        "fields": fields_map,
+                        "_producer": self.producer(),
+                        "_schemaURL": "https://openlineage.io/spec/facets/1-1-1/ColumnLineageDatasetFacet.json"
+                    });
+                }
+
                 let mut out = vec![json!({
                     "namespace": self.config.namespace,
                     "name": name,
-                    "facets": {
-                        "symlinks": symlinks_facet(self.producer(), &acc_ns, &acc_path, "TABLE"),
-                        "schema": schema_facet,
-                        "dataQualityMetrics": accepted_dq_facet,
-                        "floeQualityRun": floe_facet
-                    }
+                    "facets": accepted_facets
                 })];
 
                 // Rejected output (when configured): DIRECTORY type, rejected-row quality metrics.
@@ -322,7 +379,7 @@ struct EntityStats {
     rejected: u64,
     warnings: u64,
     errors: u64,
-    schema_fields: Vec<(String, String)>,
+    schema_fields: Vec<ColumnMapping>,
 }
 
 fn ms_to_iso8601(ms: u128) -> String {
@@ -388,7 +445,7 @@ impl RunObserver for OpenLineageObserver {
                     },
                     "job": {
                         "namespace": self.config.namespace,
-                        "name": run_id,
+                        "name": self.run_job_name,
                         "facets": {}
                     },
                     "inputs": [],
@@ -483,7 +540,7 @@ impl RunObserver for OpenLineageObserver {
                     },
                     "job": {
                         "namespace": self.config.namespace,
-                        "name": run_id,
+                        "name": self.run_job_name,
                         "facets": {}
                     },
                     "inputs": [],
@@ -501,8 +558,9 @@ impl RunObserver for OpenLineageObserver {
 pub fn build_observer(
     config: &LineageConfig,
     entities: &[EntityConfig],
+    config_path: &str,
 ) -> crate::FloeResult<Arc<dyn RunObserver>> {
-    let obs = OpenLineageObserver::new(config, entities)?;
+    let obs = OpenLineageObserver::new(config, entities, config_path)?;
     Ok(Arc::new(obs))
 }
 

--- a/crates/floe-core/src/lineage/mod.rs
+++ b/crates/floe-core/src/lineage/mod.rs
@@ -306,7 +306,7 @@ impl OpenLineageObserver {
                             let entry = json!({
                                 "inputFields": [{
                                     "namespace": format!("{}.source", self.config.namespace),
-                                    "dataset": name,
+                                    "name": name,
                                     "field": src
                                 }]
                             });

--- a/crates/floe-core/tests/unit/config/lineage_validation.rs
+++ b/crates/floe-core/tests/unit/config/lineage_validation.rs
@@ -185,6 +185,7 @@ entities:
         timeout_secs: Some(2),
         producer: None,
         max_failures: None,
+        job_name: None,
     };
     let config = load_config_with_profile_overrides(
         &path,

--- a/crates/floe-core/tests/unit/run/lineage.rs
+++ b/crates/floe-core/tests/unit/run/lineage.rs
@@ -1,6 +1,6 @@
 use floe_core::config::{
-    EntityConfig, IncrementalMode, LineageConfig, PolicyConfig, PolicySeverity, SchemaConfig,
-    SinkConfig, SinkTarget, SourceConfig, WriteMode,
+    ColumnConfig, EntityConfig, IncrementalMode, LineageConfig, PolicyConfig, PolicySeverity,
+    SchemaConfig, SinkConfig, SinkTarget, SourceConfig, WriteMode,
 };
 use floe_core::lineage::OpenLineageObserver;
 use floe_core::run::events::{RunEvent, RunObserver};
@@ -14,6 +14,7 @@ fn make_config(server_url: &str, max_failures: Option<u32>) -> LineageConfig {
         namespace: "test-ns".to_string(),
         producer: None,
         max_failures,
+        job_name: None,
     }
 }
 
@@ -48,7 +49,7 @@ fn circuit_opens_after_threshold() {
         .create();
 
     let config = make_config(&server.url(), Some(1));
-    let obs = OpenLineageObserver::new(&config, &[]).unwrap();
+    let obs = OpenLineageObserver::new(&config, &[], "config.yml").unwrap();
 
     // RunStarted: resets circuit state, then POSTs once → all 3 retries fail → circuit opens.
     obs.on_event(run_started_event());
@@ -76,7 +77,7 @@ fn success_resets_failure_counter() {
         .create();
 
     let config = make_config(&server.url(), Some(3));
-    let obs = OpenLineageObserver::new(&config, &[]).unwrap();
+    let obs = OpenLineageObserver::new(&config, &[], "config.yml").unwrap();
 
     obs.on_event(run_started_event());
     obs.on_event(entity_started_event());
@@ -104,7 +105,7 @@ fn non_retryable_error_counts_without_retry() {
         .create();
 
     let config = make_config(&server.url(), Some(3));
-    let obs = OpenLineageObserver::new(&config, &[]).unwrap();
+    let obs = OpenLineageObserver::new(&config, &[], "config.yml").unwrap();
 
     obs.on_event(run_started_event());
 
@@ -128,7 +129,7 @@ fn rate_limit_response_is_retried() {
         .create();
 
     let config = make_config(&server.url(), Some(5));
-    let obs = OpenLineageObserver::new(&config, &[]).unwrap();
+    let obs = OpenLineageObserver::new(&config, &[], "config.yml").unwrap();
 
     obs.on_event(run_started_event());
 
@@ -149,7 +150,7 @@ fn circuit_stays_closed_after_recovery() {
         .create();
 
     let config = make_config(&server.url(), Some(3));
-    let obs = OpenLineageObserver::new(&config, &[]).unwrap();
+    let obs = OpenLineageObserver::new(&config, &[], "config.yml").unwrap();
 
     obs.on_event(run_started_event());
     assert_eq!(obs.consecutive_failures(), 1);
@@ -277,7 +278,7 @@ fn entity_complete_event_has_source_input_and_accepted_output() {
 
     let entity = make_entity("orders", "/data/in/", "/data/out/", None);
     let config = make_config(&server.url(), None);
-    let obs = OpenLineageObserver::new(&config, &[entity]).unwrap();
+    let obs = OpenLineageObserver::new(&config, &[entity], "config.yml").unwrap();
 
     obs.on_event(entity_started_event());
     obs.on_event(entity_finished_event("orders", "success"));
@@ -315,7 +316,7 @@ fn entity_complete_event_includes_rejected_output_when_configured() {
 
     let entity = make_entity("orders", "/data/in/", "/data/out/", Some("/data/rejected/"));
     let config = make_config(&server.url(), None);
-    let obs = OpenLineageObserver::new(&config, &[entity]).unwrap();
+    let obs = OpenLineageObserver::new(&config, &[entity], "config.yml").unwrap();
 
     obs.on_event(entity_started_event());
     obs.on_event(entity_finished_event("orders", "success"));
@@ -355,7 +356,7 @@ fn source_dataset_has_symlinks_with_directory_type() {
 
     let entity = make_entity("orders", "/data/in/", "/data/out/", None);
     let config = make_config(&server.url(), None);
-    let obs = OpenLineageObserver::new(&config, &[entity]).unwrap();
+    let obs = OpenLineageObserver::new(&config, &[entity], "config.yml").unwrap();
 
     obs.on_event(entity_started_event());
     obs.on_event(entity_finished_event("orders", "success"));
@@ -394,7 +395,7 @@ fn accepted_dataset_has_symlinks_with_table_type() {
 
     let entity = make_entity("orders", "/data/in/", "/data/out/", None);
     let config = make_config(&server.url(), None);
-    let obs = OpenLineageObserver::new(&config, &[entity]).unwrap();
+    let obs = OpenLineageObserver::new(&config, &[entity], "config.yml").unwrap();
 
     obs.on_event(entity_started_event());
     obs.on_event(entity_finished_event("orders", "success"));
@@ -426,7 +427,7 @@ fn accepted_dataset_has_schema_facet() {
 
     let entity = make_entity("orders", "/data/in/", "/data/out/", None);
     let config = make_config(&server.url(), None);
-    let obs = OpenLineageObserver::new(&config, &[entity]).unwrap();
+    let obs = OpenLineageObserver::new(&config, &[entity], "config.yml").unwrap();
 
     obs.on_event(entity_started_event());
     obs.on_event(entity_finished_event("orders", "success"));
@@ -468,7 +469,7 @@ fn accepted_dq_reflects_accepted_rows_only() {
 
     let entity = make_entity("orders", "/data/in/", "/data/out/", None);
     let config = make_config(&server.url(), None);
-    let obs = OpenLineageObserver::new(&config, &[entity]).unwrap();
+    let obs = OpenLineageObserver::new(&config, &[entity], "config.yml").unwrap();
 
     obs.on_event(entity_started_event());
     obs.on_event(entity_finished_event("orders", "success"));
@@ -514,7 +515,7 @@ fn rejected_dq_reflects_rejected_rows_only() {
 
     let entity = make_entity("orders", "/data/in/", "/data/out/", Some("/data/rejected/"));
     let config = make_config(&server.url(), None);
-    let obs = OpenLineageObserver::new(&config, &[entity]).unwrap();
+    let obs = OpenLineageObserver::new(&config, &[entity], "config.yml").unwrap();
 
     obs.on_event(entity_started_event());
     obs.on_event(entity_finished_event("orders", "success"));
@@ -570,7 +571,7 @@ fn floe_quality_run_has_no_accepted_rejected_keys() {
 
     let entity = make_entity("orders", "/data/in/", "/data/out/", None);
     let config = make_config(&server.url(), None);
-    let obs = OpenLineageObserver::new(&config, &[entity]).unwrap();
+    let obs = OpenLineageObserver::new(&config, &[entity], "config.yml").unwrap();
 
     obs.on_event(entity_started_event());
     obs.on_event(entity_finished_event("orders", "success"));
@@ -620,7 +621,7 @@ fn split_storage_uri_s3() {
         None,
     );
     let config = make_config(&server.url(), None);
-    let obs = OpenLineageObserver::new(&config, &[entity]).unwrap();
+    let obs = OpenLineageObserver::new(&config, &[entity], "config.yml").unwrap();
 
     obs.on_event(entity_started_event());
     obs.on_event(entity_finished_event("orders", "success"));
@@ -669,7 +670,7 @@ fn split_storage_uri_adls() {
         None,
     );
     let config = make_config(&server.url(), None);
-    let obs = OpenLineageObserver::new(&config, &[entity]).unwrap();
+    let obs = OpenLineageObserver::new(&config, &[entity], "config.yml").unwrap();
 
     obs.on_event(entity_started_event());
     obs.on_event(entity_finished_event("orders", "success"));
@@ -718,7 +719,160 @@ fn split_storage_uri_abfs_preserved() {
         None,
     );
     let config = make_config(&server.url(), None);
-    let obs = OpenLineageObserver::new(&config, &[entity]).unwrap();
+    let obs = OpenLineageObserver::new(&config, &[entity], "config.yml").unwrap();
+
+    obs.on_event(entity_started_event());
+    obs.on_event(entity_finished_event("orders", "success"));
+
+    _start_mock.assert();
+    _complete_mock.assert();
+}
+
+// RunStarted uses the config file stem as a stable job name, not the run UUID.
+#[test]
+fn run_started_uses_stable_job_name_derived_from_config_path() {
+    let mut server = mockito::Server::new();
+
+    let _mock = server
+        .mock("POST", "/api/v1/lineage")
+        .match_body(mockito::Matcher::PartialJson(json!({
+            "eventType": "START",
+            "job": { "namespace": "test-ns", "name": "orders" }
+        })))
+        .with_status(200)
+        .expect(1)
+        .create();
+
+    let config = make_config(&server.url(), None);
+    let obs = OpenLineageObserver::new(&config, &[], "pipelines/orders.yml").unwrap();
+
+    obs.on_event(run_started_event());
+    _mock.assert();
+}
+
+// lineage.job_name overrides the config-path-derived stable name.
+#[test]
+fn run_job_name_override_via_config_field() {
+    let mut server = mockito::Server::new();
+
+    let _mock = server
+        .mock("POST", "/api/v1/lineage")
+        .match_body(mockito::Matcher::PartialJson(json!({
+            "eventType": "START",
+            "job": { "namespace": "test-ns", "name": "my-pipeline" }
+        })))
+        .with_status(200)
+        .expect(1)
+        .create();
+
+    let mut config = make_config(&server.url(), None);
+    config.job_name = Some("my-pipeline".to_string());
+    let obs = OpenLineageObserver::new(&config, &[], "orders.yml").unwrap();
+
+    obs.on_event(run_started_event());
+    _mock.assert();
+}
+
+fn make_column(name: &str, column_type: &str, source: Option<&str>) -> ColumnConfig {
+    ColumnConfig {
+        name: name.to_string(),
+        source: source.map(|s| s.to_string()),
+        column_type: column_type.to_string(),
+        nullable: None,
+        unique: None,
+        width: None,
+        trim: None,
+    }
+}
+
+// columnLineage facet maps each output column to itself when no explicit source field is set.
+#[test]
+fn accepted_dataset_has_column_lineage_facet() {
+    let mut server = mockito::Server::new();
+
+    let _start_mock = server
+        .mock("POST", "/api/v1/lineage")
+        .with_status(200)
+        .expect(1)
+        .create();
+
+    let _complete_mock = server
+        .mock("POST", "/api/v1/lineage")
+        .match_body(mockito::Matcher::PartialJson(json!({
+            "eventType": "COMPLETE",
+            "outputs": [{
+                "name": "orders",
+                "facets": {
+                    "columnLineage": {
+                        "fields": {
+                            "order_id": {
+                                "inputFields": [{
+                                    "namespace": "test-ns",
+                                    "dataset": "orders_source",
+                                    "field": "order_id"
+                                }]
+                            }
+                        }
+                    }
+                }
+            }]
+        })))
+        .with_status(200)
+        .expect(1)
+        .create();
+
+    let mut entity = make_entity("orders", "/data/in/", "/data/out/", None);
+    entity.schema.columns = vec![make_column("order_id", "string", None)];
+    let config = make_config(&server.url(), None);
+    let obs = OpenLineageObserver::new(&config, &[entity], "config.yml").unwrap();
+
+    obs.on_event(entity_started_event());
+    obs.on_event(entity_finished_event("orders", "success"));
+
+    _start_mock.assert();
+    _complete_mock.assert();
+}
+
+// columnLineage facet uses the source field when set instead of the output column name.
+#[test]
+fn column_lineage_uses_source_field_when_set() {
+    let mut server = mockito::Server::new();
+
+    let _start_mock = server
+        .mock("POST", "/api/v1/lineage")
+        .with_status(200)
+        .expect(1)
+        .create();
+
+    let _complete_mock = server
+        .mock("POST", "/api/v1/lineage")
+        .match_body(mockito::Matcher::PartialJson(json!({
+            "eventType": "COMPLETE",
+            "outputs": [{
+                "name": "orders",
+                "facets": {
+                    "columnLineage": {
+                        "fields": {
+                            "amount": {
+                                "inputFields": [{
+                                    "namespace": "test-ns",
+                                    "dataset": "orders_source",
+                                    "field": "raw_amt"
+                                }]
+                            }
+                        }
+                    }
+                }
+            }]
+        })))
+        .with_status(200)
+        .expect(1)
+        .create();
+
+    let mut entity = make_entity("orders", "/data/in/", "/data/out/", None);
+    entity.schema.columns = vec![make_column("amount", "float64", Some("raw_amt"))];
+    let config = make_config(&server.url(), None);
+    let obs = OpenLineageObserver::new(&config, &[entity], "config.yml").unwrap();
 
     obs.on_event(entity_started_event());
     obs.on_event(entity_finished_event("orders", "success"));
@@ -741,7 +895,7 @@ fn circuit_resets_on_new_run_started() {
         .create();
 
     let config = make_config(&server.url(), Some(1));
-    let obs = OpenLineageObserver::new(&config, &[]).unwrap();
+    let obs = OpenLineageObserver::new(&config, &[], "config.yml").unwrap();
 
     obs.on_event(run_started_event());
     assert!(obs.is_circuit_open());

--- a/crates/floe-core/tests/unit/run/lineage.rs
+++ b/crates/floe-core/tests/unit/run/lineage.rs
@@ -808,7 +808,7 @@ fn accepted_dataset_has_column_lineage_facet() {
                             "order_id": {
                                 "inputFields": [{
                                     "namespace": "test-ns.source",
-                                    "dataset": "orders",
+                                    "name": "orders",
                                     "field": "order_id"
                                 }]
                             }
@@ -856,7 +856,7 @@ fn column_lineage_uses_source_field_when_set() {
                             "amount": {
                                 "inputFields": [{
                                     "namespace": "test-ns.source",
-                                    "dataset": "orders",
+                                    "name": "orders",
                                     "field": "raw_amt"
                                 }]
                             }

--- a/crates/floe-core/tests/unit/run/lineage.rs
+++ b/crates/floe-core/tests/unit/run/lineage.rs
@@ -807,8 +807,8 @@ fn accepted_dataset_has_column_lineage_facet() {
                         "fields": {
                             "order_id": {
                                 "inputFields": [{
-                                    "namespace": "test-ns",
-                                    "dataset": "orders_source",
+                                    "namespace": "test-ns.source",
+                                    "dataset": "orders",
                                     "field": "order_id"
                                 }]
                             }
@@ -855,8 +855,8 @@ fn column_lineage_uses_source_field_when_set() {
                         "fields": {
                             "amount": {
                                 "inputFields": [{
-                                    "namespace": "test-ns",
-                                    "dataset": "orders_source",
+                                    "namespace": "test-ns.source",
+                                    "dataset": "orders",
                                     "field": "raw_amt"
                                 }]
                             }

--- a/docs/lineage.md
+++ b/docs/lineage.md
@@ -15,16 +15,18 @@ lineage:
   api_key: "{{OPENLINEAGE_API_KEY}}"   # optional — Bearer token
   timeout_secs: 5                       # optional, default 5
   producer: "https://github.com/myorg/floe"  # optional
+  job_name: "orders_ingestion"          # optional
 ```
 
-| Field            | Required | Description                                                          |
-|------------------|----------|----------------------------------------------------------------------|
-| `url`            | yes      | Base URL of the OpenLineage-compatible endpoint                      |
-| `namespace`      | yes      | OpenLineage namespace used for all jobs and datasets in this run     |
-| `api_key`        | no       | Bearer token sent in the `Authorization` header                      |
-| `timeout_secs`   | no       | HTTP request timeout in seconds (default: `5`)                       |
-| `producer`       | no       | URI identifying this producer (default: the Floe GitHub URL)        |
-| `max_failures`   | no       | Consecutive failures before the circuit opens (default: `3`)        |
+| Field          | Required | Description |
+|----------------|----------|-------------|
+| `url`          | yes      | Base URL of the OpenLineage-compatible endpoint |
+| `namespace`    | yes      | OpenLineage namespace used for all jobs and datasets in this run |
+| `api_key`      | no       | Bearer token sent in the `Authorization` header |
+| `timeout_secs` | no       | HTTP request timeout in seconds (default: `5`) |
+| `producer`     | no       | URI identifying this producer. Defaults to the versioned release URL for the current build (e.g. `https://github.com/malon64/floe/releases/tag/v0.4.2`). |
+| `max_failures` | no       | Consecutive failures before the circuit opens (default: `3`) |
+| `job_name`     | no       | Stable OpenLineage job name for top-level `RunStarted`/`RunFinished` events. Defaults to the config file stem (e.g. `orders.yml` → `orders`), fallback `floe-run`. Use this to group multiple runs under the same Marquez job node. |
 
 `api_key` supports `{{VAR}}` placeholder expansion via the same profile and
 env-vars mechanism used for the rest of the config.

--- a/orchestrators/dagster-floe/src/floe_dagster/assets.py
+++ b/orchestrators/dagster-floe/src/floe_dagster/assets.py
@@ -186,6 +186,7 @@ def _make_entity_multi_asset(
         run_id = getattr(run, "run_id", None) if run is not None else None
         if run_id is None:
             run_id = getattr(context, "run_id", None)
+        dagster_job_name = getattr(run, "job_name", None) if run is not None else None
         result = runner.run_floe_entity(
             config_uri=config_uri,
             manifest_uri=manifest_path,
@@ -194,6 +195,7 @@ def _make_entity_multi_asset(
             log_format=execution.log_format,
             execution=execution,
             runner_definition=runner_definition,
+            dagster_job_name=dagster_job_name,
         )
 
         if result.stderr.strip():

--- a/orchestrators/dagster-floe/src/floe_dagster/runner.py
+++ b/orchestrators/dagster-floe/src/floe_dagster/runner.py
@@ -29,6 +29,7 @@ class Runner:
         execution: ManifestExecution | None = None,
         runner_definition: ManifestRunnerDefinition | None = None,
         manifest_uri: str | None = None,
+        dagster_job_name: str | None = None,
     ) -> RunResult:
         raise NotImplementedError
 
@@ -46,6 +47,7 @@ class LocalRunner(Runner):
         execution: ManifestExecution | None = None,
         runner_definition: ManifestRunnerDefinition | None = None,
         manifest_uri: str | None = None,
+        dagster_job_name: str | None = None,
     ) -> RunResult:
         if runner_definition is not None and runner_definition.runner_type == "kubernetes_job":
             if execution is None:
@@ -120,17 +122,20 @@ class LocalRunner(Runner):
             args.extend(["--log-format", log_format])
             cwd = None
             env_overrides = None
-        return _run(args, cwd=cwd, env_overrides=env_overrides)
+        return _run(args, cwd=cwd, env_overrides=env_overrides, dagster_job_name=dagster_job_name)
 
 
 def _run(
     args: list[str],
     cwd: str | None = None,
     env_overrides: dict[str, str] | None = None,
+    dagster_job_name: str | None = None,
 ) -> RunResult:
     env = os.environ.copy()
     if env_overrides:
         env.update(env_overrides)
+    if dagster_job_name:
+        env["DAGSTER_JOB_NAME"] = dagster_job_name
     proc = subprocess.run(
         args,
         cwd=cwd,

--- a/orchestrators/dagster-floe/tests/test_asset_checks.py
+++ b/orchestrators/dagster-floe/tests/test_asset_checks.py
@@ -25,8 +25,9 @@ class _StaticRunner(Runner):
         execution=None,
         runner_definition=None,
         manifest_uri: str | None = None,
+        dagster_job_name: str | None = None,
     ) -> RunResult:
-        del config_uri, run_id, entity, log_format, execution, runner_definition, manifest_uri
+        del config_uri, run_id, entity, log_format, execution, runner_definition, manifest_uri, dagster_job_name
         return self._result
 
 

--- a/orchestrators/dagster-floe/tests/test_assets_manifest.py
+++ b/orchestrators/dagster-floe/tests/test_assets_manifest.py
@@ -26,8 +26,9 @@ class _NoopRunner(Runner):
         execution=None,
         runner_definition=None,
         manifest_uri: str | None = None,
+        dagster_job_name: str | None = None,
     ) -> RunResult:
-        del config_uri, run_id, entity, log_format, execution, runner_definition, manifest_uri
+        del config_uri, run_id, entity, log_format, execution, runner_definition, manifest_uri, dagster_job_name
         return RunResult(stdout="", stderr="", exit_code=0)
 
 

--- a/orchestrators/dagster-floe/tests/test_definitions.py
+++ b/orchestrators/dagster-floe/tests/test_definitions.py
@@ -21,8 +21,9 @@ class _NoopRunner(Runner):
         execution=None,
         runner_definition=None,
         manifest_uri: str | None = None,
+        dagster_job_name: str | None = None,
     ) -> RunResult:
-        del config_uri, run_id, entity, log_format, execution, runner_definition, manifest_uri
+        del config_uri, run_id, entity, log_format, execution, runner_definition, manifest_uri, dagster_job_name
         return RunResult(stdout="", stderr="", exit_code=0)
 
 

--- a/orchestrators/dagster-floe/tests/test_runner_defaults.py
+++ b/orchestrators/dagster-floe/tests/test_runner_defaults.py
@@ -29,7 +29,7 @@ def _execution(*, env: dict[str, str], workdir: str | None) -> ManifestExecution
 def test_local_runner_applies_execution_defaults(monkeypatch, tmp_path: Path) -> None:
     captured: dict[str, object] = {}
 
-    def fake_run(args, cwd=None, env_overrides=None):
+    def fake_run(args, cwd=None, env_overrides=None, dagster_job_name=None):
         captured["args"] = args
         captured["cwd"] = cwd
         captured["env_overrides"] = env_overrides
@@ -57,7 +57,7 @@ def test_local_runner_applies_execution_defaults(monkeypatch, tmp_path: Path) ->
 def test_local_runner_without_execution_keeps_default_process_context(monkeypatch) -> None:
     captured: dict[str, object] = {}
 
-    def fake_run(args, cwd=None, env_overrides=None):
+    def fake_run(args, cwd=None, env_overrides=None, dagster_job_name=None):
         captured["args"] = args
         captured["cwd"] = cwd
         captured["env_overrides"] = env_overrides


### PR DESCRIPTION
## Summary

Fixes four related lineage issues in a single PR:

- **#335** — Top-level `RunStarted`/`RunFinished` events now use a stable job name derived from the config file stem (e.g. `orders.yml` → `orders`) instead of the run UUID. Eliminates the per-run Marquez job node explosion. Optional `lineage.job_name` config field allows explicit override.
- **#336** — `dagster-floe` runner now extracts `context.run.job_name` and injects `DAGSTER_JOB_NAME` into the floe subprocess env, so the OpenLineage `ParentRun` facet carries the correct Dagster job name instead of an empty string.
- **#337** — Accepted output datasets in entity `COMPLETE`/`FAIL` events now carry a `ColumnLineageDatasetFacet` mapping each output column to its source column (using `schema.columns[].source` when set, identity mapping otherwise).
- **#338** — `_producer` URI now defaults to the versioned release URL (`https://github.com/malon64/floe/releases/tag/v<version>`) compiled in via `env!("CARGO_PKG_VERSION")` instead of the bare repo root URL.

## Files changed

| File | Issues |
|------|--------|
| `crates/floe-core/src/lineage/mod.rs` | #335, #337, #338 |
| `crates/floe-core/src/config/types.rs` | #335 |
| `crates/floe-core/src/config/parse.rs` | #335 |
| `crates/floe-cli/src/main.rs` | #335 (call site) |
| `crates/floe-core/tests/unit/run/lineage.rs` | #335, #337 (4 new tests) |
| `crates/floe-core/tests/unit/config/lineage_validation.rs` | #335 (struct update) |
| `orchestrators/dagster-floe/src/floe_dagster/runner.py` | #336 |
| `orchestrators/dagster-floe/src/floe_dagster/assets.py` | #336 |
| `docs/lineage.md` | #335, #338 |

## Test plan

- [x] `cargo fmt --all` — clean
- [x] `cargo clippy -p floe-core -p floe-cli -p floe-python -- -D warnings` — 0 warnings
- [x] `cargo test -p floe-core` — 512 passed, 0 failed (21 new tests including 4 new lineage tests)
- [x] `cd orchestrators/dagster-floe && uv run pytest tests/ -v` — 82 passed, 1 skipped, 0 failed

Closes #335
Closes #336
Closes #337
Closes #338