### PR TITLE
fix(iceberg): use correct StorageFactory for REST catalog on S3/GCS

### DIFF
--- a/crates/floe-core/src/io/write/iceberg.rs
+++ b/crates/floe-core/src/io/write/iceberg.rs
@@ -627,9 +627,14 @@ fn seed_iceberg_from_catalog(
                 .map_err(|err| Box::new(RunError(format!("glue iceberg seed failed: {err}"))))?;
             seed_from_batches(tracker, batches, rename_back)
         }
-        IcebergCatalogConfig::Rest(rest_cfg) => {
-            seed_iceberg_from_rest(tracker, rest_cfg, file_io_props, scan_cols, rename_back)
-        }
+        IcebergCatalogConfig::Rest(rest_cfg) => seed_iceberg_from_rest(
+            tracker,
+            rest_cfg,
+            file_io_props,
+            &warehouse_location,
+            scan_cols,
+            rename_back,
+        ),
     }
 }
 
@@ -637,6 +642,7 @@ fn seed_iceberg_from_rest(
     tracker: &mut check::UniqueTracker,
     rest_cfg: &RestIcebergCatalogConfig,
     file_io_props: HashMap<String, String>,
+    warehouse_location: &str,
     scan_cols: &[String],
     rename_back: &HashMap<String, String>,
 ) -> FloeResult<()> {
@@ -653,7 +659,7 @@ fn seed_iceberg_from_rest(
 
     let batches = runtime
         .block_on(async {
-            let catalog = build_rest_catalog(rest_cfg, file_io_props).await?;
+            let catalog = build_rest_catalog(rest_cfg, file_io_props, warehouse_location).await?;
             let namespace = NamespaceIdent::new(rest_cfg.namespace.clone());
 
             if !catalog

--- a/crates/floe-core/src/io/write/iceberg/rest.rs
+++ b/crates/floe-core/src/io/write/iceberg/rest.rs
@@ -9,6 +9,7 @@ use iceberg::{Catalog, CatalogBuilder, NamespaceIdent, TableIdent};
 use iceberg_catalog_rest::{
     RestCatalogBuilder, REST_CATALOG_PROP_URI, REST_CATALOG_PROP_WAREHOUSE,
 };
+use iceberg_storage_opendal::OpenDalStorageFactory;
 
 use crate::config::CatalogTypeConfig;
 use crate::errors::RunError;
@@ -28,6 +29,7 @@ use super::{map_iceberg_err, IcebergWriteResult, PreparedIcebergWrite};
 pub(crate) async fn build_rest_catalog(
     rest_cfg: &RestIcebergCatalogConfig,
     file_io_props: HashMap<String, String>,
+    table_location: &str,
 ) -> FloeResult<iceberg_catalog_rest::RestCatalog> {
     let mut props: HashMap<String, String> = file_io_props;
 
@@ -63,7 +65,29 @@ pub(crate) async fn build_rest_catalog(
         props.insert("scope".to_string(), scope.to_string());
     }
 
-    let storage_factory: Arc<dyn StorageFactory> = Arc::new(LocalFsStorageFactory);
+    // Prefer the concrete table location for storage factory dispatch; fall back to the
+    // warehouse field for cases where the caller only has catalog-level config (e.g. seeding).
+    let effective_uri = if !table_location.is_empty() {
+        table_location
+    } else {
+        rest_cfg.warehouse.as_deref().unwrap_or("")
+    };
+    let storage_factory: Arc<dyn StorageFactory> =
+        if effective_uri.starts_with("s3://") || effective_uri.starts_with("s3a://") {
+            let scheme = effective_uri
+                .split("://")
+                .next()
+                .unwrap_or("s3")
+                .to_string();
+            Arc::new(OpenDalStorageFactory::S3 {
+                configured_scheme: scheme,
+                customized_credential_load: None,
+            })
+        } else if effective_uri.starts_with("gs://") {
+            Arc::new(OpenDalStorageFactory::Gcs)
+        } else {
+            Arc::new(LocalFsStorageFactory)
+        };
 
     RestCatalogBuilder::default()
         .with_storage_factory(storage_factory)
@@ -125,7 +149,7 @@ pub(crate) async fn write_via_rest_catalog(
     mode: config::WriteMode,
     small_file_threshold_bytes: u64,
 ) -> FloeResult<IcebergWriteResult> {
-    let catalog = build_rest_catalog(rest_cfg, file_io_props).await?;
+    let catalog = build_rest_catalog(rest_cfg, file_io_props, &table_root_uri).await?;
 
     let namespace_name = rest_cfg.namespace.clone();
     let namespace = NamespaceIdent::new(namespace_name);


### PR DESCRIPTION
## Summary

- `build_rest_catalog()` was hardcoded to `LocalFsStorageFactory` regardless of the warehouse URI scheme, causing all data file reads and writes to fail when the table is backed by S3 or GCS.
- The fix dispatches on the **actual table location URI** (`table_root_uri` for writes, `warehouse_location` for uniqueness seeding), falling back to `rest_cfg.warehouse` when no concrete table location is available.
- `OpenDalStorageFactory` was already a dependency (used in the non-REST Iceberg path); no `Cargo.toml` changes required.

Fixes #348 — REST catalog (Polaris) Iceberg writes fail on S3 — `LocalFsStorageFactory` hardcoded  
Fixes #349 — REST Iceberg catalog writes to S3 use `LocalFsStorageFactory` in manifest mode (Polaris `warehouse` field is a catalog name, not an S3 URI — the old `rest_cfg.warehouse`-based dispatch missed this case entirely)

## Changes

**`crates/floe-core/src/io/write/iceberg/rest.rs`**
- Added `use iceberg_storage_opendal::OpenDalStorageFactory;`
- Added `table_location: &str` parameter to `build_rest_catalog()`
- Replaced hardcoded `Arc::new(LocalFsStorageFactory)` with scheme-based dispatch: `s3://`/`s3a://` → `OpenDalStorageFactory::S3`, `gs://` → `OpenDalStorageFactory::Gcs`, anything else → `LocalFsStorageFactory`
- Updated `write_via_rest_catalog()` call site to pass `&table_root_uri`

**`crates/floe-core/src/io/write/iceberg.rs`**
- Added `warehouse_location: &str` parameter to `seed_iceberg_from_rest()`
- Updated the call site in `seed_iceberg_from_catalog()` to pass `&warehouse_location`
- Updated `build_rest_catalog()` call to pass `warehouse_location`

## Test plan

- [x] `cargo fmt --all` — clean
- [x] `cargo clippy -p floe-core -- -D warnings` — no warnings
- [x] `cargo test -p floe-core` — 518 tests pass
- [x] Integration: configure a REST catalog pointing at Polaris/Snowflake Open Catalog with `warehouse = "s3://..."` and assert `run_finished.status == "success"`, data files appear on S3 (covers #348)
- [x] Integration: configure a REST catalog with `warehouse = "lakehouse"` (Polaris catalog name) and `warehouse_prefix = "s3://..."` and assert same (covers #349 manifest mode)
- [x] Regression: local Nessie REST catalog — assert behaviour unchanged (falls through to `LocalFsStorageFactory`)