### PR TITLE
chore: bump floe to v0.4.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to Floe are documented in this file.
 
 ## Unreleased
 
+## v0.4.4
+
+- **REST catalog: correct storage factory for S3 and GCS** (fixes #348 #349):
+  - `build_rest_catalog()` previously always used `LocalFsStorageFactory` regardless of warehouse scheme, causing Parquet data file reads/writes to fail with OS-level errors on any cloud-backed REST catalog (Polaris, Snowflake Open Catalog, Nessie with S3).
+  - The factory is now selected based on the concrete table location URI (`s3://`, `s3a://` → `OpenDalStorageFactory::S3`; `gs://` → `OpenDalStorageFactory::Gcs`; everything else → `LocalFsStorageFactory`).
+  - When the warehouse field is a catalog name rather than a storage URI (e.g. Polaris `"lakehouse"`), the table location from `warehouse_location` / `table_root_uri` is used as the primary dispatch key, with `warehouse` as fallback.
+  - Both write and uniqueness-seed (Append dedup) paths are fixed.
+
+- **`floe` 0.4.4**: version bump for this release.
+
 ## v0.4.3
 
 - **Remote manifest support for `floe run --manifest`** (`docs/cli.md`, fixes #342):

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3399,7 +3399,7 @@ dependencies = [
 
 [[package]]
 name = "floe-cli"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "assert_cmd",
  "clap",
@@ -3412,7 +3412,7 @@ dependencies = [
 
 [[package]]
 name = "floe-core"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "apache-avro 0.16.0",
  "arrow",
@@ -3455,7 +3455,7 @@ dependencies = [
 
 [[package]]
 name = "floe-python"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "floe-core",
  "pyo3",

--- a/crates/floe-cli/Cargo.toml
+++ b/crates/floe-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "floe-cli"
-version = "0.4.3"
+version = "0.4.4"
 edition = "2021"
 description = "CLI for Floe, a YAML-driven technical ingestion tool."
 license = "MIT"
@@ -17,7 +17,7 @@ path = "src/main.rs"
 
 [dependencies]
 clap = { version = "4", features = ["derive"] }
-floe-core = { path = "../floe-core", version = "0.4.3" }
+floe-core = { path = "../floe-core", version = "0.4.4" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 

--- a/crates/floe-core/Cargo.toml
+++ b/crates/floe-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "floe-core"
-version = "0.4.3"
+version = "0.4.4"
 edition = "2021"
 description = "Core library for Floe, a YAML-driven technical ingestion tool."
 license = "MIT"

--- a/crates/floe-python/Cargo.toml
+++ b/crates/floe-python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "floe-python"
-version = "0.4.3"
+version = "0.4.4"
 edition = "2021"
 description = "Python bindings for floe-core (PyO3-based)"
 license = "Apache-2.0"
@@ -13,7 +13,7 @@ name = "_floe"
 crate-type = ["cdylib"]
 
 [dependencies]
-floe-core = { path = "../floe-core", version = "0.4.3" }
+floe-core = { path = "../floe-core", version = "0.4.4" }
 pyo3 = { version = "0.22", features = ["extension-module", "abi3-py310"] }
 serde_json = "1"
 

--- a/crates/floe-python/pyproject.toml
+++ b/crates/floe-python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "floe-python"
-version = "0.4.3"
+version = "0.4.4"
 description = "Python bindings for floe-core — run floe pipelines at Rust speed from Python and notebooks"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Bump `floe-core`, `floe-cli`, and `floe-python` (Cargo + pyproject) from `0.4.3` → `0.4.4`
- Add `v0.4.4` CHANGELOG entry documenting the REST catalog storage factory fix
- Update `Cargo.lock`

## Context

This version bump accompanies #350, which fixes REST catalog Iceberg writes on S3/GCS (issues #348 and #349). No orchestrator bumps needed — `dagster-floe` and `airflow-floe` are unchanged in this release.

## Test plan

- [x] CI passes (fmt, clippy, tests)
- [x] Versions read `0.4.4` across all three crates
EOF
)