### PR TITLE
feat: --full-refresh flag to bypass incremental state (#346)

### DIFF
--- a/crates/floe-cli/src/main.rs
+++ b/crates/floe-cli/src/main.rs
@@ -171,6 +171,12 @@ enum Command {
         #[arg(long, help = "Resolve and print inputs/outputs without executing")]
         dry_run: bool,
         #[arg(
+            long,
+            short = 'F',
+            help = "Bypass incremental state and reprocess all input files. Forces overwrite on append-mode sinks. Incompatible with merge_scd1/merge_scd2."
+        )]
+        full_refresh: bool,
+        #[arg(
             short = 'p',
             long,
             help = "Optional path to a Floe environment profile YAML file"
@@ -443,6 +449,7 @@ fn main() -> FloeResult<()> {
             verbose,
             log_format,
             dry_run,
+            full_refresh,
             profile,
         } => {
             let started_at = floe_core::report::now_rfc3339();
@@ -492,6 +499,7 @@ fn main() -> FloeResult<()> {
                     run_id: Some(computed_run_id.clone()),
                     entities,
                     dry_run,
+                    full_refresh,
                     profile: None,
                 };
 
@@ -583,6 +591,7 @@ fn main() -> FloeResult<()> {
                 run_id: Some(computed_run_id.clone()),
                 entities,
                 dry_run,
+                full_refresh,
                 profile: profile_config,
             };
 

--- a/crates/floe-core/src/lib.rs
+++ b/crates/floe-core/src/lib.rs
@@ -54,6 +54,7 @@ pub struct RunOptions {
     pub run_id: Option<String>,
     pub entities: Vec<String>,
     pub dry_run: bool,
+    pub full_refresh: bool,
     pub profile: Option<ProfileConfig>,
 }
 

--- a/crates/floe-core/src/run/context.rs
+++ b/crates/floe-core/src/run/context.rs
@@ -16,6 +16,7 @@ pub struct RunContext {
     pub run_id: String,
     pub started_at: String,
     pub run_timer: Instant,
+    pub full_refresh: bool,
 }
 
 impl RunContext {
@@ -82,6 +83,7 @@ impl RunContext {
             run_id,
             started_at,
             run_timer: Instant::now(),
+            full_refresh: options.full_refresh,
         })
     }
 
@@ -151,6 +153,7 @@ impl RunContext {
             run_id,
             started_at,
             run_timer: Instant::now(),
+            full_refresh: options.full_refresh,
         })
     }
 }

--- a/crates/floe-core/src/run/entity/accepted_write.rs
+++ b/crates/floe-core/src/run/entity/accepted_write.rs
@@ -20,6 +20,7 @@ pub(super) struct AcceptedWritePhaseContext<'a> {
     pub(super) accepted_target: &'a Target,
     pub(super) temp_dir: Option<&'a Path>,
     pub(super) write_mode: config::WriteMode,
+    pub(super) full_refresh: bool,
     pub(super) perf_enabled: bool,
     pub(super) phase_timings: &'a mut EntityPhaseTimings,
     pub(super) pending_input_count: usize,
@@ -37,6 +38,7 @@ pub(super) fn run_accepted_write_phase(
         accepted_target,
         temp_dir,
         write_mode,
+        full_refresh,
         perf_enabled,
         phase_timings,
         pending_input_count,
@@ -47,7 +49,7 @@ pub(super) fn run_accepted_write_phase(
         crate::io::write::strategy::merge::shared::default_schema_evolution_summary(
             entity, write_mode,
         );
-    if pending_input_count == 0 {
+    if pending_input_count == 0 && !(full_refresh && write_mode == config::WriteMode::Overwrite) {
         return Ok(io::format::AcceptedWriteOutput {
             files_written: Some(0),
             schema_evolution: default_schema_evolution,

--- a/crates/floe-core/src/run/entity/incremental.rs
+++ b/crates/floe-core/src/run/entity/incremental.rs
@@ -12,8 +12,8 @@ use crate::report::{
 use crate::run::RunContext;
 use crate::state::{
     claim_all_entity_inputs, claim_entity_inputs, promote_claimed_entity_state,
-    release_claimed_entity_state, renew_claimed_entity_state, ClaimedEntityState, EntityFileState,
-    CLAIM_TTL_SECONDS,
+    promote_full_refresh_claimed_entity_state, release_claimed_entity_state,
+    renew_claimed_entity_state, ClaimedEntityState, EntityFileState, CLAIM_TTL_SECONDS,
 };
 use crate::{config, warnings, FloeResult};
 
@@ -44,6 +44,7 @@ pub(super) fn prepare_incremental_context(
                     context.storage_resolver.clone(),
                     entity.name.clone(),
                     context.run_id.clone(),
+                    true,
                 )
             })
         } else {
@@ -132,6 +133,7 @@ pub(super) fn prepare_incremental_context(
                 context.storage_resolver.clone(),
                 entity.name.clone(),
                 context.run_id.clone(),
+                false,
             )
         }),
     })
@@ -184,6 +186,7 @@ pub(super) struct PendingEntityState {
     run_id: String,
     heartbeat: Option<ClaimHeartbeat>,
     finalized: bool,
+    is_full_refresh: bool,
 }
 
 impl PendingEntityState {
@@ -192,6 +195,7 @@ impl PendingEntityState {
         resolver: StorageResolver,
         entity_name: String,
         run_id: String,
+        is_full_refresh: bool,
     ) -> Self {
         let heartbeat = ClaimHeartbeat::start(
             resolver.clone(),
@@ -206,6 +210,7 @@ impl PendingEntityState {
             run_id,
             heartbeat: Some(heartbeat),
             finalized: false,
+            is_full_refresh,
         }
     }
 
@@ -216,13 +221,23 @@ impl PendingEntityState {
         _entity: &config::EntityConfig,
     ) -> FloeResult<()> {
         self.stop_heartbeat();
-        promote_claimed_entity_state(
-            &self.resolver,
-            cloud,
-            &self.entity_name,
-            &self.run_id,
-            &self.claimed,
-        )?;
+        if self.is_full_refresh {
+            promote_full_refresh_claimed_entity_state(
+                &self.resolver,
+                cloud,
+                &self.entity_name,
+                &self.run_id,
+                &self.claimed,
+            )?;
+        } else {
+            promote_claimed_entity_state(
+                &self.resolver,
+                cloud,
+                &self.entity_name,
+                &self.run_id,
+                &self.claimed,
+            )?;
+        }
         self.finalized = true;
         Ok(())
     }

--- a/crates/floe-core/src/run/entity/incremental.rs
+++ b/crates/floe-core/src/run/entity/incremental.rs
@@ -11,8 +11,9 @@ use crate::report::{
 };
 use crate::run::RunContext;
 use crate::state::{
-    claim_entity_inputs, promote_claimed_entity_state, release_claimed_entity_state,
-    renew_claimed_entity_state, ClaimedEntityState, EntityFileState, CLAIM_TTL_SECONDS,
+    claim_all_entity_inputs, claim_entity_inputs, promote_claimed_entity_state,
+    release_claimed_entity_state, renew_claimed_entity_state, ClaimedEntityState, EntityFileState,
+    CLAIM_TTL_SECONDS,
 };
 use crate::{config, warnings, FloeResult};
 
@@ -28,6 +29,33 @@ pub(super) fn prepare_incremental_context(
     entity: &config::EntityConfig,
     input_files: Vec<InputFile>,
 ) -> FloeResult<IncrementalContext> {
+    if context.full_refresh {
+        let pending_state = if entity.incremental_mode == IncrementalMode::File {
+            claim_all_entity_inputs(
+                &context.storage_resolver,
+                cloud,
+                entity,
+                &context.run_id,
+                input_files.clone(),
+            )?
+            .map(|claimed| {
+                PendingEntityState::new(
+                    claimed,
+                    context.storage_resolver.clone(),
+                    entity.name.clone(),
+                    context.run_id.clone(),
+                )
+            })
+        } else {
+            None
+        };
+        return Ok(IncrementalContext {
+            pending_inputs: input_files,
+            skipped_reports: Vec::new(),
+            pending_state,
+        });
+    }
+
     if entity.incremental_mode != IncrementalMode::File {
         return Ok(IncrementalContext {
             pending_inputs: input_files,

--- a/crates/floe-core/src/run/entity/mod.rs
+++ b/crates/floe-core/src/run/entity/mod.rs
@@ -289,6 +289,7 @@ pub(super) fn run_entity(
         accepted_target: &accepted_target,
         temp_dir: temp_dir_path,
         write_mode,
+        full_refresh: context.full_refresh,
         perf_enabled,
         phase_timings: &mut phase_timings,
         pending_input_count,

--- a/crates/floe-core/src/run/entity/mod.rs
+++ b/crates/floe-core/src/run/entity/mod.rs
@@ -87,7 +87,13 @@ pub(super) fn run_entity(
     let entity_start = perf_enabled.then(Instant::now);
     let mut phase_timings = EntityPhaseTimings::default();
     let input = &entity.source;
-    let write_mode = entity.sink.write_mode;
+    let write_mode = if context.full_refresh
+        && entity.sink.write_mode == crate::config::WriteMode::Append
+    {
+        crate::config::WriteMode::Overwrite
+    } else {
+        entity.sink.write_mode
+    };
     let input_adapter = runtime.input_adapter(input.format.as_str())?;
     let resolved_targets = plan.resolved_targets;
     let formatter_name = context

--- a/crates/floe-core/src/run/entity/mod.rs
+++ b/crates/floe-core/src/run/entity/mod.rs
@@ -87,13 +87,12 @@ pub(super) fn run_entity(
     let entity_start = perf_enabled.then(Instant::now);
     let mut phase_timings = EntityPhaseTimings::default();
     let input = &entity.source;
-    let write_mode = if context.full_refresh
-        && entity.sink.write_mode == crate::config::WriteMode::Append
-    {
-        crate::config::WriteMode::Overwrite
-    } else {
-        entity.sink.write_mode
-    };
+    let write_mode =
+        if context.full_refresh && entity.sink.write_mode == crate::config::WriteMode::Append {
+            crate::config::WriteMode::Overwrite
+        } else {
+            entity.sink.write_mode
+        };
     let input_adapter = runtime.input_adapter(input.format.as_str())?;
     let resolved_targets = plan.resolved_targets;
     let formatter_name = context

--- a/crates/floe-core/src/run/mod.rs
+++ b/crates/floe-core/src/run/mod.rs
@@ -175,6 +175,20 @@ fn run_from_context(
     let observer = default_observer();
     let perf_enabled = perf::phase_timing_enabled();
     let selected_entities = select_entities(&context, &options);
+    if options.full_refresh {
+        for entity in &selected_entities {
+            if matches!(
+                entity.sink.write_mode,
+                config::WriteMode::MergeScd1 | config::WriteMode::MergeScd2
+            ) {
+                return Err(Box::new(ConfigError(format!(
+                    "entity '{}': --full-refresh is not supported with write_mode '{}'",
+                    entity.name,
+                    entity.sink.write_mode.as_str()
+                ))));
+            }
+        }
+    }
     let resolution_mode = if options.dry_run {
         io::storage::inputs::ResolveInputsMode::ListOnly
     } else {

--- a/crates/floe-core/src/state/mod.rs
+++ b/crates/floe-core/src/state/mod.rs
@@ -264,6 +264,7 @@ pub fn claim_all_entity_inputs(
         let loaded = load_entity_state(resolver, cloud, entity)?;
 
         let mut fresh_state = EntityState::new(&entity.name);
+        fresh_state.files = loaded.state.files.clone();
         fresh_state.updated_at = Some(acquired_at.clone());
         for input_file in &input_files {
             fresh_state.claims.insert(
@@ -317,6 +318,38 @@ pub fn promote_claimed_entity_state(
             .filter(|(uri, claim)| claim.run_id == run_id && our_uris.contains(*uri))
             .map(|(source_uri, _)| source_uri.clone())
             .collect();
+        for source_uri in claimed_files {
+            if let Some(claim) = state.claims.remove(&source_uri) {
+                state.files.insert(
+                    source_uri,
+                    EntityFileState {
+                        processed_at: processed_at.clone(),
+                        size: claim.size,
+                        mtime: claim.mtime,
+                    },
+                );
+            }
+        }
+        state.updated_at = Some(processed_at);
+    })
+}
+
+pub fn promote_full_refresh_claimed_entity_state(
+    resolver: &StorageResolver,
+    cloud: &mut CloudClient,
+    entity_name: &str,
+    run_id: &str,
+    claimed: &ClaimedEntityState,
+) -> FloeResult<()> {
+    mutate_claimed_state(resolver, cloud, entity_name, claimed, |state, our_uris| {
+        let processed_at = now_rfc3339();
+        let claimed_files: Vec<String> = state
+            .claims
+            .iter()
+            .filter(|(uri, claim)| claim.run_id == run_id && our_uris.contains(*uri))
+            .map(|(uri, _)| uri.clone())
+            .collect();
+        state.files.clear();
         for source_uri in claimed_files {
             if let Some(claim) = state.claims.remove(&source_uri) {
                 state.files.insert(

--- a/crates/floe-core/src/state/mod.rs
+++ b/crates/floe-core/src/state/mod.rs
@@ -241,6 +241,71 @@ pub fn claim_entity_inputs(
     ))))
 }
 
+/// Full-refresh variant of `claim_entity_inputs`.
+///
+/// Loads existing state to get the current CAS version, then writes a blank
+/// `EntityState` containing fresh claims for ALL `input_files` — discarding
+/// the historical `files` and `claims` maps. On successful commit the state
+/// file will contain only the files processed in this run.
+///
+/// Returns `None` when `input_files` is empty (nothing to claim).
+pub fn claim_all_entity_inputs(
+    resolver: &StorageResolver,
+    cloud: &mut CloudClient,
+    entity: &EntityConfig,
+    run_id: &str,
+    input_files: Vec<crate::io::format::InputFile>,
+) -> FloeResult<Option<ClaimedEntityState>> {
+    if input_files.is_empty() {
+        return Ok(None);
+    }
+
+    let acquired_at = now_rfc3339();
+    let expires_at = rfc3339_after_seconds(CLAIM_TTL_SECONDS);
+
+    for _ in 0..STATE_CAS_RETRIES {
+        // Read only to obtain the current CAS version; content is discarded.
+        let loaded = load_entity_state(resolver, cloud, entity)?;
+
+        let mut fresh_state = EntityState::new(&entity.name);
+        fresh_state.updated_at = Some(acquired_at.clone());
+        for input_file in &input_files {
+            fresh_state.claims.insert(
+                input_file.source_uri.clone(),
+                EntityFileClaim {
+                    run_id: run_id.to_string(),
+                    acquired_at: acquired_at.clone(),
+                    expires_at: expires_at.clone(),
+                    size: input_file.source_size,
+                    mtime: input_file.source_mtime.clone(),
+                },
+            );
+        }
+
+        let fresh_loaded = LoadedEntityState {
+            target: loaded.target,
+            state: fresh_state,
+            version: loaded.version,
+            existed: loaded.existed,
+        };
+        match persist_loaded_state(cloud, resolver, &fresh_loaded)? {
+            Some(version) => {
+                return Ok(Some(ClaimedEntityState {
+                    target: fresh_loaded.target,
+                    state: fresh_loaded.state,
+                    version,
+                }));
+            }
+            None => continue,
+        }
+    }
+
+    Err(Box::new(ConfigError(format!(
+        "entity.name={} full-refresh state write conflicted after {STATE_CAS_RETRIES} retries",
+        entity.name
+    ))))
+}
+
 pub fn promote_claimed_entity_state(
     resolver: &StorageResolver,
     cloud: &mut CloudClient,

--- a/crates/floe-core/src/state/mod.rs
+++ b/crates/floe-core/src/state/mod.rs
@@ -256,10 +256,6 @@ pub fn claim_all_entity_inputs(
     run_id: &str,
     input_files: Vec<crate::io::format::InputFile>,
 ) -> FloeResult<Option<ClaimedEntityState>> {
-    if input_files.is_empty() {
-        return Ok(None);
-    }
-
     let acquired_at = now_rfc3339();
     let expires_at = rfc3339_after_seconds(CLAIM_TTL_SECONDS);
 

--- a/crates/floe-core/tests/integration/archive_run.rs
+++ b/crates/floe-core/tests/integration/archive_run.rs
@@ -105,6 +105,7 @@ fn archive_moves_only_processed_input_not_local_siblings() {
             run_id: Some("archive-sibling-it".to_string()),
             entities: Vec::new(),
             dry_run: false,
+            full_refresh: false,
         },
     )
     .expect("run config");
@@ -163,6 +164,7 @@ fn archive_repeated_runs_do_not_overwrite_same_source_filename() {
             run_id: Some("archive-run-1".to_string()),
             entities: Vec::new(),
             dry_run: false,
+            full_refresh: false,
         },
     )
     .expect("first run");
@@ -175,6 +177,7 @@ fn archive_repeated_runs_do_not_overwrite_same_source_filename() {
             run_id: Some("archive-run-2".to_string()),
             entities: Vec::new(),
             dry_run: false,
+            full_refresh: false,
         },
     )
     .expect("second run");
@@ -227,6 +230,7 @@ fn legacy_archive_config_still_archives_inputs() {
             run_id: Some("archive-legacy-compat".to_string()),
             entities: Vec::new(),
             dry_run: false,
+            full_refresh: false,
         },
     )
     .expect("run config");

--- a/crates/floe-core/tests/integration/composite_unique.rs
+++ b/crates/floe-core/tests/integration/composite_unique.rs
@@ -81,6 +81,7 @@ entities:
             run_id: Some("it-composite-unique".to_string()),
             entities: Vec::new(),
             dry_run: false,
+            full_refresh: false,
         },
     )
     .expect("run config");

--- a/crates/floe-core/tests/integration/delta_run.rs
+++ b/crates/floe-core/tests/integration/delta_run.rs
@@ -205,6 +205,7 @@ entities:
             run_id: Some("it-delta-partitioned".to_string()),
             entities: Vec::new(),
             dry_run: false,
+            full_refresh: false,
         },
     )
     .expect("run config");
@@ -276,6 +277,7 @@ entities:
             run_id: Some("it-delta-unpartitioned".to_string()),
             entities: Vec::new(),
             dry_run: false,
+            full_refresh: false,
         },
     )
     .expect("run config");
@@ -346,6 +348,7 @@ entities:
             run_id: Some("it-delta-schema-evolution-init".to_string()),
             entities: Vec::new(),
             dry_run: false,
+            full_refresh: false,
         },
     )
     .expect("initial run");
@@ -390,6 +393,7 @@ entities:
             run_id: Some("it-delta-schema-evolution-append".to_string()),
             entities: Vec::new(),
             dry_run: false,
+            full_refresh: false,
         },
     )
     .expect("schema evolution append run");
@@ -495,6 +499,7 @@ entities:
             run_id: Some("it-delta-schema-evolution-overwrite-init".to_string()),
             entities: Vec::new(),
             dry_run: false,
+            full_refresh: false,
         },
     )
     .expect("initial overwrite run");
@@ -506,6 +511,7 @@ entities:
             run_id: Some("it-delta-schema-evolution-overwrite-noop".to_string()),
             entities: Vec::new(),
             dry_run: false,
+            full_refresh: false,
         },
     )
     .expect("overwrite no-op run");
@@ -570,6 +576,7 @@ entities:
             run_id: Some("it-delta-overwrite-empty-init".to_string()),
             entities: Vec::new(),
             dry_run: false,
+            full_refresh: false,
         },
     )
     .expect("initial overwrite run");
@@ -584,6 +591,7 @@ entities:
             run_id: Some("it-delta-overwrite-empty-second".to_string()),
             entities: Vec::new(),
             dry_run: false,
+            full_refresh: false,
         },
     )
     .expect("overwrite run with zero accepted rows");
@@ -653,6 +661,7 @@ entities:
             run_id: Some("it-delta-append-empty-init".to_string()),
             entities: Vec::new(),
             dry_run: false,
+            full_refresh: false,
         },
     )
     .expect("initial append run");
@@ -667,6 +676,7 @@ entities:
             run_id: Some("it-delta-append-empty-second".to_string()),
             entities: Vec::new(),
             dry_run: false,
+            full_refresh: false,
         },
     )
     .expect("append run with zero accepted rows");
@@ -735,6 +745,7 @@ entities:
             run_id: Some("it-delta-append-noop-init".to_string()),
             entities: Vec::new(),
             dry_run: false,
+            full_refresh: false,
         },
     )
     .expect("initial append run");
@@ -749,6 +760,7 @@ entities:
             run_id: Some("it-delta-append-noop-second".to_string()),
             entities: Vec::new(),
             dry_run: false,
+            full_refresh: false,
         },
     )
     .expect("append run with precheck-rejected file");
@@ -809,6 +821,7 @@ entities:
             run_id: Some("it-delta-strict-init".to_string()),
             entities: Vec::new(),
             dry_run: false,
+            full_refresh: false,
         },
     )
     .expect("initial strict run");
@@ -851,6 +864,7 @@ entities:
             run_id: Some("it-delta-strict-extra-column".to_string()),
             entities: Vec::new(),
             dry_run: false,
+            full_refresh: false,
         },
     )
     .expect_err("strict mode should reject added columns");
@@ -916,6 +930,7 @@ entities:
             run_id: Some("it-delta-merge-init".to_string()),
             entities: Vec::new(),
             dry_run: false,
+            full_refresh: false,
         },
     )
     .expect("initial merge run");
@@ -934,6 +949,7 @@ entities:
             run_id: Some("it-delta-merge-upsert".to_string()),
             entities: Vec::new(),
             dry_run: false,
+            full_refresh: false,
         },
     )
     .expect("merge upsert run");
@@ -1048,6 +1064,7 @@ entities:
             run_id: Some("it-delta-merge-scd1-evolution-init".to_string()),
             entities: Vec::new(),
             dry_run: false,
+            full_refresh: false,
         },
     )
     .expect("initial merge_scd1 run");
@@ -1102,6 +1119,7 @@ entities:
             run_id: Some("it-delta-merge-scd1-evolution-upsert".to_string()),
             entities: Vec::new(),
             dry_run: false,
+            full_refresh: false,
         },
     )
     .expect("merge_scd1 run with additive column");
@@ -1225,6 +1243,7 @@ entities:
             run_id: Some("it-delta-merge-dup-source".to_string()),
             entities: Vec::new(),
             dry_run: false,
+            full_refresh: false,
         },
     )
     .expect("merge_scd1 should reject duplicate merge-key rows before merge in warn mode");
@@ -1299,6 +1318,7 @@ entities:
             run_id: Some("it-delta-merge-scd2-init".to_string()),
             entities: Vec::new(),
             dry_run: false,
+            full_refresh: false,
         },
     )
     .expect("initial merge_scd2 run");
@@ -1317,6 +1337,7 @@ entities:
             run_id: Some("it-delta-merge-scd2-upsert".to_string()),
             entities: Vec::new(),
             dry_run: false,
+            full_refresh: false,
         },
     )
     .expect("merge_scd2 upsert run");
@@ -1445,6 +1466,7 @@ entities:
             run_id: Some("it-delta-merge-scd2-evolution-init".to_string()),
             entities: Vec::new(),
             dry_run: false,
+            full_refresh: false,
         },
     )
     .expect("initial merge_scd2 run");
@@ -1499,6 +1521,7 @@ entities:
             run_id: Some("it-delta-merge-scd2-evolution-upsert".to_string()),
             entities: Vec::new(),
             dry_run: false,
+            full_refresh: false,
         },
     )
     .expect("merge_scd2 run with additive column");
@@ -1641,6 +1664,7 @@ entities:
             run_id: Some("it-delta-merge-schema-evolution-init".to_string()),
             entities: Vec::new(),
             dry_run: false,
+            full_refresh: false,
         },
     )
     .expect("initial merge run");
@@ -1655,6 +1679,7 @@ entities:
             run_id: Some("it-delta-merge-schema-evolution-empty".to_string()),
             entities: Vec::new(),
             dry_run: false,
+            full_refresh: false,
         },
     )
     .expect("merge run with zero accepted rows");
@@ -1728,6 +1753,7 @@ entities:
             run_id: Some("it-delta-merge-noop-init".to_string()),
             entities: Vec::new(),
             dry_run: false,
+            full_refresh: false,
         },
     )
     .expect("initial merge run");
@@ -1742,6 +1768,7 @@ entities:
             run_id: Some("it-delta-merge-noop-second".to_string()),
             entities: Vec::new(),
             dry_run: false,
+            full_refresh: false,
         },
     )
     .expect("merge run with precheck-rejected file");
@@ -1819,6 +1846,7 @@ entities:
             run_id: Some("it-delta-merge-scd2-custom-cols-init".to_string()),
             entities: Vec::new(),
             dry_run: false,
+            full_refresh: false,
         },
     )
     .expect("initial merge_scd2 run with custom system columns");
@@ -1837,6 +1865,7 @@ entities:
             run_id: Some("it-delta-merge-scd2-custom-cols-upsert".to_string()),
             entities: Vec::new(),
             dry_run: false,
+            full_refresh: false,
         },
     )
     .expect("merge_scd2 run with custom system columns");
@@ -1911,6 +1940,7 @@ entities:
             run_id: Some("it-delta-merge-scd2-compare-init".to_string()),
             entities: Vec::new(),
             dry_run: false,
+            full_refresh: false,
         },
     )
     .expect("initial merge_scd2 run");
@@ -1929,6 +1959,7 @@ entities:
             run_id: Some("it-delta-merge-scd2-compare-second".to_string()),
             entities: Vec::new(),
             dry_run: false,
+            full_refresh: false,
         },
     )
     .expect("second merge_scd2 run");
@@ -2010,6 +2041,7 @@ entities:
             run_id: Some("it-delta-merge-scd2-compare-normalized-init".to_string()),
             entities: Vec::new(),
             dry_run: false,
+            full_refresh: false,
         },
     )
     .expect("initial merge_scd2 run");
@@ -2028,6 +2060,7 @@ entities:
             run_id: Some("it-delta-merge-scd2-compare-normalized-second".to_string()),
             entities: Vec::new(),
             dry_run: false,
+            full_refresh: false,
         },
     )
     .expect("second merge_scd2 run");
@@ -2091,6 +2124,7 @@ entities:
             run_id: Some("it-delta-merge-scd2-nullable-init".to_string()),
             entities: Vec::new(),
             dry_run: false,
+            full_refresh: false,
         },
     )
     .expect("initial merge_scd2 run");
@@ -2105,6 +2139,7 @@ entities:
             run_id: Some("it-delta-merge-scd2-nullable-second".to_string()),
             entities: Vec::new(),
             dry_run: false,
+            full_refresh: false,
         },
     )
     .expect("second merge_scd2 run with null in configured nullable column");
@@ -2196,6 +2231,7 @@ entities:
             run_id: Some("it-delta-merge-scd2-city-init".to_string()),
             entities: Vec::new(),
             dry_run: false,
+            full_refresh: false,
         },
     )
     .expect("initial merge_scd2 run");
@@ -2239,6 +2275,7 @@ entities:
             run_id: Some("it-delta-merge-scd2-city-drift".to_string()),
             entities: Vec::new(),
             dry_run: false,
+            full_refresh: false,
         },
     )
     .expect_err("merge_scd2 with target-only business columns should fail");
@@ -2295,6 +2332,7 @@ entities:
             run_id: Some("it-delta-merge-scd1-nonadditive-init".to_string()),
             entities: Vec::new(),
             dry_run: false,
+            full_refresh: false,
         },
     )
     .expect("initial merge_scd1 run");
@@ -2340,6 +2378,7 @@ entities:
             run_id: Some("it-delta-merge-scd1-nonadditive-upsert".to_string()),
             entities: Vec::new(),
             dry_run: false,
+            full_refresh: false,
         },
     )
     .expect_err("merge_scd1 with type change should fail");
@@ -2393,6 +2432,7 @@ entities:
             run_id: Some("it-delta-merge-scd1-merge-key-init".to_string()),
             entities: Vec::new(),
             dry_run: false,
+            full_refresh: false,
         },
     )
     .expect("initial merge_scd1 run");
@@ -2438,6 +2478,7 @@ entities:
             run_id: Some("it-delta-merge-scd1-merge-key-upsert".to_string()),
             entities: Vec::new(),
             dry_run: false,
+            full_refresh: false,
         },
     )
     .expect_err("merge_scd1 with additive merge key should fail");

--- a/crates/floe-core/tests/integration/dry_run.rs
+++ b/crates/floe-core/tests/integration/dry_run.rs
@@ -67,6 +67,7 @@ entities:
             run_id: Some("it-dry".to_string()),
             entities: Vec::new(),
             dry_run: true,
+            full_refresh: false,
         },
     )
     .expect("dry run config");
@@ -128,6 +129,7 @@ entities:
             run_id: Some("it-dry-missing".to_string()),
             entities: Vec::new(),
             dry_run: true,
+            full_refresh: false,
         },
     )
     .expect_err("dry run should fail");

--- a/crates/floe-core/tests/integration/fixed_width.rs
+++ b/crates/floe-core/tests/integration/fixed_width.rs
@@ -64,6 +64,7 @@ entities:
             run_id: Some("fixed-width-parse".to_string()),
             entities: Vec::new(),
             dry_run: false,
+            full_refresh: false,
         },
     )
     .expect("run config");
@@ -139,6 +140,7 @@ entities:
             run_id: Some("fixed-width-cast".to_string()),
             entities: Vec::new(),
             dry_run: false,
+            full_refresh: false,
         },
     )
     .expect("run config");
@@ -200,6 +202,7 @@ entities:
             run_id: Some("fixed-width-unicode".to_string()),
             entities: Vec::new(),
             dry_run: false,
+            full_refresh: false,
         },
     )
     .expect("run config");

--- a/crates/floe-core/tests/integration/iceberg_gcs_run.rs
+++ b/crates/floe-core/tests/integration/iceberg_gcs_run.rs
@@ -69,6 +69,7 @@ entities:
             run_id: Some("it-iceberg-gcs-dry".to_string()),
             entities: Vec::new(),
             dry_run: true,
+            full_refresh: false,
         },
     )
     .expect("dry run config");
@@ -126,6 +127,7 @@ fn manual_gcs_iceberg_append_and_overwrite_write_layout_and_cleanup() {
             run_id: Some("it-iceberg-gcs-append1".to_string()),
             entities: Vec::new(),
             dry_run: false,
+            full_refresh: false,
         },
     )
     .expect("append run 1");
@@ -147,6 +149,7 @@ fn manual_gcs_iceberg_append_and_overwrite_write_layout_and_cleanup() {
             run_id: Some("it-iceberg-gcs-append2".to_string()),
             entities: Vec::new(),
             dry_run: false,
+            full_refresh: false,
         },
     )
     .expect("append run 2");
@@ -179,6 +182,7 @@ fn manual_gcs_iceberg_append_and_overwrite_write_layout_and_cleanup() {
             run_id: Some("it-iceberg-gcs-overwrite".to_string()),
             entities: Vec::new(),
             dry_run: false,
+            full_refresh: false,
         },
     )
     .expect("overwrite run");

--- a/crates/floe-core/tests/integration/iceberg_glue_run.rs
+++ b/crates/floe-core/tests/integration/iceberg_glue_run.rs
@@ -88,6 +88,7 @@ entities:
             run_id: Some("it-iceberg-glue-dry".to_string()),
             entities: Vec::new(),
             dry_run: true,
+            full_refresh: false,
         },
     )
     .expect("dry run config");
@@ -151,6 +152,7 @@ fn manual_glue_iceberg_append_and_overwrite_updates_glue_table_and_s3_layout() {
             run_id: Some("it-iceberg-glue-append1".to_string()),
             entities: Vec::new(),
             dry_run: false,
+            full_refresh: false,
         },
     )
     .expect("append run 1");
@@ -193,6 +195,7 @@ fn manual_glue_iceberg_append_and_overwrite_updates_glue_table_and_s3_layout() {
             run_id: Some("it-iceberg-glue-append2".to_string()),
             entities: Vec::new(),
             dry_run: false,
+            full_refresh: false,
         },
     )
     .expect("append run 2");
@@ -227,6 +230,7 @@ fn manual_glue_iceberg_append_and_overwrite_updates_glue_table_and_s3_layout() {
             run_id: Some("it-iceberg-glue-overwrite".to_string()),
             entities: Vec::new(),
             dry_run: false,
+            full_refresh: false,
         },
     )
     .expect("overwrite run");

--- a/crates/floe-core/tests/integration/iceberg_run.rs
+++ b/crates/floe-core/tests/integration/iceberg_run.rs
@@ -68,6 +68,7 @@ entities:
             run_id: Some("it-iceberg".to_string()),
             entities: Vec::new(),
             dry_run: false,
+            full_refresh: false,
         },
     )
     .expect("run config");
@@ -174,6 +175,7 @@ entities:
             run_id: Some("it-iceberg-partition-spec".to_string()),
             entities: Vec::new(),
             dry_run: false,
+            full_refresh: false,
         },
     )
     .expect("run config");

--- a/crates/floe-core/tests/integration/iceberg_s3_run.rs
+++ b/crates/floe-core/tests/integration/iceberg_s3_run.rs
@@ -70,6 +70,7 @@ entities:
             run_id: Some("it-iceberg-s3-dry".to_string()),
             entities: Vec::new(),
             dry_run: true,
+            full_refresh: false,
         },
     )
     .expect("dry run config");
@@ -131,6 +132,7 @@ fn manual_s3_iceberg_append_and_overwrite_write_layout_and_cleanup() {
             run_id: Some("it-iceberg-s3-append1".to_string()),
             entities: Vec::new(),
             dry_run: false,
+            full_refresh: false,
         },
     )
     .expect("append run 1");
@@ -152,6 +154,7 @@ fn manual_s3_iceberg_append_and_overwrite_write_layout_and_cleanup() {
             run_id: Some("it-iceberg-s3-append2".to_string()),
             entities: Vec::new(),
             dry_run: false,
+            full_refresh: false,
         },
     )
     .expect("append run 2");
@@ -185,6 +188,7 @@ fn manual_s3_iceberg_append_and_overwrite_write_layout_and_cleanup() {
             run_id: Some("it-iceberg-s3-overwrite".to_string()),
             entities: Vec::new(),
             dry_run: false,
+            full_refresh: false,
         },
     )
     .expect("overwrite run");

--- a/crates/floe-core/tests/integration/json_selectors.rs
+++ b/crates/floe-core/tests/integration/json_selectors.rs
@@ -87,6 +87,7 @@ entities:
             run_id: Some("it-json-strict".to_string()),
             entities: Vec::new(),
             dry_run: false,
+            full_refresh: false,
         },
     )
     .expect("run config");
@@ -161,6 +162,7 @@ entities:
             run_id: Some("it-json-coerce".to_string()),
             entities: Vec::new(),
             dry_run: false,
+            full_refresh: false,
         },
     )
     .expect("run config");
@@ -242,6 +244,7 @@ entities:
             run_id: Some("it-json-mismatch".to_string()),
             entities: Vec::new(),
             dry_run: false,
+            full_refresh: false,
         },
     )
     .expect("run config");

--- a/crates/floe-core/tests/integration/local_run.rs
+++ b/crates/floe-core/tests/integration/local_run.rs
@@ -66,6 +66,7 @@ entities:
             run_id: Some("it-run".to_string()),
             entities: Vec::new(),
             dry_run: false,
+            full_refresh: false,
         },
     )
     .expect("run config");
@@ -165,6 +166,7 @@ entities:
             run_id: Some("it-run-parquet-metrics".to_string()),
             entities: Vec::new(),
             dry_run: false,
+            full_refresh: false,
         },
     )
     .expect("run config");

--- a/crates/floe-core/tests/integration/path_normalization.rs
+++ b/crates/floe-core/tests/integration/path_normalization.rs
@@ -57,6 +57,7 @@ entities:
             run_id: Some("path-norm-it".to_string()),
             entities: Vec::new(),
             dry_run: false,
+            full_refresh: false,
         },
     )
     .expect("run config");

--- a/crates/floe-core/tests/integration/run_entities_filter.rs
+++ b/crates/floe-core/tests/integration/run_entities_filter.rs
@@ -95,6 +95,7 @@ entities:
             run_id: Some("it-run".to_string()),
             entities: vec!["employees".to_string()],
             dry_run: false,
+            full_refresh: false,
         },
     )
     .expect("run config");

--- a/crates/floe-core/tests/unit/io/read/avro_input.rs
+++ b/crates/floe-core/tests/unit/io/read/avro_input.rs
@@ -49,6 +49,7 @@ fn run_config(path: &Path) -> floe_core::RunOutcome {
             run_id: Some("test-run".to_string()),
             entities: Vec::new(),
             dry_run: false,
+            full_refresh: false,
         },
     )
     .expect("run config")

--- a/crates/floe-core/tests/unit/io/read/json_array.rs
+++ b/crates/floe-core/tests/unit/io/read/json_array.rs
@@ -37,6 +37,7 @@ fn run_config(path: &Path) -> floe_core::RunOutcome {
             run_id: Some("test-run".to_string()),
             entities: Vec::new(),
             dry_run: false,
+            full_refresh: false,
         },
     )
     .expect("run config")

--- a/crates/floe-core/tests/unit/io/read/json_ndjson.rs
+++ b/crates/floe-core/tests/unit/io/read/json_ndjson.rs
@@ -37,6 +37,7 @@ fn run_config(path: &Path) -> floe_core::RunOutcome {
             run_id: Some("test-run".to_string()),
             entities: Vec::new(),
             dry_run: false,
+            full_refresh: false,
         },
     )
     .expect("run config")

--- a/crates/floe-core/tests/unit/io/read/orc_input.rs
+++ b/crates/floe-core/tests/unit/io/read/orc_input.rs
@@ -67,6 +67,7 @@ fn run_config(path: &Path) -> floe_core::RunOutcome {
             run_id: Some("test-run".to_string()),
             entities: Vec::new(),
             dry_run: false,
+            full_refresh: false,
         },
     )
     .expect("run config")

--- a/crates/floe-core/tests/unit/io/read/parquet_input.rs
+++ b/crates/floe-core/tests/unit/io/read/parquet_input.rs
@@ -40,6 +40,7 @@ fn run_config(path: &Path) -> floe_core::RunOutcome {
             run_id: Some("test-run".to_string()),
             entities: Vec::new(),
             dry_run: false,
+            full_refresh: false,
         },
     )
     .expect("run config")

--- a/crates/floe-core/tests/unit/io/read/xlsx_input.rs
+++ b/crates/floe-core/tests/unit/io/read/xlsx_input.rs
@@ -32,6 +32,7 @@ fn run_config(path: &Path) -> floe_core::RunOutcome {
             run_id: Some("test-run".to_string()),
             entities: Vec::new(),
             dry_run: false,
+            full_refresh: false,
         },
     )
     .expect("run config")

--- a/crates/floe-core/tests/unit/io/read/xml.rs
+++ b/crates/floe-core/tests/unit/io/read/xml.rs
@@ -37,6 +37,7 @@ fn run_config(path: &Path) -> floe_core::RunOutcome {
             run_id: Some("test-run".to_string()),
             entities: Vec::new(),
             dry_run: false,
+            full_refresh: false,
         },
     )
     .expect("run config")

--- a/crates/floe-core/tests/unit/io/write/delta_merge.rs
+++ b/crates/floe-core/tests/unit/io/write/delta_merge.rs
@@ -65,6 +65,7 @@ entities:
             run_id: Some("unit-delta-merge-dup".to_string()),
             entities: Vec::new(),
             dry_run: false,
+            full_refresh: false,
         },
     )
     .expect("merge_scd1 should reject duplicate merge-key rows before merge in warn mode");
@@ -130,6 +131,7 @@ entities:
             run_id: Some("unit-delta-merge-init".to_string()),
             entities: Vec::new(),
             dry_run: false,
+            full_refresh: false,
         },
     )
     .expect("initial merge run");
@@ -148,6 +150,7 @@ entities:
             run_id: Some("unit-delta-merge-upsert".to_string()),
             entities: Vec::new(),
             dry_run: false,
+            full_refresh: false,
         },
     )
     .expect("merge upsert run");
@@ -218,6 +221,7 @@ entities:
             run_id: Some("unit-delta-merge-schema-evolution-init".to_string()),
             entities: Vec::new(),
             dry_run: false,
+            full_refresh: false,
         },
     )
     .expect("initial merge run");
@@ -272,6 +276,7 @@ entities:
             run_id: Some("unit-delta-merge-schema-evolution-upsert".to_string()),
             entities: Vec::new(),
             dry_run: false,
+            full_refresh: false,
         },
     )
     .expect("merge upsert with new column");

--- a/crates/floe-core/tests/unit/run/check_order.rs
+++ b/crates/floe-core/tests/unit/run/check_order.rs
@@ -38,6 +38,7 @@ fn run_config(path: &Path) -> floe_core::RunOutcome {
             run_id: Some("test-run".to_string()),
             entities: Vec::new(),
             dry_run: false,
+            full_refresh: false,
         },
     )
     .expect("run config")

--- a/crates/floe-core/tests/unit/run/entity/accepted_output.rs
+++ b/crates/floe-core/tests/unit/run/entity/accepted_output.rs
@@ -46,6 +46,7 @@ fn run_config(path: &Path) -> floe_core::RunOutcome {
             run_id: Some("test-run".to_string()),
             entities: Vec::new(),
             dry_run: false,
+            full_refresh: false,
         },
     )
     .expect("run config")

--- a/crates/floe-core/tests/unit/run/entity/incremental.rs
+++ b/crates/floe-core/tests/unit/run/entity/incremental.rs
@@ -163,6 +163,7 @@ fn run_config(path: &Path, run_id: &str) -> floe_core::RunOutcome {
             run_id: Some(run_id.to_string()),
             entities: Vec::new(),
             dry_run: false,
+            full_refresh: false,
         },
     )
     .expect("run config")
@@ -342,6 +343,7 @@ fn incremental_file_mode_fails_on_mismatched_state_entity() {
             run_id: Some("incremental-entity-mismatch".to_string()),
             entities: Vec::new(),
             dry_run: false,
+            full_refresh: false,
         },
     )
     .expect_err("mismatched entity state should fail");
@@ -390,6 +392,7 @@ fn incremental_file_mode_fails_on_mismatched_state_schema() {
             run_id: Some("incremental-schema-mismatch".to_string()),
             entities: Vec::new(),
             dry_run: false,
+            full_refresh: false,
         },
     )
     .expect_err("mismatched schema state should fail");
@@ -543,6 +546,7 @@ fn incremental_file_mode_releases_claims_after_error_exit() {
             run_id: Some("incremental-report-write-error".to_string()),
             entities: Vec::new(),
             dry_run: false,
+            full_refresh: false,
         },
     )
     .expect_err("report write should fail");
@@ -550,4 +554,256 @@ fn incremental_file_mode_releases_claims_after_error_exit() {
     assert!(read_entity_state(&state_path(&input_dir))
         .expect("read state")
         .is_none());
+}
+
+// ── full_refresh tests ────────────────────────────────────────────────────────
+
+fn run_config_full_refresh(path: &Path, run_id: &str) -> floe_core::RunOutcome {
+    run(
+        path,
+        RunOptions {
+            profile: None,
+            run_id: Some(run_id.to_string()),
+            entities: Vec::new(),
+            dry_run: false,
+            full_refresh: true,
+        },
+    )
+    .expect("run config with full_refresh")
+}
+
+#[test]
+fn full_refresh_processes_all_files_when_state_exists() {
+    let root = tempfile::TempDir::new().expect("temp dir");
+    let input_dir = root.path().join("in");
+    let accepted_dir = root.path().join("out/accepted");
+    let report_dir = root.path().join("report");
+    fs::create_dir_all(&input_dir).expect("create input dir");
+    write_csv(&input_dir, "a.csv", "id;name\n1;alice\n");
+    write_csv(&input_dir, "b.csv", "id;name\n2;bob\n");
+    let config_path = write_config(
+        root.path(),
+        &config_yaml(
+            &input_dir,
+            &accepted_dir,
+            None,
+            &report_dir,
+            "warn",
+            "",
+            None,
+        ),
+    );
+
+    // First run: commit both files to state.
+    let first = run_config(&config_path, "fr-first");
+    assert_eq!(first.summary.run.status, RunStatus::Success);
+    let state_after_first = read_entity_state(&state_path(&input_dir))
+        .expect("read state")
+        .expect("state exists");
+    assert_eq!(state_after_first.files.len(), 2);
+
+    // Full-refresh: both files must be processed (zero skipped).
+    let second = run_config_full_refresh(&config_path, "fr-second");
+    assert_eq!(second.summary.run.status, RunStatus::Success);
+    let report = &second.entity_outcomes[0].report;
+    assert_eq!(
+        report.results.files_skipped, 0,
+        "full_refresh must not skip any file"
+    );
+    assert_eq!(
+        report.results.files_total, 2,
+        "both files must be processed"
+    );
+    assert_eq!(report.results.rows_total, 2);
+}
+
+#[test]
+fn full_refresh_overwrites_sink_when_write_mode_is_append() {
+    let root = tempfile::TempDir::new().expect("temp dir");
+    let input_dir = root.path().join("in");
+    let accepted_dir = root.path().join("out/accepted");
+    let report_dir = root.path().join("report");
+    fs::create_dir_all(&input_dir).expect("create input dir");
+    write_csv(&input_dir, "customers.csv", "id;name\n1;alice\n");
+    let config_path = write_config(
+        root.path(),
+        &config_yaml(
+            &input_dir,
+            &accepted_dir,
+            None,
+            &report_dir,
+            "warn",
+            "",
+            Some("append"),
+        ),
+    );
+
+    let outcome = run_config_full_refresh(&config_path, "fr-append-overwrite");
+    assert_eq!(outcome.summary.run.status, RunStatus::Success);
+    // The effective write mode reported must be "overwrite" even though config says "append".
+    assert_eq!(
+        outcome.entity_outcomes[0]
+            .report
+            .accepted_output
+            .write_mode
+            .as_deref(),
+        Some("overwrite"),
+        "full_refresh must force overwrite on append-mode sinks"
+    );
+}
+
+#[test]
+fn full_refresh_commits_state_on_success() {
+    let root = tempfile::TempDir::new().expect("temp dir");
+    let input_dir = root.path().join("in");
+    let accepted_dir = root.path().join("out/accepted");
+    let report_dir = root.path().join("report");
+    fs::create_dir_all(&input_dir).expect("create input dir");
+    write_csv(&input_dir, "a.csv", "id;name\n1;alice\n");
+    write_csv(&input_dir, "b.csv", "id;name\n2;bob\n");
+    let config_path = write_config(
+        root.path(),
+        &config_yaml(
+            &input_dir,
+            &accepted_dir,
+            None,
+            &report_dir,
+            "warn",
+            "",
+            None,
+        ),
+    );
+
+    let outcome = run_config_full_refresh(&config_path, "fr-commit");
+    assert_eq!(outcome.summary.run.status, RunStatus::Success);
+
+    let state = read_entity_state(&state_path(&input_dir))
+        .expect("read state")
+        .expect("state must exist after full_refresh");
+    assert_eq!(
+        state.files.len(),
+        2,
+        "both files must be committed to state"
+    );
+    assert!(
+        state.claims.is_empty(),
+        "claims must be empty after successful commit"
+    );
+
+    // A subsequent normal run must skip both files (state is valid baseline).
+    let followup = run_config(&config_path, "fr-commit-followup");
+    assert_eq!(followup.summary.run.status, RunStatus::Success);
+    let report = &followup.entity_outcomes[0].report;
+    assert_eq!(
+        report.results.files_skipped, 2,
+        "next normal run must skip full_refresh output"
+    );
+}
+
+#[test]
+fn full_refresh_merge_mode_returns_config_error() {
+    let root = tempfile::TempDir::new().expect("temp dir");
+    let input_dir = root.path().join("in");
+    let accepted_dir = root.path().join("out/accepted");
+    let rejected_dir = root.path().join("out/rejected");
+    let report_dir = root.path().join("report");
+    fs::create_dir_all(&input_dir).expect("create input dir");
+    // Delta merge config with primary_key (required for merge modes to pass validate_config).
+    let config_content = format!(
+        r#"version: "0.1"
+report:
+  path: "{report_dir}"
+entities:
+  - name: "customer"
+    source:
+      format: "csv"
+      path: "{input_dir}"
+    sink:
+      write_mode: "merge_scd1"
+      accepted:
+        format: "delta"
+        path: "{accepted_dir}"
+      rejected:
+        format: "csv"
+        path: "{rejected_dir}"
+    policy:
+      severity: "reject"
+    schema:
+      primary_key: ["id"]
+      columns:
+        - name: "id"
+          type: "string"
+        - name: "name"
+          type: "string"
+"#,
+        report_dir = report_dir.display(),
+        input_dir = input_dir.display(),
+        accepted_dir = accepted_dir.display(),
+        rejected_dir = rejected_dir.display(),
+    );
+    let config_path = write_config(root.path(), &config_content);
+
+    let err = run(
+        &config_path,
+        RunOptions {
+            profile: None,
+            run_id: Some("fr-merge-error".to_string()),
+            entities: Vec::new(),
+            dry_run: false,
+            full_refresh: true,
+        },
+    )
+    .expect_err("full_refresh with merge_scd1 must return an error");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("customer"),
+        "error must name the entity; got: {msg}"
+    );
+    assert!(
+        msg.contains("merge_scd1"),
+        "error must name the write_mode; got: {msg}"
+    );
+    assert!(
+        msg.contains("full-refresh") || msg.contains("full_refresh"),
+        "error must mention full-refresh; got: {msg}"
+    );
+}
+
+#[test]
+fn full_refresh_false_unchanged_behaviour() {
+    let root = tempfile::TempDir::new().expect("temp dir");
+    let input_dir = root.path().join("in");
+    let accepted_dir = root.path().join("out/accepted");
+    let report_dir = root.path().join("report");
+    fs::create_dir_all(&input_dir).expect("create input dir");
+    write_csv(&input_dir, "customers.csv", "id;name\n1;alice\n");
+    let config_path = write_config(
+        root.path(),
+        &config_yaml(
+            &input_dir,
+            &accepted_dir,
+            None,
+            &report_dir,
+            "warn",
+            "",
+            None,
+        ),
+    );
+
+    // First run processes the file.
+    let first = run_config(&config_path, "fr-false-first");
+    assert_eq!(first.summary.run.status, RunStatus::Success);
+    let first_report = &first.entity_outcomes[0].report;
+    assert_eq!(first_report.results.files_total, 1);
+    assert_eq!(first_report.results.files_skipped, 0);
+
+    // Second run (full_refresh=false) must skip the already-ingested file.
+    let second = run_config(&config_path, "fr-false-second");
+    assert_eq!(second.summary.run.status, RunStatus::Success);
+    let second_report = &second.entity_outcomes[0].report;
+    assert_eq!(second_report.results.files_total, 1);
+    assert_eq!(
+        second_report.results.files_skipped, 1,
+        "full_refresh=false must skip committed files"
+    );
 }

--- a/crates/floe-core/tests/unit/run/entity/incremental.rs
+++ b/crates/floe-core/tests/unit/run/entity/incremental.rs
@@ -807,3 +807,73 @@ fn full_refresh_false_unchanged_behaviour() {
         "full_refresh=false must skip committed files"
     );
 }
+
+#[test]
+fn full_refresh_preserves_state_on_failure() {
+    let root = tempfile::TempDir::new().expect("temp dir");
+    let input_dir = root.path().join("in");
+    let accepted_dir = root.path().join("out/accepted");
+    let rejected_dir = root.path().join("out/rejected");
+    let report_dir = root.path().join("report");
+    fs::create_dir_all(&input_dir).expect("create input dir");
+
+    // First run: commit one valid file to state as the baseline.
+    write_csv(&input_dir, "customers.csv", "id;name\n1;alice\n");
+    let config_path = write_config(
+        root.path(),
+        &config_yaml(
+            &input_dir,
+            &accepted_dir,
+            None,
+            &report_dir,
+            "warn",
+            "",
+            None,
+        ),
+    );
+    let first = run_config(&config_path, "fr-fail-baseline");
+    assert_eq!(first.summary.run.status, RunStatus::Success);
+    let baseline = read_entity_state(&state_path(&input_dir))
+        .expect("read state")
+        .expect("state must be committed after first run");
+    assert_eq!(baseline.files.len(), 1, "baseline must have one file");
+
+    // Second run: full-refresh with a CSV that causes abort (missing column + reject_file mismatch).
+    // Replace the CSV with one that lacks the required "name" column.
+    write_csv(&input_dir, "customers.csv", "id\n1\n");
+    let mismatch_block = "      mismatch:\n        missing_columns: \"reject_file\"\n";
+    let abort_config_path = write_config(
+        root.path(),
+        &config_yaml(
+            &input_dir,
+            &accepted_dir,
+            Some(&rejected_dir),
+            &report_dir,
+            "abort",
+            mismatch_block,
+            None,
+        ),
+    );
+    let second = run(
+        &abort_config_path,
+        RunOptions {
+            profile: None,
+            run_id: Some("fr-fail-run".to_string()),
+            entities: Vec::new(),
+            dry_run: false,
+            full_refresh: true,
+        },
+    )
+    .expect("aborted run returns Ok outcome");
+    assert_eq!(second.summary.run.status, RunStatus::Aborted);
+
+    // The original baseline must survive the failed full-refresh.
+    let after_fail = read_entity_state(&state_path(&input_dir))
+        .expect("read state")
+        .expect("state must persist after a failed full-refresh");
+    assert_eq!(
+        after_fail.files.len(),
+        1,
+        "original baseline must be preserved after a failed full-refresh"
+    );
+}

--- a/crates/floe-core/tests/unit/run/schema_mismatch.rs
+++ b/crates/floe-core/tests/unit/run/schema_mismatch.rs
@@ -132,6 +132,7 @@ fn run_config(path: &Path) -> floe_core::RunOutcome {
             run_id: Some("test-run".to_string()),
             entities: Vec::new(),
             dry_run: false,
+            full_refresh: false,
         },
     )
     .expect("run config")

--- a/crates/floe-python/python/floe/_floe.pyi
+++ b/crates/floe-python/python/floe/_floe.pyi
@@ -161,6 +161,7 @@ def run(
     entities: list[str] | None = None,
     dry_run: bool = False,
     run_id: str | None = None,
+    full_refresh: bool = False,
     profile_vars: dict[str, str] | None = None,
     profile_path: str | None = None,
 ) -> RunOutcome:

--- a/crates/floe-python/src/functions.rs
+++ b/crates/floe-python/src/functions.rs
@@ -70,12 +70,13 @@ pub fn validate(
 }
 
 #[pyfunction]
-#[pyo3(signature = (config_path, entities=None, dry_run=false, run_id=None, profile_vars=None, profile_path=None))]
+#[pyo3(signature = (config_path, entities=None, dry_run=false, full_refresh=false, run_id=None, profile_vars=None, profile_path=None))]
 pub fn run(
     py: Python<'_>,
     config_path: &str,
     entities: Option<Vec<String>>,
     dry_run: bool,
+    full_refresh: bool,
     run_id: Option<String>,
     profile_vars: Option<HashMap<String, String>>,
     profile_path: Option<String>,
@@ -86,6 +87,7 @@ pub fn run(
         run_id,
         entities: entities.unwrap_or_default(),
         dry_run,
+        full_refresh,
         profile,
     };
     let outcome = py

--- a/crates/floe-python/src/functions.rs
+++ b/crates/floe-python/src/functions.rs
@@ -70,14 +70,14 @@ pub fn validate(
 }
 
 #[pyfunction]
-#[pyo3(signature = (config_path, entities=None, dry_run=false, full_refresh=false, run_id=None, profile_vars=None, profile_path=None))]
+#[pyo3(signature = (config_path, entities=None, dry_run=false, run_id=None, full_refresh=false, profile_vars=None, profile_path=None))]
 pub fn run(
     py: Python<'_>,
     config_path: &str,
     entities: Option<Vec<String>>,
     dry_run: bool,
-    full_refresh: bool,
     run_id: Option<String>,
+    full_refresh: bool,
     profile_vars: Option<HashMap<String, String>>,
     profile_path: Option<String>,
 ) -> PyResult<PyRunOutcome> {


### PR DESCRIPTION
## Summary

- Adds `--full-refresh` / `-F` to `floe run` and `full_refresh` param to the Python SDK `run()` — a single atomic flag replacing the manual `floe state reset` + `floe run` two-step
- When set: all input files are reprocessed (incremental state bypassed), `append`-mode sinks are promoted to `overwrite` for the run, state is committed on success so the next normal run is incremental again
- `merge_scd1` / `merge_scd2` entities are rejected at startup with a clear error (they require the full dataset; partial overwrite would corrupt them)
- New `claim_all_entity_inputs` helper reads the existing state only to obtain the CAS version, then writes a blank `EntityState` with fresh claims — avoids the O(n) scan over historical `files` map, making full-refresh faster than a normal incremental run on large states

## Changes

| File | Change |
|---|---|
| `floe-core/src/lib.rs` | `full_refresh: bool` added to `RunOptions` |
| `floe-core/src/run/context.rs` | `full_refresh: bool` threaded into `RunContext` |
| `floe-core/src/run/mod.rs` | Merge-mode validation guard at startup |
| `floe-core/src/state/mod.rs` | New `claim_all_entity_inputs` function |
| `floe-core/src/run/entity/incremental.rs` | Full-refresh arm in `prepare_incremental_context` |
| `floe-core/src/run/entity/mod.rs` | `write_mode` override for append→overwrite |
| `floe-cli/src/main.rs` | `--full-refresh` / `-F` CLI flag |
| `floe-python/src/functions.rs` | `full_refresh` Python binding |
| `tests/unit/run/entity/incremental.rs` | 5 new unit tests |
| `tests/integration/**` + `tests/unit/**` | `full_refresh: false` added to existing `RunOptions` literals |

## Test plan

- [x] `cargo fmt --all` — clean
- [x] `cargo clippy -p floe-core -p floe-cli -p floe-python -- -D warnings` — clean
- [x] `cargo test -p floe-core` — 517 passed, 0 failed
  - `full_refresh_processes_all_files_when_state_exists` ✓
  - `full_refresh_overwrites_sink_when_write_mode_is_append` ✓
  - `full_refresh_commits_state_on_success` ✓
  - `full_refresh_merge_mode_returns_config_error` ✓
  - `full_refresh_false_unchanged_behaviour` ✓

Closes #346