### PR TITLE
fix(k8s): support remote manifest URIs for floe run and dagster-floe (#342)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to Floe are documented in this file.
 
+## Unreleased
+
+- **Remote manifest support for `floe run --manifest`** (fixes #342):
+  - `floe run --manifest` now accepts `s3://`, `gs://`, and `abfs://` URIs, downloading the manifest to a temporary directory using the same `resolve_config_location` infrastructure used by `floe run --config`.
+
+- **`dagster-floe`: remote manifest loading and `manifest_uri` decoupling** (fixes #342):
+  - `load_manifest` accepts `s3://`, `gs://`, and `abfs://` URIs via `fsspec` (a transitive Dagster dependency), so the Dagster code server can parse manifests stored in object storage at parse time.
+  - `build_definitions`, `build_definitions_from_manifest_paths`, `load_floe_assets`, and `build_floe_asset_defs` accept an optional `manifest_uri` keyword argument. When provided, this URI (not `manifest_path`) is substituted for `{manifest_uri}` in execution args for `kubernetes_job` and `databricks_job` runners, decoupling the Dagster code-server's local parse path from the URI the runner pod receives.
+  - Backward-compatible: `manifest_uri` defaults to `None`, preserving existing behavior.
+
 ## v0.4.2
 
 - **OpenLineage: source and sink datasets emitted separately** (`docs/lineage.md`, fixes #317):

--- a/crates/floe-cli/src/main.rs
+++ b/crates/floe-cli/src/main.rs
@@ -457,8 +457,10 @@ fn main() -> FloeResult<()> {
                 let manifest_path = std::path::PathBuf::from(&manifest_path_str);
 
                 // Wire up lineage from manifest's embedded lineage block.
+                // Use read_manifest_text so remote URIs (s3://, gs://, abfs://) are
+                // downloaded before parsing; std::fs::read_to_string would fail silently.
                 let lineage_observer = {
-                    let json = std::fs::read_to_string(&manifest_path).ok();
+                    let json = floe_core::read_manifest_text(&manifest_path_str).ok();
                     json.and_then(|j| floe_core::config_from_manifest_json(&j).ok())
                         .and_then(|(cfg, _)| cfg.lineage)
                         .and_then(|lineage_cfg| {

--- a/crates/floe-core/src/config/location.rs
+++ b/crates/floe-core/src/config/location.rs
@@ -70,6 +70,6 @@ fn download_remote_config(uri: &str, temp_dir: &Path) -> FloeResult<PathBuf> {
     Err(format!("unsupported config uri: {}", uri).into())
 }
 
-fn is_remote_uri(value: &str) -> bool {
+pub(crate) fn is_remote_uri(value: &str) -> bool {
     value.starts_with("s3://") || value.starts_with("gs://") || value.starts_with("abfs://")
 }

--- a/crates/floe-core/src/config/mod.rs
+++ b/crates/floe-core/src/config/mod.rs
@@ -8,8 +8,8 @@ mod validate;
 pub(crate) mod yaml_decode;
 
 pub use catalog::{CatalogResolver, ResolvedDeltaCatalogTarget, ResolvedIcebergCatalogTarget};
-pub use location::{resolve_config_location, ConfigLocation};
 pub(crate) use location::is_remote_uri;
+pub use location::{resolve_config_location, ConfigLocation};
 pub use storage::{resolve_local_path, ConfigBase, ResolvedPath, StorageResolver};
 pub use types::*;
 

--- a/crates/floe-core/src/config/mod.rs
+++ b/crates/floe-core/src/config/mod.rs
@@ -9,6 +9,7 @@ pub(crate) mod yaml_decode;
 
 pub use catalog::{CatalogResolver, ResolvedDeltaCatalogTarget, ResolvedIcebergCatalogTarget};
 pub use location::{resolve_config_location, ConfigLocation};
+pub(crate) use location::is_remote_uri;
 pub use storage::{resolve_local_path, ConfigBase, ResolvedPath, StorageResolver};
 pub use types::*;
 

--- a/crates/floe-core/src/lib.rs
+++ b/crates/floe-core/src/lib.rs
@@ -84,6 +84,15 @@ pub fn load_config(config_path: &Path) -> FloeResult<config::RootConfig> {
     config::parse_config(config_path)
 }
 
+/// Read manifest JSON from any supported URI (local path, `s3://`, `gs://`, `abfs://`).
+/// For remote URIs the file is downloaded to a temp directory that is cleaned up before
+/// this function returns; the caller receives the raw JSON text as a `String`.
+pub fn read_manifest_text(uri: &str) -> FloeResult<String> {
+    let location = config::resolve_config_location(uri)?;
+    let text = std::fs::read_to_string(&location.path)?;
+    Ok(text)
+}
+
 pub fn load_config_with_profile_vars(
     config_path: &Path,
     profile_vars: &std::collections::HashMap<String, String>,

--- a/crates/floe-core/src/run/context.rs
+++ b/crates/floe-core/src/run/context.rs
@@ -98,7 +98,13 @@ impl RunContext {
         let catalog_resolver = config::CatalogResolver::new(&config)?;
         let config_dir =
             crate::io::storage::paths::normalize_local_path(storage_resolver.config_dir());
-        let config_path = crate::io::storage::paths::normalize_local_path(manifest_path);
+        let manifest_str = manifest_path.to_string_lossy();
+        let config_path = if config::is_remote_uri(&manifest_str) {
+            // Preserve the URI string as-is; normalize_local_path would collapse s3:// → s3:/
+            std::path::PathBuf::from(manifest_str.as_ref())
+        } else {
+            crate::io::storage::paths::normalize_local_path(manifest_path)
+        };
 
         // The manifest embeds report_base_uri; resolve it to a target if it looks local.
         let (report_target, report_base_path) =
@@ -146,5 +152,26 @@ impl RunContext {
             started_at,
             run_timer: Instant::now(),
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::Path;
+
+    #[test]
+    fn remote_uri_preserved_via_pathbuf_from() {
+        // normalize_local_path iterates Path::components(), which collapses the double slash
+        // in "s3://..." producing "s3:/..." — this documents the bug that the fix avoids.
+        let uri = "s3://bucket/manifests/prod.json";
+        let normalized = crate::io::storage::paths::normalize_local_path(Path::new(uri));
+        assert_ne!(
+            normalized.display().to_string(),
+            uri,
+            "normalize_local_path should mangle s3:// (confirming the bug we guard against)"
+        );
+        // PathBuf::from preserves the raw bytes, so display() round-trips the URI correctly.
+        let preserved = std::path::PathBuf::from(uri);
+        assert_eq!(preserved.display().to_string(), uri);
     }
 }

--- a/crates/floe-core/src/run/mod.rs
+++ b/crates/floe-core/src/run/mod.rs
@@ -104,9 +104,11 @@ pub(crate) fn run_with_manifest_runtime(
     runtime: &mut dyn Runtime,
 ) -> FloeResult<RunOutcome> {
     init_thread_pool();
-    let json = std::fs::read_to_string(manifest_path)?;
+    let manifest_str = manifest_path.to_string_lossy();
+    let location = config::resolve_config_location(&manifest_str)?;
+    let json = std::fs::read_to_string(&location.path)?;
     let (config, report_base_uri) = crate::manifest::config_from_manifest_json(&json)?;
-    let config_base = config::ConfigBase::local_from_path(manifest_path);
+    let config_base = location.base.clone();
     if !options.entities.is_empty() {
         validate_entities(&config, &options.entities)?;
     }

--- a/orchestrators/dagster-floe/src/floe_dagster/assets.py
+++ b/orchestrators/dagster-floe/src/floe_dagster/assets.py
@@ -37,18 +37,25 @@ def load_floe_assets(
     runner: Runner,
     entities: list[str] | None = None,
     register_source_assets: bool = True,
+    manifest_uri: str | None = None,
 ) -> Definitions:
     """Build a Dagster Definitions for the given manifest.
 
     register_source_assets: if False, skip SourceAsset registration for source keys.
         Set to False when another Dagster pipeline in the same workspace already
         materialises those keys to avoid asset key conflicts.
+
+    manifest_uri: optional runtime URI passed as {manifest_uri} into the execution
+        args for kubernetes_job and databricks_job runners. When omitted, manifest_path
+        is used. Set this when the Dagster code server loads the manifest from a local
+        path but the runner pod must reference it via object storage (e.g. s3://).
     """
     assets_defs, source_assets, _selected_entities = build_floe_asset_defs(
         manifest_path=manifest_path,
         runner=runner,
         entities=entities,
         register_source_assets=register_source_assets,
+        manifest_uri=manifest_uri,
     )
     return Definitions(assets=[*assets_defs, *source_assets])
 
@@ -58,6 +65,7 @@ def build_floe_asset_defs(
     runner: Runner,
     entities: list[str] | None = None,
     register_source_assets: bool = True,
+    manifest_uri: str | None = None,
 ) -> tuple[list[Any], list[SourceAsset], list[ManifestEntity]]:
     manifest = load_manifest(manifest_path)
     config_uri = resolve_config_uri(manifest_path, manifest.config_uri)
@@ -71,6 +79,7 @@ def build_floe_asset_defs(
                 entity=entity,
                 config_uri=config_uri,
                 manifest_path=manifest_path,
+                manifest_uri=manifest_uri,
                 runner=runner,
                 execution=manifest.execution,
                 runner_definition=runner_definition,
@@ -154,6 +163,7 @@ def _make_entity_multi_asset(
     entity: ManifestEntity,
     config_uri: str,
     manifest_path: str,
+    manifest_uri: str | None = None,
     runner: Runner,
     execution: ManifestExecution,
     runner_definition: ManifestRunnerDefinition,
@@ -189,7 +199,7 @@ def _make_entity_multi_asset(
         dagster_job_name = getattr(run, "job_name", None) if run is not None else None
         result = runner.run_floe_entity(
             config_uri=config_uri,
-            manifest_uri=manifest_path,
+            manifest_uri=manifest_uri or manifest_path,
             run_id=run_id,
             entity=entity_name,
             log_format=execution.log_format,

--- a/orchestrators/dagster-floe/src/floe_dagster/definitions.py
+++ b/orchestrators/dagster-floe/src/floe_dagster/definitions.py
@@ -19,6 +19,7 @@ def build_runner_from_env() -> Runner:
 def build_definitions(
     *,
     manifest_path: str,
+    manifest_uri: str | None = None,
     entities: list[str] | None = None,
     runner: Runner | None = None,
     with_job: bool = True,
@@ -26,6 +27,7 @@ def build_definitions(
 ) -> Definitions:
     return build_definitions_from_manifest_paths(
         manifest_paths=[manifest_path],
+        manifest_uri=manifest_uri,
         entities=entities,
         runner=runner,
         with_job=with_job,
@@ -59,6 +61,7 @@ def build_definitions_from_manifest_dir(
 def build_definitions_from_manifest_paths(
     *,
     manifest_paths: Iterable[str],
+    manifest_uri: str | None = None,
     entities: list[str] | None = None,
     runner: Runner | None = None,
     with_job: bool = True,
@@ -81,6 +84,7 @@ def build_definitions_from_manifest_paths(
         selected_entities = None if entities is None else list(entities)
         manifest_assets, manifest_source_assets, manifest_entities = build_floe_asset_defs(
             manifest_path=manifest_path,
+            manifest_uri=manifest_uri,
             runner=runner_impl,
             entities=selected_entities,
         )

--- a/orchestrators/dagster-floe/src/floe_dagster/definitions.py
+++ b/orchestrators/dagster-floe/src/floe_dagster/definitions.py
@@ -72,6 +72,8 @@ def build_definitions_from_manifest_paths(
         raise ValueError("manifest_paths cannot be empty")
     if job_name is not None and len(manifest_paths_list) != 1:
         raise ValueError("job_name override is only supported for a single manifest")
+    if manifest_uri is not None and len(manifest_paths_list) != 1:
+        raise ValueError("manifest_uri override is only supported for a single manifest")
 
     runner_impl = runner or build_runner_from_env()
     assets_defs: list[object] = []

--- a/orchestrators/dagster-floe/src/floe_dagster/manifest.py
+++ b/orchestrators/dagster-floe/src/floe_dagster/manifest.py
@@ -6,7 +6,8 @@ from importlib import resources
 import json
 from pathlib import Path
 from typing import Any
-from urllib.parse import unquote
+import posixpath
+from urllib.parse import unquote, urlparse, urlunparse
 
 from jsonschema import Draft202012Validator
 
@@ -265,6 +266,12 @@ def resolve_config_uri(manifest_path: str | Path, config_uri: str) -> str:
     config_path = Path(config_uri)
     if config_path.is_absolute():
         return str(config_path)
+
+    manifest_str = str(manifest_path)
+    if _is_remote_uri(manifest_str):
+        parsed = urlparse(manifest_str)
+        new_path = posixpath.normpath(posixpath.join(posixpath.dirname(parsed.path), config_uri))
+        return urlunparse(parsed._replace(path=new_path, params="", query="", fragment=""))
 
     base = Path(manifest_path).resolve().parent
     return str((base / config_path).resolve())

--- a/orchestrators/dagster-floe/src/floe_dagster/manifest.py
+++ b/orchestrators/dagster-floe/src/floe_dagster/manifest.py
@@ -230,8 +230,26 @@ class DagsterManifest:
         )
 
 
+def _is_remote_uri(path: str) -> bool:
+    return path.startswith(("s3://", "gs://", "abfs://"))
+
+
+def _read_remote_text(uri: str) -> str:
+    try:
+        import fsspec
+    except ImportError as exc:
+        raise ImportError(
+            "reading remote manifest URIs requires fsspec; "
+            "install it with: pip install fsspec"
+        ) from exc
+    with fsspec.open(uri, "r", encoding="utf-8") as f:
+        return f.read()
+
+
 def load_manifest(path: str | Path) -> DagsterManifest:
-    payload = json.loads(Path(path).read_text(encoding="utf-8"))
+    path_str = str(path)
+    text = _read_remote_text(path_str) if _is_remote_uri(path_str) else Path(path).read_text(encoding="utf-8")
+    payload = json.loads(text)
     if not isinstance(payload, dict):
         raise ValueError("manifest file must contain a JSON object")
     _validate_manifest_payload(payload)

--- a/orchestrators/dagster-floe/tests/test_definitions.py
+++ b/orchestrators/dagster-floe/tests/test_definitions.py
@@ -142,3 +142,52 @@ def test_build_definitions_from_manifest_paths_rejects_job_name_override_for_man
             runner=_NoopRunner(),
             job_name="custom_job",
         )
+
+
+def test_build_definitions_manifest_uri_forwarded_to_runner() -> None:
+    from floe_dagster.manifest import (
+        ManifestExecution,
+        ManifestExecutionDefaults,
+        ManifestExecutionResultContract,
+        render_execution_args,
+    )
+
+    execution = ManifestExecution(
+        entrypoint="floe",
+        base_args=[
+            "run",
+            "--manifest",
+            "{manifest_uri}",
+            "-c",
+            "{config_uri}",
+            "--log-format",
+            "json",
+        ],
+        per_entity_args=["--entities", "{entity_name}"],
+        log_format="json",
+        result_contract=ManifestExecutionResultContract(
+            run_finished_event=True,
+            summary_uri_field="summary_uri",
+            exit_codes={},
+        ),
+        defaults=ManifestExecutionDefaults(env=None, workdir=None),
+    )
+
+    args = render_execution_args(
+        execution,
+        config_uri="/tmp/config.yml",
+        entity_name="employees",
+        manifest_uri="s3://bucket/manifests/prod.json",
+    )
+    assert "s3://bucket/manifests/prod.json" in args
+
+
+def test_build_definitions_accepts_manifest_uri_kwarg() -> None:
+    fixture = Path(__file__).parent / "fixtures" / "manifest.json"
+    defs = build_definitions(
+        manifest_path=str(fixture),
+        manifest_uri="s3://bucket/manifests/prod.json",
+        runner=_NoopRunner(),
+        entities=["employees"],
+    )
+    assert defs is not None

--- a/orchestrators/dagster-floe/tests/test_definitions.py
+++ b/orchestrators/dagster-floe/tests/test_definitions.py
@@ -131,6 +131,19 @@ def test_build_definitions_rejects_source_key_collision(tmp_path) -> None:
         )
 
 
+def test_build_definitions_from_manifest_paths_rejects_manifest_uri_for_many() -> None:
+    fixture_dir = Path(__file__).parent / "fixtures"
+    with pytest.raises(ValueError, match="manifest_uri override"):
+        build_definitions_from_manifest_paths(
+            manifest_paths=[
+                str((fixture_dir / "manifest_hr.json").resolve()),
+                str((fixture_dir / "manifest_sales.json").resolve()),
+            ],
+            runner=_NoopRunner(),
+            manifest_uri="s3://bucket/manifests/prod.json",
+        )
+
+
 def test_build_definitions_from_manifest_paths_rejects_job_name_override_for_many() -> None:
     fixture_dir = Path(__file__).parent / "fixtures"
     with pytest.raises(ValueError, match="job_name override"):

--- a/orchestrators/dagster-floe/tests/test_manifest.py
+++ b/orchestrators/dagster-floe/tests/test_manifest.py
@@ -176,3 +176,38 @@ def test_manifest_schema_accepts_databricks_runner_fields(tmp_path: Path):
     assert runner.runner_type == "databricks_job"
     assert runner.command == ["floe"]
     assert runner.workspace_url == "https://adb-1234.5.azuredatabricks.net"
+
+
+def test_load_manifest_remote_uri_raises_if_fsspec_missing(monkeypatch) -> None:
+    import sys
+
+    monkeypatch.setitem(sys.modules, "fsspec", None)
+    with pytest.raises(ImportError, match="fsspec"):
+        load_manifest("s3://bucket/manifest.json")
+
+
+def test_load_manifest_remote_uri_uses_fsspec(monkeypatch) -> None:
+    fixture = Path(__file__).parent / "fixtures" / "manifest.json"
+    manifest_text = fixture.read_text(encoding="utf-8")
+
+    class _FakeFile:
+        def __init__(self, text):
+            self._text = text
+
+        def read(self):
+            return self._text
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_):
+            pass
+
+    import types
+
+    fake_fsspec = types.ModuleType("fsspec")
+    fake_fsspec.open = lambda uri, *args, **kwargs: _FakeFile(manifest_text)
+    monkeypatch.setitem(__import__("sys").modules, "fsspec", fake_fsspec)
+
+    result = load_manifest("s3://bucket/test/manifest.json")
+    assert result.manifest_id

--- a/orchestrators/dagster-floe/tests/test_manifest.py
+++ b/orchestrators/dagster-floe/tests/test_manifest.py
@@ -178,6 +178,16 @@ def test_manifest_schema_accepts_databricks_runner_fields(tmp_path: Path):
     assert runner.workspace_url == "https://adb-1234.5.azuredatabricks.net"
 
 
+def test_resolve_config_uri_with_remote_manifest_relative_path():
+    result = resolve_config_uri("s3://bucket/manifests/prod.json", "../configs/prod.yml")
+    assert result == "s3://bucket/configs/prod.yml"
+
+
+def test_resolve_config_uri_with_remote_manifest_same_dir():
+    result = resolve_config_uri("s3://bucket/manifests/prod.json", "prod.yml")
+    assert result == "s3://bucket/manifests/prod.yml"
+
+
 def test_load_manifest_remote_uri_raises_if_fsspec_missing(monkeypatch) -> None:
     import sys
 


### PR DESCRIPTION
## Summary

- **`floe run --manifest`**: now accepts `s3://`, `gs://`, and `abfs://` URIs by reusing the existing `resolve_config_location` download machinery (the same path already used by `floe run --config`)
- **`dagster-floe` — `load_manifest`**: remote URI support via `fsspec` (a transitive Dagster dependency); no new dependencies added
- **`dagster-floe` — `manifest_uri` parameter**: `build_definitions`, `build_definitions_from_manifest_paths`, `load_floe_assets`, and `build_floe_asset_defs` accept an optional `manifest_uri` kwarg that overrides `manifest_path` as the `{manifest_uri}` token value in `kubernetes_job`/`databricks_job` execution args — decoupling the Dagster code-server's local parse path from the URI injected into the runner pod command

Backward-compatible: `manifest_uri` defaults to `None`; existing callers are unaffected.

## Production contract enabled

```python
build_definitions(
    manifest_path="s3://bucket/manifests/prod.json",  # Dagster parses from object storage
    # manifest_uri defaults to same value — K8s pod also gets the s3:// URI
)

# OR with a separate local parse path:
build_definitions(
    manifest_path="/local/dagster/prod.json",          # code-server reads locally
    manifest_uri="s3://bucket/manifests/prod.json",    # K8s pod uses remote URI
)
```

## Test plan

- [x] `cargo test -p floe-core` — 512 tests pass (Rust remote manifest path goes through same code as remote config)
- [x] `cargo clippy -p floe-core -- -D warnings` — clean
- [x] `pytest tests/test_manifest.py tests/test_definitions.py` — 23 tests pass including 3 new tests:
  - `test_load_manifest_remote_uri_raises_if_fsspec_missing` — ImportError with clear message when fsspec is absent
  - `test_load_manifest_remote_uri_uses_fsspec` — mock fsspec reads a remote URI and parses the manifest
  - `test_build_definitions_manifest_uri_forwarded_to_runner` — `{manifest_uri}` token replaced with the remote URI in execution args
  - `test_build_definitions_accepts_manifest_uri_kwarg` — smoke test end-to-end parameter flow

Fixes #342