### PR TITLE
docs: add floe-python guide, manifest guide, and orchestrator connector updates

### DIFF
--- a/crates/floe-python/README.md
+++ b/crates/floe-python/README.md
@@ -70,6 +70,43 @@ except floe.FloeError as e:
 | `set_observer(callback)` | Register a live-event callback |
 | `clear_observer()` | Remove the current callback |
 
+## Jupyter
+
+`RunOutcome` renders as a color-coded HTML table automatically in Jupyter — no extra code needed. Just end a cell with the variable:
+
+```python
+outcome = floe.run("orders.yml")
+outcome  # renders inline HTML table with per-entity status, accepted/rejected counts
+```
+
+Use `outcome.to_dict()` to turn results into a plain dict for pandas:
+
+```python
+import pandas as pd
+df = pd.DataFrame(outcome.entity_reports)
+```
+
+## Observing progress
+
+Register a callback to receive live events as the run proceeds:
+
+```python
+floe.set_observer(lambda e: print(f"[{e['event']}]", e.get("name", e.get("entity", ""))))
+outcome = floe.run("orders.yml")
+floe.clear_observer()
+```
+
+Event types: `run_started`, `entity_started`, `file_started`, `file_finished`, `schema_evolution_applied`, `entity_finished`, `run_finished`, `log`. See the [full guide](../../docs/python-bindings.md#observing-runs-in-real-time) for all event fields.
+
+## Profile overrides
+
+Override config variables or cloud credentials without editing the YAML:
+
+```python
+floe.run("orders.yml", profile_vars={"incoming_root": "s3://my-bucket/incoming"})
+floe.run("orders.yml", profile_path="prod.yml")
+```
+
 ## Building from source
 
 ```bash
@@ -82,3 +119,7 @@ maturin develop
 ## License
 
 Apache 2.0
+
+---
+
+→ Full API reference and examples: [docs/python-bindings.md](../../docs/python-bindings.md)

--- a/docs/manifest.md
+++ b/docs/manifest.md
@@ -50,7 +50,7 @@ A manifest is a self-contained JSON document. Here's an annotated excerpt:
   // The exact CLI command the orchestrator must call
   "execution": {
     "entrypoint": "floe",
-    "base_args": ["run", "-c", "{config_uri}", "--log-format", "json", "--quiet"],
+    "base_args": ["run", "--manifest", "{manifest_uri}", "--log-format", "json", "--quiet"],
     "per_entity_args": ["--entities", "{entity_name}"],
     "log_format": "json",
     "result_contract": {
@@ -117,12 +117,12 @@ config.yml ──[floe manifest generate]──► orders.json
                   --log-format json
                │
                ▼
-       Orchestrator parses JSON logs (NDJSON on stderr)
+       Orchestrator parses JSON logs (NDJSON on stdout)
        → finds "run_finished" event → extracts summary_uri
        → loads run summary → publishes asset metadata
 ```
 
-The `{config_uri}`, `{entity_name}`, and `{run_id}` placeholders in `execution.base_args` and `per_entity_args` are rendered at run time by the orchestrator connector, not by floe itself.
+The `{manifest_uri}`, `{entity_name}`, and `{run_id}` placeholders in `execution.base_args` and `per_entity_args` are rendered at run time by the orchestrator connector, not by floe itself.
 
 ---
 

--- a/docs/manifest.md
+++ b/docs/manifest.md
@@ -134,11 +134,12 @@ Regenerate the manifest whenever you change:
 - source or sink paths
 - runner definitions or execution args
 
-A simple CI check that catches drift:
+A simple CI check that catches drift. Strip `generated_at_ts_ms` before comparing — it changes on every `generate` call regardless of config changes:
 
 ```bash
-floe manifest generate -c orders.yml -o - > /tmp/fresh.json
-diff <(jq -S . manifests/orders.json) <(jq -S . /tmp/fresh.json)
+diff \
+  <(jq -S 'del(.generated_at_ts_ms)' manifests/orders.json) \
+  <(floe manifest generate -c orders.yml -o - | jq -S 'del(.generated_at_ts_ms)')
 ```
 
 If the diff is non-empty, the committed manifest is stale. Commit manifests in the same PR as config changes so they're always in sync.

--- a/docs/manifest.md
+++ b/docs/manifest.md
@@ -1,0 +1,153 @@
+# Manifest Generation
+
+## Why manifests?
+
+Orchestrators like Dagster and Airflow build their job/DAG graphs *before* any data runs — at parse time. If they read your Floe YAML directly at that moment, they'd have to understand Floe's config format, resolve `{{variables}}`, infer entity names, and guess output paths — all before a single row moves. That's a lot of coupling for a scheduling layer.
+
+**Manifests decouple "what will run" from "when it runs."** You generate a manifest once (after editing your config), commit it alongside your code, and the orchestrator reads the static JSON at parse time. At run time it just calls `floe run --manifest` — no YAML parsing, no variable resolution, no guesswork.
+
+Think of it as: **"resolve everything now so the orchestrator can be dumb at runtime."**
+
+---
+
+## Generating a manifest
+
+```bash
+floe manifest generate -c orders.yml --output manifests/orders.json
+```
+
+Pipe to stdout for use in CI scripts:
+
+```bash
+floe manifest generate -c orders.yml -o - | jq '.entities[].name'
+```
+
+If your config uses profile variables (cloud paths, credentials), pass the profile at generation time to bake them in:
+
+```bash
+floe manifest generate -c orders.yml -p prod.yml --output manifests/orders.json
+```
+
+Only need a subset of entities? Use `--entities`:
+
+```bash
+floe manifest generate -c orders.yml --entities orders,returns --output manifests/orders.json
+```
+
+---
+
+## What's inside
+
+A manifest is a self-contained JSON document. Here's an annotated excerpt:
+
+```jsonc
+{
+  "schema": "floe.manifest.v1",          // version sentinel — never changes for v1
+  "manifest_id": "orders-2024",          // stable ID for tracking
+  "config_uri": "./orders.yml",          // where the source YAML lives
+  "report_base_uri": "./report",         // where run reports are written
+
+  // The exact CLI command the orchestrator must call
+  "execution": {
+    "entrypoint": "floe",
+    "base_args": ["run", "-c", "{config_uri}", "--log-format", "json", "--quiet"],
+    "per_entity_args": ["--entities", "{entity_name}"],
+    "log_format": "json",
+    "result_contract": {
+      "exit_codes": {
+        "0": "success_or_rejected",  // data ran; some rows may be in the rejected sink
+        "1": "technical_failure",    // floe crashed or config error
+        "2": "aborted"               // pipeline aborted by policy
+      }
+    }
+  },
+
+  // Runner definitions (local, kubernetes, databricks, etc.)
+  "runners": {
+    "default": "local",
+    "definitions": {
+      "local": { "type": "local_process" }
+    }
+  },
+
+  // One entry per entity — this is what orchestrators iterate over
+  "entities": [
+    {
+      "name": "orders",
+      "domain": "sales",
+      "asset_key": ["sales", "orders"],      // Dagster asset key
+      "group_name": "sales",                 // Dagster asset group
+      "source_format": "csv",
+      "accepted_sink_uri": "./out/accepted/orders",
+      "rejected_sink_uri": "./out/rejected/orders",
+      "schema": {
+        "columns": [
+          { "name": "order_id", "type": "string", "nullable": false },
+          { "name": "amount",   "type": "float64", "nullable": true }
+        ]
+      }
+      // ... source/sinks/policy/pii details also present
+    }
+  ]
+}
+```
+
+The full JSON Schema for the manifest format is at [`orchestrators/schemas/floe.manifest.v1.json`](../orchestrators/schemas/floe.manifest.v1.json).
+
+---
+
+## The orchestrator flow
+
+```
+config.yml ──[floe manifest generate]──► orders.json
+                                              │
+               ┌──────────────────────────────┘
+               │  Parse-time (DAG/job construction)
+               ▼
+       Orchestrator reads manifest
+       → registers one asset / task per entity
+       → knows output paths, schema, runner config
+               │
+               │  Run-time (when triggered)
+               ▼
+       For each entity, orchestrator calls:
+         floe run --manifest orders.json \
+                  --entities orders \
+                  --run-id $RUN_ID \
+                  --log-format json
+               │
+               ▼
+       Orchestrator parses JSON logs (NDJSON on stderr)
+       → finds "run_finished" event → extracts summary_uri
+       → loads run summary → publishes asset metadata
+```
+
+The `{config_uri}`, `{entity_name}`, and `{run_id}` placeholders in `execution.base_args` and `per_entity_args` are rendered at run time by the orchestrator connector, not by floe itself.
+
+---
+
+## Keeping manifests fresh
+
+Regenerate the manifest whenever you change:
+
+- entity names, domains, or schema
+- source or sink paths
+- runner definitions or execution args
+
+A simple CI check that catches drift:
+
+```bash
+floe manifest generate -c orders.yml -o - > /tmp/fresh.json
+diff <(jq -S . manifests/orders.json) <(jq -S . /tmp/fresh.json)
+```
+
+If the diff is non-empty, the committed manifest is stale. Commit manifests in the same PR as config changes so they're always in sync.
+
+---
+
+## See also
+
+- [CLI reference — `floe manifest generate`](cli.md)
+- [Dagster connector](../orchestrators/dagster-floe/README.md)
+- [Airflow connector](../orchestrators/airflow-floe/README.md)
+- [Full manifest JSON Schema](../orchestrators/schemas/floe.manifest.v1.json)

--- a/docs/python-bindings.md
+++ b/docs/python-bindings.md
@@ -53,17 +53,20 @@ outcome = floe.run("orders.yml")
 
 # Top-level summary
 summary = outcome.summary
-print(summary["results"]["status"])   # "Success" | "SuccessWithWarnings" | "Failure"
-print(summary["results"]["rows"])     # total rows scanned
-print(summary["results"]["accepted"]) # rows written to accepted sink
+print(summary["run"]["status"])              # "success" | "success_with_warnings" | "failed"
+print(summary["results"]["rows_total"])      # total rows scanned
+print(summary["results"]["accepted_total"])  # rows written to accepted sink
 
-# Per-entity breakdown
+# Per-entity status lives in summary["entities"], not entity_reports
+for entity in summary["entities"]:
+    print(entity["name"], entity["status"])  # "success" | "rejected" | "failed" | …
+
+# Per-entity detail reports (schema, file-level results, write metadata)
 for report in outcome.entity_reports:
-    name   = report["entity"]["name"]
-    status = report["entity"]["status"]
-    acc    = report["entity"]["accepted"]
-    rej    = report["entity"]["rejected"]
-    print(f"{name}: {acc} accepted, {rej} rejected ({status})")
+    name = report["entity"]["name"]
+    acc  = report["results"]["accepted_total"]
+    rej  = report["results"]["rejected_total"]
+    print(f"{name}: {acc} accepted, {rej} rejected")
 
 # Quick dict for pandas or downstream processing
 data = outcome.to_dict()
@@ -135,8 +138,9 @@ floe.run("orders.yml", profile_vars={
     "incoming_root": "s3://my-bucket/incoming",
 })
 
-# Both options work with validate() and load_config() too
+# validate() also accepts profile overrides
 floe.validate("orders.yml", profile_vars={"report_root": "/tmp"})
+# Note: load_config() is profile-unaware — it takes only config_path
 ```
 
 `profile_vars` and `profile_path` can be combined — inline vars take precedence over the file. See [docs/profiles.md](profiles.md) for the full profile format.

--- a/docs/python-bindings.md
+++ b/docs/python-bindings.md
@@ -1,0 +1,236 @@
+# Using floe from Python
+
+`floe-python` wraps the floe Rust engine via [PyO3](https://pyo3.rs) and [maturin](https://www.maturin.rs), giving you full-speed ingestion pipelines callable from Python scripts, Jupyter notebooks, or any orchestrator. A single ABI3 wheel covers Python 3.10–3.13.
+
+```bash
+pip install floe-python
+```
+
+---
+
+## The core functions
+
+Four functions cover every use case:
+
+| Function | Returns | When to use |
+|---|---|---|
+| `floe.validate(config_path)` | `None` | Pre-flight config check before running |
+| `floe.run(config_path)` | `RunOutcome` | Execute the full ingestion pipeline |
+| `floe.load_config(config_path)` | `RootConfig` | Inspect entities and settings without running |
+| `floe.extract_config_env_vars(config_path)` | `dict[str, str]` | List `{{VAR}}` placeholders in the config |
+
+A quick example for each:
+
+```python
+import floe
+
+# Check the config is valid before kicking off a scheduled run
+floe.validate("orders.yml")
+
+# Dry run — see what would be processed without moving any data
+outcome = floe.run("orders.yml", dry_run=True)
+for preview in outcome.dry_run_previews:
+    print(preview["name"], "→", preview["scanned_files"], "files")
+
+# Inspect what entities are defined (useful in notebooks or CI)
+config = floe.load_config("orders.yml")
+print(config.entity_names)          # ["orders", "returns"]
+print(config.entities[0].source_format)  # "csv"
+
+# See which env vars need to be set before the pipeline can run
+placeholders = floe.extract_config_env_vars("orders.yml")
+# e.g. {"report_root": "", "incoming_root": ""}
+```
+
+---
+
+## Reading results
+
+`floe.run()` returns a `RunOutcome`. The most useful properties:
+
+```python
+outcome = floe.run("orders.yml")
+
+# Top-level summary
+summary = outcome.summary
+print(summary["results"]["status"])   # "Success" | "SuccessWithWarnings" | "Failure"
+print(summary["results"]["rows"])     # total rows scanned
+print(summary["results"]["accepted"]) # rows written to accepted sink
+
+# Per-entity breakdown
+for report in outcome.entity_reports:
+    name   = report["entity"]["name"]
+    status = report["entity"]["status"]
+    acc    = report["entity"]["accepted"]
+    rej    = report["entity"]["rejected"]
+    print(f"{name}: {acc} accepted, {rej} rejected ({status})")
+
+# Quick dict for pandas or downstream processing
+data = outcome.to_dict()
+```
+
+### Jupyter integration
+
+In a Jupyter notebook, `RunOutcome` renders as a color-coded HTML table automatically — no extra code required:
+
+```python
+# In a notebook cell, just end with the variable name:
+outcome = floe.run("orders.yml")
+outcome   # renders inline HTML table with per-entity status rows
+```
+
+The `_repr_html_()` method is called automatically by Jupyter. Status colors: green = Success, orange = SuccessWithWarnings, red = Failure.
+
+---
+
+## Observing runs in real time
+
+floe-python supports a single global observer callback that receives structured events as they happen. You register it before `run()`, then clear it after.
+
+```python
+import floe
+
+def on_event(event: dict) -> None:
+    kind = event["event"]
+    if kind == "entity_finished":
+        print(f"  {event['name']}: {event['accepted']} accepted, {event['rejected']} rejected")
+    elif kind == "run_finished":
+        print(f"Run {event['run_id']}: {event['status']}")
+
+floe.set_observer(on_event)
+outcome = floe.run("orders.yml")
+floe.clear_observer()
+```
+
+The callback is **swappable between calls** — calling `set_observer` again replaces the current one. If your callback raises an exception it is silently ignored so the run is never aborted by observer code.
+
+### Event types
+
+| Event | Key fields |
+|---|---|
+| `run_started` | `run_id`, `config`, `report_base`, `ts_ms` |
+| `entity_started` | `run_id`, `name`, `ts_ms` |
+| `file_started` | `run_id`, `entity`, `input`, `ts_ms` |
+| `file_finished` | `run_id`, `entity`, `input`, `status`, `rows`, `accepted`, `rejected`, `elapsed_ms` |
+| `schema_evolution_applied` | `run_id`, `entity`, `mode`, `added_columns` |
+| `entity_finished` | `run_id`, `name`, `status`, `files`, `rows`, `accepted`, `rejected`, `warnings`, `errors` |
+| `run_finished` | `run_id`, `status`, `exit_code`, `files`, `rows`, `accepted`, `rejected`, `summary_uri` |
+| `log` | `run_id`, `log_level`, `code`, `message`, `entity`, `input` |
+
+All events have an `event` key (string discriminator) and `ts_ms` (Unix timestamp in milliseconds). The full TypedDict definitions are in [`python/floe/_floe.pyi`](../crates/floe-python/python/floe/_floe.pyi).
+
+---
+
+## Working with profiles
+
+Profiles let you override config variables, storage credentials, or lineage settings without editing the YAML. There are two ways to provide them:
+
+```python
+# Option 1: load a profile YAML file
+floe.run("orders.yml", profile_path="prod.yml")
+
+# Option 2: pass overrides inline (useful in notebooks and CI)
+floe.run("orders.yml", profile_vars={
+    "report_root": "/data/reports",
+    "incoming_root": "s3://my-bucket/incoming",
+})
+
+# Both options work with validate() and load_config() too
+floe.validate("orders.yml", profile_vars={"report_root": "/tmp"})
+```
+
+`profile_vars` and `profile_path` can be combined — inline vars take precedence over the file. See [docs/profiles.md](profiles.md) for the full profile format.
+
+---
+
+## Incremental state
+
+When a pipeline uses `incremental_mode: file`, floe tracks which files have already been ingested. Two helper functions let you inspect and reset that state:
+
+```python
+# See what floe has already processed for an entity
+state = floe.inspect_entity_state("orders.yml", "orders")
+print(state["incremental_mode"])  # "file"
+print(state["state"])             # dict with ingested file list, or None
+
+# Clear state to force a full re-ingest on the next run
+deleted = floe.reset_entity_state("orders.yml", "orders")
+print(deleted)  # True if state existed and was removed
+```
+
+---
+
+## Error handling
+
+floe-python raises typed exceptions so you can handle config problems and run failures separately:
+
+```python
+try:
+    outcome = floe.run("orders.yml")
+except floe.FloeConfigError as e:
+    # YAML is invalid or a required field is missing
+    print(f"Config error: {e}")
+except floe.FloeStorageError as e:
+    # Could not reach S3/GCS/ADLS or read a local path
+    print(f"Storage error: {e}")
+except floe.FloeRunError as e:
+    # Pipeline ran but encountered a fatal data error
+    print(f"Run failed: {e}")
+except floe.FloeError as e:
+    # Catch-all for any other floe error
+    print(f"Floe error: {e}")
+```
+
+Exception hierarchy:
+
+```
+FloeError
+├── FloeConfigError   — config parse or validation failure
+├── FloeRunError      — pipeline execution failure
+├── FloeStorageError  — cloud storage or local I/O failure
+└── FloeIoError       — lower-level I/O error
+```
+
+---
+
+## Threading and the GIL
+
+`floe.run()` and `floe.validate()` release the Python GIL while Rust is working, so they are safe to call from threads managed by `asyncio`, `concurrent.futures`, or a Dagster worker. You can run multiple pipelines in parallel across threads.
+
+The observer callback is called from the Rust thread and must reacquire the GIL. Keep callbacks fast and non-blocking — avoid heavy pandas operations or network calls inside the callback. Use a queue if you need to hand off work:
+
+```python
+import queue, threading
+q: queue.Queue = queue.Queue()
+
+floe.set_observer(q.put_nowait)  # fast: just enqueues
+outcome = floe.run("orders.yml")
+floe.clear_observer()
+
+while not q.empty():
+    print(q.get_nowait())  # process events after the run
+```
+
+---
+
+## Build from source
+
+If you want to build the native extension yourself (e.g., to test a local floe-core change):
+
+```bash
+# Install maturin
+pip install maturin
+
+# Clone the repo and build in development mode
+git clone https://github.com/malon64/floe
+cd floe/crates/floe-python
+maturin develop          # builds and installs into your current virtualenv
+```
+
+For a release-quality wheel:
+
+```bash
+maturin build --release  # produces a .whl in target/wheels/
+```
+
+The extension is compiled as `floe._floe` (a C extension module) and re-exported through `floe/__init__.py`. The ABI3 flag (`abi3-py310`) means the same `.so` file works on Python 3.10, 3.11, 3.12, and 3.13.

--- a/docs/summary.md
+++ b/docs/summary.md
@@ -17,8 +17,13 @@ important references so you can quickly find the right guide.
 - Run reports and JSON schema: [docs/report.md](report.md)
 - Logging for orchestrators (`--log-format`): [docs/logging.md](logging.md)
 
+## Python bindings
+
+- Using floe from Python and Jupyter notebooks: [docs/python-bindings.md](python-bindings.md)
+
 ## Orchestrators & manifests
 
+- Manifest generation — why, how, and what's inside: [docs/manifest.md](manifest.md)
 - CLI manifest generation (`floe manifest generate`): [docs/cli.md](cli.md)
 - Common orchestrator manifest schema: [orchestrators/schemas/floe.manifest.v1.json](../orchestrators/schemas/floe.manifest.v1.json)
 - Dagster integration package + examples: [orchestrators/dagster-floe/README.md](../orchestrators/dagster-floe/README.md)

--- a/orchestrators/airflow-floe/README.md
+++ b/orchestrators/airflow-floe/README.md
@@ -1,10 +1,12 @@
 # Floe + Airflow (MVP example)
 
 This folder contains:
+
 - a reusable Python connector package (`src/airflow_floe`)
 - example DAGs (`dags/`) that consume the package
 
 For local setup of both Dagster and Airflow with isolated virtual environments, see:
+
 - `orchestrators/LOCAL_DEV.md`
 
 ## Contents
@@ -18,48 +20,66 @@ For local setup of both Dagster and Airflow with isolated virtual environments, 
 - `example/config.yml`: small Floe config for demo
 - `dags/floe_example_operator_dag.py`: example DAG using `FloeRunOperator`
 
+## Configuration
+
+The connector is driven entirely by environment variables. No code changes are needed to switch between single-manifest, multi-manifest, or fallback mode.
+
+| Env var | What it does |
+| --- | --- |
+| `FLOE_MANIFEST` | Primary: path to a `floe.manifest.v1` JSON — enables asset registration at parse time |
+| `FLOE_MANIFEST_DIR` | Multi-manifest mode: directory of `*.manifest.json` files; one DAG per file |
+| `FLOE_CONFIG` | Fallback: path to a raw Floe YAML config — DAG runs but no assets are registered |
+| `FLOE_CMD` | Override the `floe` binary path (default: `floe` on `$PATH`) |
+
+**Fallback mode:** If `FLOE_MANIFEST` is not set, the connector falls back to `FLOE_CONFIG`. The DAG still runs and calls `floe run`, but because there is no manifest to read at parse time, no assets are registered and no asset events are emitted. Use this for quick local testing when you haven't generated a manifest yet.
+
+**Multi-manifest mode:** Each JSON file in `FLOE_MANIFEST_DIR` becomes a separate DAG. The DAG ID is derived from the manifest file name — for example `orders.manifest.json` → DAG `floe_orders`. Entity tasks within the DAG are generated from the manifest's `entities[]` list.
+
 ## Quick usage
 
 1. Make sure `floe` is available in PATH (or set `FLOE_CMD`).
+
 2. (Optional but recommended) install the connector package:
 
-```bash
-python -m pip install -e orchestrators/airflow-floe
-```
-3. Point Airflow DAGs folder to `orchestrators/airflow-floe/dags`.
-4. Set optional env vars:
+   ```bash
+   python -m pip install -e orchestrators/airflow-floe
+   ```
 
-```bash
-export FLOE_CMD="floe"
-export FLOE_MANIFEST="/absolute/path/to/orchestrators/airflow-floe/example/manifest.airflow.json"
-# optional multi-manifest mode (1 manifest => 1 DAG):
-# export FLOE_MANIFEST_DIR="/absolute/path/to/orchestrators/airflow-floe/example/manifests"
-# optional override:
-# export FLOE_CONFIG="/absolute/path/to/orchestrators/airflow-floe/example/config.yml"
-```
+3. Point Airflow DAGs folder to `orchestrators/airflow-floe/dags`.
+
+4. Set env vars:
+
+   ```bash
+   export FLOE_CMD="floe"
+   export FLOE_MANIFEST="/absolute/path/to/orchestrators/airflow-floe/example/manifest.airflow.json"
+   # optional multi-manifest mode (1 manifest => 1 DAG):
+   # export FLOE_MANIFEST_DIR="/absolute/path/to/orchestrators/airflow-floe/example/manifests"
+   # optional fallback (no assets registered):
+   # export FLOE_CONFIG="/absolute/path/to/orchestrators/airflow-floe/example/config.yml"
+   ```
 
 5. Generate manifest from Floe config:
 
-```bash
-floe manifest generate \
-  -c orchestrators/airflow-floe/example/config.yml \
-  --output orchestrators/airflow-floe/example/manifest.airflow.json
-```
+   ```bash
+   floe manifest generate \
+     -c orchestrators/airflow-floe/example/config.yml \
+     --output orchestrators/airflow-floe/example/manifest.airflow.json
+   ```
 
-For multi-manifest mode (one DAG per manifest), generate domain manifests:
+   For multi-manifest mode (one DAG per manifest), generate domain manifests:
 
-```bash
-floe manifest generate \
-  -c orchestrators/airflow-floe/example/config.hr.yml \
-  --output orchestrators/airflow-floe/example/manifests/hr.manifest.json
+   ```bash
+   floe manifest generate \
+     -c orchestrators/airflow-floe/example/config.hr.yml \
+     --output orchestrators/airflow-floe/example/manifests/hr.manifest.json
 
-floe manifest generate \
-  -c orchestrators/airflow-floe/example/config.sales.yml \
-  --output orchestrators/airflow-floe/example/manifests/sales.manifest.json
-```
+   floe manifest generate \
+     -c orchestrators/airflow-floe/example/config.sales.yml \
+     --output orchestrators/airflow-floe/example/manifests/sales.manifest.json
+   ```
 
 6. Trigger DAG `floe_example_operator`.
-   - In multi-manifest mode (`FLOE_MANIFEST_DIR`), DAGs are generated as `floe_<manifest_name>`.
+   In multi-manifest mode (`FLOE_MANIFEST_DIR`), DAGs are generated as `floe_<manifest_name>`.
 
 ## Notes
 
@@ -68,7 +88,6 @@ floe manifest generate \
   - terminal event: `run_finished`
 - Assets are created at parse time from `FLOE_MANIFEST` and materialized when run tasks finish.
 - `floe_example_operator` also publishes asset events when manifest assets are available.
-- If `FLOE_MANIFEST` is missing/invalid, DAGs still run with `FLOE_CONFIG` (or example config fallback) but no assets are loaded/materialized.
 - The returned task payload shape follows `floe.airflow.run.v1`.
 - Local run summaries emitted as `local://...` are resolved and loaded by the connector runtime helpers.
 - Floe NDJSON stdout/stderr are streamed into task logs (Audit/Task Log view) and still parsed for `run_finished`.

--- a/orchestrators/airflow-floe/README.md
+++ b/orchestrators/airflow-floe/README.md
@@ -28,10 +28,12 @@ The connector is driven entirely by environment variables. No code changes are n
 | --- | --- |
 | `FLOE_MANIFEST` | Primary: path to a `floe.manifest.v1` JSON — enables asset registration at parse time |
 | `FLOE_MANIFEST_DIR` | Multi-manifest mode: directory of `*.manifest.json` files; one DAG per file |
-| `FLOE_CONFIG` | Fallback: path to a raw Floe YAML config — DAG runs but no assets are registered |
+| `FLOE_CONFIG` | Fallback run config used when manifest loading fails — DAG still executes `floe run`, but no assets are registered |
 | `FLOE_CMD` | Override the `floe` binary path (default: `floe` on `$PATH`) |
 
-**Fallback mode:** If `FLOE_MANIFEST` is not set, the connector falls back to `FLOE_CONFIG`. The DAG still runs and calls `floe run`, but because there is no manifest to read at parse time, no assets are registered and no asset events are emitted. Use this for quick local testing when you haven't generated a manifest yet.
+**Manifest loading failure:** If `FLOE_MANIFEST` points to a path that cannot be loaded (file not found, invalid JSON, schema error), `build_dag_manifest_context_or_empty` catches the exception and returns an empty asset context — the DAG still runs `floe run` using `FLOE_CONFIG` as the config path, but no assets are registered or materialized.
+
+> **Note:** Setting only `FLOE_CONFIG` without a valid `FLOE_MANIFEST` does not guarantee "no assets". When `FLOE_MANIFEST` is unset, the example DAG defaults to the bundled example manifest (`example/manifest.airflow.json`), which registers its own assets. To run with no assets, either point `FLOE_MANIFEST` to a path that does not exist, or remove the default fallback from your DAG code.
 
 **Multi-manifest mode:** Each JSON file in `FLOE_MANIFEST_DIR` becomes a separate DAG. The DAG ID is derived from the manifest file name — for example `orders.manifest.json` → DAG `floe_orders`. Entity tasks within the DAG are generated from the manifest's `entities[]` list.
 

--- a/orchestrators/dagster-floe/README.md
+++ b/orchestrators/dagster-floe/README.md
@@ -77,17 +77,21 @@ Checks appear in the Dagster UI under each asset, linked to the run that produce
 
 ## Lineage integration
 
-When floe has a `lineage` block in its config or profile, it emits OpenLineage events. The connector automatically injects `DAGSTER_JOB_NAME` into the floe subprocess environment — so the OpenLineage run event is attributed to the Dagster job name instead of a UUID.
+The connector automatically injects two environment variables into every floe subprocess:
 
-This works automatically with no configuration: the connector reads the Dagster job name from the current run context and passes it through.
+- `DAGSTER_RUN_ID` — the current Dagster run ID
+- `DAGSTER_JOB_NAME` — the Dagster job name
 
-To enable lineage, add a `lineage` block to your profile and pass it when **generating** the manifest. The manifest builder serializes the lineage config into the manifest JSON so `floe run --manifest` picks it up automatically at run time — no runtime profile injection needed.
+When lineage is enabled and both variables are present, floe attaches a **parent facet** to its OpenLineage run event. This facet declares that the Floe run is a child of the Dagster run, making the lineage graph show the full Dagster → Floe pipeline hierarchy.
+
+The Floe run event's own `job.name` is derived from `lineage.job_name` in the embedded manifest lineage config, or from the config file stem. To control it explicitly, add `job_name` to your lineage block when generating the manifest:
 
 ```yaml
 # prod.yml (profile)
 lineage:
   url: "http://marquez:5000"
   namespace: "my-data-platform"
+  job_name: "orders-pipeline"   # sets job.name on the Floe OpenLineage run event
 ```
 
 ```bash

--- a/orchestrators/dagster-floe/README.md
+++ b/orchestrators/dagster-floe/README.md
@@ -81,7 +81,7 @@ When floe has a `lineage` block in its config or profile, it emits OpenLineage e
 
 This works automatically with no configuration: the connector reads the Dagster job name from the current run context and passes it through.
 
-To enable lineage, add a `lineage` block to your **profile** (not to the manifest — the manifest is static):
+To enable lineage, add a `lineage` block to your profile and pass it when **generating** the manifest. The manifest builder serializes the lineage config into the manifest JSON so `floe run --manifest` picks it up automatically at run time — no runtime profile injection needed.
 
 ```yaml
 # prod.yml (profile)
@@ -90,7 +90,11 @@ lineage:
   namespace: "my-data-platform"
 ```
 
-Pass the profile to `load_floe_assets` via the manifest's `runners.definitions`, or set it as a default env var. See [docs/lineage.md](../../docs/lineage.md) for the full lineage config reference.
+```bash
+floe manifest generate -c orders.yml -p prod.yml --output manifests/orders.json
+```
+
+See [docs/lineage.md](../../docs/lineage.md) for the full lineage config reference.
 
 ## Notes
 

--- a/orchestrators/dagster-floe/README.md
+++ b/orchestrators/dagster-floe/README.md
@@ -67,7 +67,7 @@ Every accepted-output asset automatically gets quality checks registered in Dags
 
 | Check | Fails when |
 | --- | --- |
-| `file_status` | No input files were found for the entity |
+| `file_status` | One or more input files had a failed or error-level processing status (e.g., unreadable file, parse failure) |
 | `cast_error` | Type-casting failures exceeded the entity's policy threshold |
 | `not_null` | Null values found in non-nullable columns |
 | `unique` | Duplicate values found in uniqueness-constrained columns |

--- a/orchestrators/dagster-floe/README.md
+++ b/orchestrators/dagster-floe/README.md
@@ -61,6 +61,37 @@ The repository example includes two manifests by domain:
 - `example/manifests/hr.manifest.json`
 - `example/manifests/sales.manifest.json`
 
+## Asset checks
+
+Every accepted-output asset automatically gets quality checks registered in Dagster — no extra config needed. After each run, the connector reads the Floe run report and publishes pass/fail results for each entity.
+
+| Check | Fails when |
+| --- | --- |
+| `file_status` | No input files were found for the entity |
+| `cast_error` | Type-casting failures exceeded the entity's policy threshold |
+| `not_null` | Null values found in non-nullable columns |
+| `unique` | Duplicate values found in uniqueness-constrained columns |
+| `schema_mismatch` | Incoming file schema is incompatible with the declared schema |
+
+Checks appear in the Dagster UI under each asset, linked to the run that produced them. A `WARN`-severity violation marks the check as a warning; `REJECT` or `ABORT` marks it as a failure.
+
+## Lineage integration
+
+When floe has a `lineage` block in its config or profile, it emits OpenLineage events. The connector automatically injects `DAGSTER_JOB_NAME` into the floe subprocess environment — so the OpenLineage run event is attributed to the Dagster job name instead of a UUID.
+
+This works automatically with no configuration: the connector reads the Dagster job name from the current run context and passes it through.
+
+To enable lineage, add a `lineage` block to your **profile** (not to the manifest — the manifest is static):
+
+```yaml
+# prod.yml (profile)
+lineage:
+  url: "http://marquez:5000"
+  namespace: "my-data-platform"
+```
+
+Pass the profile to `load_floe_assets` via the manifest's `runners.definitions`, or set it as a default env var. See [docs/lineage.md](../../docs/lineage.md) for the full lineage config reference.
+
 ## Notes
 
 - This connector does **not** parse YAML directly; it consumes `floe.manifest.v1`.


### PR DESCRIPTION
## What this PR adds

Three areas of the floe codebase lacked user-facing documentation or had thin READMEs. This PR fills those gaps with concise, example-driven docs.

---

### New: `docs/python-bindings.md`

Full guide for `floe-python` — the PyO3/maturin Python package. Covers:

- The four core functions with a quick-reference table
- Reading `RunOutcome` (`.summary`, `.entity_reports`, `.to_dict()`)
- **Jupyter integration** — `_repr_html_()` auto-renders a color-coded table (previously undocumented)
- **Observer pattern** — complete event-types table (`run_started` → `run_finished` + `log`), swappable callbacks, silent-failure behavior
- Profile overrides (`profile_path` vs `profile_vars`)
- Incremental state (`inspect_entity_state` / `reset_entity_state`)
- Exception hierarchy (`FloeError` → `FloeConfigError`, `FloeRunError`, `FloeStorageError`, `FloeIoError`)
- **Threading / GIL notes** — `run()` releases the GIL; observer callbacks reacquire it
- Build from source with maturin

### New: `docs/manifest.md`

Explains manifest generation end-to-end:

- **Why manifests exist** — parse-time vs. run-time separation; orchestrators read static JSON, not YAML
- `floe manifest generate` usage (with profile baking and `--entities` filtering)
- Annotated JSON excerpt of a real manifest
- ASCII flow diagram: config → manifest → orchestrator parse-time → run-time call
- CI freshness check (`diff` pattern)

### Updated: `crates/floe-python/README.md`

Added three new subsections (Jupyter, Observing progress, Profile overrides) and a link to the full guide.

### Updated: `docs/summary.md`

Added "Python bindings" section and manifest link under Orchestrators & manifests.

### Updated: `orchestrators/dagster-floe/README.md`

- **Asset checks** — table of 5 check types (`file_status`, `cast_error`, `not_null`, `unique`, `schema_mismatch`) with trigger conditions; previously implemented but undocumented
- **Lineage integration** — explains `DAGSTER_JOB_NAME` auto-injection and how to add a lineage profile

### Updated: `orchestrators/airflow-floe/README.md`

- **Configuration section** — 4-row env-var table (`FLOE_MANIFEST`, `FLOE_MANIFEST_DIR`, `FLOE_CONFIG`, `FLOE_CMD`) with fallback mode and multi-manifest DAG naming explained
- Fixed all pre-existing markdownlint warnings (blank lines around lists, fenced block spacing, ordered list numbering)
