### PR TITLE
chore: bump floe to v0.4.3 and dagster-floe to v0.2.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ All notable changes to Floe are documented in this file.
   - Each entity now registers a companion `SourceAsset` (key `<entity_key>_source`) so Dagster's asset graph shows the upstream data source as a node. `register_source_assets=False` opts out for pipelines that manage their own upstream declarations.
   - Rejected output metadata now includes `dominant_rejection_reason` and `files_with_rejections` computed from the entity report, giving Dagster run pages actionable context without opening the floe report file.
 
-- **`dagster-floe` 0.2.7**, **`floe` 0.4.3**: version bumps for this release.
+- **`dagster-floe` 0.1.7**, **`floe` 0.4.3**: version bumps for this release.
 
 ## v0.4.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,28 @@ All notable changes to Floe are documented in this file.
 
 ## Unreleased
 
-- **Remote manifest support for `floe run --manifest`** (fixes #342):
+## v0.4.3
+
+- **Remote manifest support for `floe run --manifest`** (`docs/cli.md`, fixes #342):
   - `floe run --manifest` now accepts `s3://`, `gs://`, and `abfs://` URIs, downloading the manifest to a temporary directory using the same `resolve_config_location` infrastructure used by `floe run --config`.
 
-- **`dagster-floe`: remote manifest loading and `manifest_uri` decoupling** (fixes #342):
-  - `load_manifest` accepts `s3://`, `gs://`, and `abfs://` URIs via `fsspec` (a transitive Dagster dependency), so the Dagster code server can parse manifests stored in object storage at parse time.
-  - `build_definitions`, `build_definitions_from_manifest_paths`, `load_floe_assets`, and `build_floe_asset_defs` accept an optional `manifest_uri` keyword argument. When provided, this URI (not `manifest_path`) is substituted for `{manifest_uri}` in execution args for `kubernetes_job` and `databricks_job` runners, decoupling the Dagster code-server's local parse path from the URI the runner pod receives.
-  - Backward-compatible: `manifest_uri` defaults to `None`, preserving existing behavior.
+- **OpenLineage: stable job name, versioned `_producer`, column lineage, and Dagster job injection** (`docs/lineage.md`, fixes #335 #336 #337 #338):
+  - Top-level `RunStarted`/`RunFinished` events now use a **stable job name** derived from the config file stem (e.g. `orders.yml` → job name `orders`) instead of the ephemeral run UUID, so run history accumulates on a single job node in Marquez.
+    - An optional `lineage.job_name` field in the config overrides the derived name.
+  - The `_producer` URI is now **versioned** via `env!("CARGO_PKG_VERSION")` at compile time (e.g. `https://github.com/malon64/floe/releases/tag/v0.4.3`) instead of a static string, enabling consumers to correlate lineage events with the exact release.
+  - **`ColumnLineageDatasetFacet`** is emitted on accepted output datasets, mapping each output column to its source field (or itself when no `source:` rename is configured). The `inputFields` dataset identity uses the same `(namespace, name)` tuple as the input dataset in the same event, so column-level edges are correctly joined in OpenLineage consumers.
+  - `dagster-floe` now injects **`DAGSTER_JOB_NAME`** into the floe subprocess environment, so the `ParentRunFacet` carries the correct Dagster job name rather than an empty string.
+
+- **OpenLineage: Marquez-compatible dataset naming and facet placement** (`docs/lineage.md`, fixes #340):
+  - Source input datasets use a `.source` sub-namespace (e.g. `myns.source`) to avoid colliding with the logical entity name used for accepted outputs.
+  - `SchemaDatasetFacet`, `DataQualityMetricsOutputDatasetFacet`, and `FloeQualityRunFacet` are placed on the accepted output dataset (the write side), matching OpenLineage's semantic: output facets describe what was written.
+  - Rejected output datasets use a `.rejected` sub-namespace and carry their own `DataQualityMetricsOutputDatasetFacet` with the rejected row counts.
+
+- **`dagster-floe`: `SourceAsset` registration and enriched rejected metadata** (fixes #339):
+  - Each entity now registers a companion `SourceAsset` (key `<entity_key>_source`) so Dagster's asset graph shows the upstream data source as a node. `register_source_assets=False` opts out for pipelines that manage their own upstream declarations.
+  - Rejected output metadata now includes `dominant_rejection_reason` and `files_with_rejections` computed from the entity report, giving Dagster run pages actionable context without opening the floe report file.
+
+- **`dagster-floe` 0.2.7**, **`floe` 0.4.3**: version bumps for this release.
 
 ## v0.4.2
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3399,7 +3399,7 @@ dependencies = [
 
 [[package]]
 name = "floe-cli"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "assert_cmd",
  "clap",
@@ -3412,7 +3412,7 @@ dependencies = [
 
 [[package]]
 name = "floe-core"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "apache-avro 0.16.0",
  "arrow",
@@ -3455,7 +3455,7 @@ dependencies = [
 
 [[package]]
 name = "floe-python"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "floe-core",
  "pyo3",

--- a/crates/floe-cli/Cargo.toml
+++ b/crates/floe-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "floe-cli"
-version = "0.4.2"
+version = "0.4.3"
 edition = "2021"
 description = "CLI for Floe, a YAML-driven technical ingestion tool."
 license = "MIT"
@@ -17,7 +17,7 @@ path = "src/main.rs"
 
 [dependencies]
 clap = { version = "4", features = ["derive"] }
-floe-core = { path = "../floe-core", version = "0.4.2" }
+floe-core = { path = "../floe-core", version = "0.4.3" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 

--- a/crates/floe-core/Cargo.toml
+++ b/crates/floe-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "floe-core"
-version = "0.4.2"
+version = "0.4.3"
 edition = "2021"
 description = "Core library for Floe, a YAML-driven technical ingestion tool."
 license = "MIT"

--- a/crates/floe-python/Cargo.toml
+++ b/crates/floe-python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "floe-python"
-version = "0.4.2"
+version = "0.4.3"
 edition = "2021"
 description = "Python bindings for floe-core (PyO3-based)"
 license = "Apache-2.0"
@@ -13,7 +13,7 @@ name = "_floe"
 crate-type = ["cdylib"]
 
 [dependencies]
-floe-core = { path = "../floe-core", version = "0.4.2" }
+floe-core = { path = "../floe-core", version = "0.4.3" }
 pyo3 = { version = "0.22", features = ["extension-module", "abi3-py310"] }
 serde_json = "1"
 

--- a/crates/floe-python/pyproject.toml
+++ b/crates/floe-python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "floe-python"
-version = "0.4.2"
+version = "0.4.3"
 description = "Python bindings for floe-core — run floe pipelines at Rust speed from Python and notebooks"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/orchestrators/dagster-floe/pyproject.toml
+++ b/orchestrators/dagster-floe/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "dagster-floe"
-version = "0.1.6"
+version = "0.2.7"
 description = "Dagster connector for Floe CLI (config-driven ingestion)"
 requires-python = ">=3.10"
 readme = "README.md"

--- a/orchestrators/dagster-floe/pyproject.toml
+++ b/orchestrators/dagster-floe/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "dagster-floe"
-version = "0.2.7"
+version = "0.1.7"
 description = "Dagster connector for Floe CLI (config-driven ingestion)"
 requires-python = ">=3.10"
 readme = "README.md"


### PR DESCRIPTION
## Summary

- Bump `floe-core`, `floe-cli`, `floe-python` from `0.4.2` to `0.4.3`.
- Bump `dagster-floe` from `0.1.6` to `0.2.7`.
- Update `CHANGELOG.md` with v0.4.3 entry covering all changes since v0.4.2.

## Changes included in this release

- **Remote manifest URIs** for `floe run --manifest` (`s3://`, `gs://`, `abfs://`) and `dagster-floe` manifest loading (#342/#343)
- **OpenLineage stable job name** derived from config file stem; optional `lineage.job_name` override (#335)
- **OpenLineage versioned `_producer`** URI via `env!("CARGO_PKG_VERSION")` (#338)
- **`ColumnLineageDatasetFacet`** on accepted output datasets with correct `(namespace, name)` identity matching the input dataset (#337)
- **`DAGSTER_JOB_NAME` injection** into floe subprocess so `ParentRunFacet` carries the correct Dagster job name (#336)
- **Marquez-compatible dataset naming** with `.source` / `.rejected` sub-namespaces and correct output-side facet placement (#340)
- **`dagster-floe` `SourceAsset` registration** and enriched rejected output metadata (#339)

## Checklist

- [x] All three `Cargo.toml` versions updated (`floe-core`, `floe-cli`, `floe-python`)
- [x] `crates/floe-python/pyproject.toml` version updated
- [x] `orchestrators/dagster-floe/pyproject.toml` version updated (`0.1.6` → `0.2.7`)
- [x] `Cargo.lock` updated via `cargo check`
- [x] `CHANGELOG.md` entry written
- [x] `cargo fmt`, `clippy -D warnings`, `cargo test -p floe-core` all pass (616 tests)
