### PR TITLE
fix(manifest): write remote summary and enrich run_finished event

### DIFF
--- a/crates/floe-cli/src/logging.rs
+++ b/crates/floe-cli/src/logging.rs
@@ -121,6 +121,8 @@ pub fn emit_failed_run_events_to(
         warnings: 0,
         errors: 1,
         summary_uri: None,
+        report_base: None,
+        entity_report_uris: std::collections::HashMap::new(),
         ts_ms: now_ms(),
     });
 }

--- a/crates/floe-core/src/config/storage.rs
+++ b/crates/floe-core/src/config/storage.rs
@@ -215,7 +215,7 @@ impl StorageResolver {
         raw_path: &str,
     ) -> FloeResult<ResolvedPath> {
         let name = storage_name.unwrap_or(self.default_name.as_str());
-        if !self.has_config && name != "local" {
+        if !self.has_config && name != "local" && !self.definitions.contains_key(name) {
             return Err(Box::new(ConfigError(format!(
                 "entity.name={} {field} references unknown storage {} (no storages block)",
                 entity_name, name
@@ -306,7 +306,7 @@ impl StorageResolver {
         raw_path: &str,
     ) -> FloeResult<ResolvedPath> {
         let name = storage_name.unwrap_or(self.default_name.as_str());
-        if !self.has_config && name != "local" {
+        if !self.has_config && name != "local" && !self.definitions.contains_key(name) {
             return Err(Box::new(ConfigError(format!(
                 "report.storage references unknown storage {} (no storages block)",
                 name
@@ -421,14 +421,17 @@ impl StorageResolver {
 
     /// Register a synthetic `StorageDefinition` into this resolver.
     /// Used in manifest mode when the report URI has no matching definition in the config.
+    /// Does NOT flip `has_config`; entity resolution keeps its implicit-local fallback.
     pub fn register_definition(&mut self, definition: StorageDefinition) {
         self.definitions.insert(definition.name.clone(), definition);
-        self.has_config = true;
     }
 
     pub fn definition(&self, name: &str) -> Option<StorageDefinition> {
         if self.has_config {
             self.definitions.get(name).cloned()
+        } else if let Some(def) = self.definitions.get(name) {
+            // Synthetic definition registered by register_definition (e.g. report target).
+            Some(def.clone())
         } else if name == "local" {
             Some(StorageDefinition {
                 name: "local".to_string(),

--- a/crates/floe-core/src/config/storage.rs
+++ b/crates/floe-core/src/config/storage.rs
@@ -390,6 +390,42 @@ impl StorageResolver {
         }
     }
 
+    /// Scan definitions for the first one whose scheme and bucket/account match `uri`.
+    /// Used in manifest mode to resolve a bare report URI back to a named definition.
+    pub fn find_definition_name_for_uri(&self, uri: &str) -> Option<String> {
+        for (name, def) in &self.definitions {
+            if uri.starts_with("s3://") && def.fs_type == "s3" {
+                if let Some(b) = &def.bucket {
+                    if uri.starts_with(&format!("s3://{b}/")) || uri == format!("s3://{b}") {
+                        return Some(name.clone());
+                    }
+                }
+            }
+            if uri.starts_with("gs://") && def.fs_type == "gcs" {
+                if let Some(b) = &def.bucket {
+                    if uri.starts_with(&format!("gs://{b}/")) || uri == format!("gs://{b}") {
+                        return Some(name.clone());
+                    }
+                }
+            }
+            if uri.starts_with("abfs://") && def.fs_type == "adls" {
+                if let (Some(c), Some(a)) = (&def.container, &def.account) {
+                    if uri.starts_with(&format!("abfs://{c}@{a}")) {
+                        return Some(name.clone());
+                    }
+                }
+            }
+        }
+        None
+    }
+
+    /// Register a synthetic `StorageDefinition` into this resolver.
+    /// Used in manifest mode when the report URI has no matching definition in the config.
+    pub fn register_definition(&mut self, definition: StorageDefinition) {
+        self.definitions.insert(definition.name.clone(), definition);
+        self.has_config = true;
+    }
+
     pub fn definition(&self, name: &str) -> Option<StorageDefinition> {
         if self.has_config {
             self.definitions.get(name).cloned()

--- a/crates/floe-core/src/config/storage.rs
+++ b/crates/floe-core/src/config/storage.rs
@@ -410,7 +410,7 @@ impl StorageResolver {
             }
             if uri.starts_with("abfs://") && def.fs_type == "adls" {
                 if let (Some(c), Some(a)) = (&def.container, &def.account) {
-                    if uri.starts_with(&format!("abfs://{c}@{a}")) {
+                    if uri.starts_with(&format!("abfs://{c}@{a}.dfs.core.windows.net")) {
                         return Some(name.clone());
                     }
                 }

--- a/crates/floe-core/src/run/context.rs
+++ b/crates/floe-core/src/run/context.rs
@@ -96,7 +96,7 @@ impl RunContext {
         report_base_uri: &str,
         options: &RunOptions,
     ) -> FloeResult<Self> {
-        let storage_resolver = config::StorageResolver::new(&config, config_base)?;
+        let mut storage_resolver = config::StorageResolver::new(&config, config_base)?;
         let catalog_resolver = config::CatalogResolver::new(&config)?;
         let config_dir =
             crate::io::storage::paths::normalize_local_path(storage_resolver.config_dir());
@@ -108,7 +108,7 @@ impl RunContext {
             crate::io::storage::paths::normalize_local_path(manifest_path)
         };
 
-        // The manifest embeds report_base_uri; resolve it to a target if it looks local.
+        // The manifest embeds report_base_uri; resolve it to a Target.
         let (report_target, report_base_path) =
             if !report_base_uri.is_empty() && report_base_uri != "report" {
                 let local_path = if let Some(stripped) = report_base_uri.strip_prefix("local://") {
@@ -122,15 +122,18 @@ impl RunContext {
                     .as_ref()
                     .map(|p| p.display().to_string())
                     .unwrap_or_else(|| report_base_uri.to_string());
-                // Only attempt to create a Target for local paths; skip for remote URIs.
-                let report_target = local_path.as_ref().and_then(|path| {
+                let report_target = if let Some(path) = local_path.as_ref() {
                     let resolved = config::ResolvedPath {
                         storage: "local".to_string(),
                         uri: report_base_uri.to_string(),
                         local_path: Some(path.clone()),
                     };
                     Target::from_resolved(&resolved).ok()
-                });
+                } else if config::is_remote_uri(report_base_uri) {
+                    build_remote_report_target(report_base_uri, &mut storage_resolver)
+                } else {
+                    None
+                };
                 (report_target, Some(base_path))
             } else {
                 (None, None)
@@ -156,6 +159,82 @@ impl RunContext {
             full_refresh: options.full_refresh,
         })
     }
+}
+
+fn build_remote_report_target(uri: &str, resolver: &mut config::StorageResolver) -> Option<Target> {
+    let storage_name = if let Some(name) = resolver.find_definition_name_for_uri(uri) {
+        name
+    } else if let Some((def, name)) = synthetic_storage_for_uri(uri) {
+        resolver.register_definition(def);
+        name
+    } else {
+        return None;
+    };
+    let resolved = config::ResolvedPath {
+        storage: storage_name,
+        uri: uri.to_string(),
+        local_path: None,
+    };
+    Target::from_resolved(&resolved).ok()
+}
+
+fn synthetic_storage_for_uri(uri: &str) -> Option<(config::StorageDefinition, String)> {
+    use crate::io::storage::{adls, gcs, s3};
+    if uri.starts_with("s3://") {
+        let loc = s3::parse_s3_uri(uri).ok()?;
+        let name = "__report_s3__".to_string();
+        return Some((
+            config::StorageDefinition {
+                name: name.clone(),
+                fs_type: "s3".to_string(),
+                bucket: Some(loc.bucket),
+                region: None,
+                endpoint: None,
+                path_style_access: None,
+                account: None,
+                container: None,
+                prefix: None,
+            },
+            name,
+        ));
+    }
+    if uri.starts_with("gs://") {
+        let loc = gcs::parse_gcs_uri(uri).ok()?;
+        let name = "__report_gcs__".to_string();
+        return Some((
+            config::StorageDefinition {
+                name: name.clone(),
+                fs_type: "gcs".to_string(),
+                bucket: Some(loc.bucket),
+                region: None,
+                endpoint: None,
+                path_style_access: None,
+                account: None,
+                container: None,
+                prefix: None,
+            },
+            name,
+        ));
+    }
+    if uri.starts_with("abfs://") {
+        let loc = adls::parse_adls_uri(uri).ok()?;
+        let name = "__report_adls__".to_string();
+        return Some((
+            config::StorageDefinition {
+                name: name.clone(),
+                fs_type: "adls".to_string(),
+                bucket: None,
+                region: None,
+                endpoint: None,
+                path_style_access: None,
+                account: Some(loc.account),
+                container: Some(loc.container),
+                prefix: None,
+            },
+            name,
+        ));
+    }
+    None
 }
 
 #[cfg(test)]

--- a/crates/floe-core/src/run/events.rs
+++ b/crates/floe-core/src/run/events.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, OnceLock};
 
@@ -78,6 +79,10 @@ pub enum RunEvent {
         warnings: u64,
         errors: u64,
         summary_uri: Option<String>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        report_base: Option<String>,
+        #[serde(skip_serializing_if = "HashMap::is_empty")]
+        entity_report_uris: HashMap<String, String>,
         ts_ms: u128,
     },
 }

--- a/crates/floe-core/src/run/mod.rs
+++ b/crates/floe-core/src/run/mod.rs
@@ -286,9 +286,9 @@ fn run_from_context(
         }
     }
     let summary = build_run_summary(&context, &entity_outcomes);
-    if let Some(report_target) = &context.report_target {
+    let written_summary_uri = if let Some(report_target) = &context.report_target {
         let summary_write_start = perf_enabled.then(Instant::now);
-        write_summary_report(
+        let uri = write_summary_report(
             report_target,
             &context.run_id,
             &summary,
@@ -308,7 +308,22 @@ fn run_from_context(
                 }),
             );
         }
-    }
+        Some(uri)
+    } else {
+        None
+    };
+    let entity_report_uris: std::collections::HashMap<String, String> = entity_outcomes
+        .iter()
+        .filter_map(|outcome| {
+            let uri = context.report_target.as_ref().map(|t| {
+                t.join_relative(&report::ReportWriter::report_relative_path(
+                    &context.run_id,
+                    &outcome.report.entity.name,
+                ))
+            })?;
+            Some((outcome.report.entity.name.clone(), uri))
+        })
+        .collect();
     observer.on_event(RunEvent::RunFinished {
         run_id: context.run_id.clone(),
         status: run_status_str(summary.run.status).to_string(),
@@ -320,11 +335,9 @@ fn run_from_context(
         rejected: summary.results.rejected_total,
         warnings: summary.results.warnings_total,
         errors: summary.results.errors_total,
-        summary_uri: context.report_target.as_ref().map(|target| {
-            target.join_relative(&report::ReportWriter::summary_relative_path(
-                &context.run_id,
-            ))
-        }),
+        summary_uri: written_summary_uri,
+        report_base: context.report_base_path.clone(),
+        entity_report_uris,
         ts_ms: event_time_ms(),
     });
 

--- a/crates/floe-core/tests/unit/config/mod.rs
+++ b/crates/floe-core/tests/unit/config/mod.rs
@@ -10,4 +10,5 @@ pub mod local_storage;
 pub mod parse;
 pub mod pii_validation;
 pub mod remote_base;
+pub mod storage_resolver_uri;
 pub mod templating;

--- a/crates/floe-core/tests/unit/config/storage_resolver_uri.rs
+++ b/crates/floe-core/tests/unit/config/storage_resolver_uri.rs
@@ -1,0 +1,124 @@
+use floe_core::config::{
+    ConfigBase, RootConfig, StorageDefinition, StorageResolver, StoragesConfig,
+};
+use std::path::PathBuf;
+
+fn resolver_with_definitions(defs: Vec<StorageDefinition>) -> StorageResolver {
+    let default = defs.first().map(|d| d.name.clone()).unwrap_or_default();
+    let config = RootConfig {
+        version: "0.1".to_string(),
+        metadata: None,
+        storages: Some(StoragesConfig {
+            default: Some(default),
+            definitions: defs,
+        }),
+        catalogs: None,
+        env: None,
+        domains: vec![],
+        report: None,
+        lineage: None,
+        entities: vec![],
+    };
+    let base = ConfigBase::local_from_path(&PathBuf::from("/tmp/config.yml"));
+    StorageResolver::new(&config, base).expect("resolver")
+}
+
+fn s3_def(name: &str, bucket: &str) -> StorageDefinition {
+    StorageDefinition {
+        name: name.to_string(),
+        fs_type: "s3".to_string(),
+        bucket: Some(bucket.to_string()),
+        region: None,
+        endpoint: None,
+        path_style_access: None,
+        account: None,
+        container: None,
+        prefix: None,
+    }
+}
+
+fn gcs_def(name: &str, bucket: &str) -> StorageDefinition {
+    StorageDefinition {
+        name: name.to_string(),
+        fs_type: "gcs".to_string(),
+        bucket: Some(bucket.to_string()),
+        region: None,
+        endpoint: None,
+        path_style_access: None,
+        account: None,
+        container: None,
+        prefix: None,
+    }
+}
+
+fn adls_def(name: &str, container: &str, account: &str) -> StorageDefinition {
+    StorageDefinition {
+        name: name.to_string(),
+        fs_type: "adls".to_string(),
+        bucket: None,
+        region: None,
+        endpoint: None,
+        path_style_access: None,
+        account: Some(account.to_string()),
+        container: Some(container.to_string()),
+        prefix: None,
+    }
+}
+
+#[test]
+fn find_s3_definition_by_uri_with_path() {
+    let resolver = resolver_with_definitions(vec![s3_def("reports", "my-reports")]);
+    assert_eq!(
+        resolver.find_definition_name_for_uri("s3://my-reports/floe/run123/"),
+        Some("reports".to_string())
+    );
+}
+
+#[test]
+fn find_s3_definition_by_uri_exact_bucket() {
+    let resolver = resolver_with_definitions(vec![s3_def("reports", "my-reports")]);
+    assert_eq!(
+        resolver.find_definition_name_for_uri("s3://my-reports"),
+        Some("reports".to_string())
+    );
+}
+
+#[test]
+fn find_gcs_definition_by_uri() {
+    let resolver = resolver_with_definitions(vec![gcs_def("gcs_store", "gcs-bucket")]);
+    assert_eq!(
+        resolver.find_definition_name_for_uri("gs://gcs-bucket/reports/"),
+        Some("gcs_store".to_string())
+    );
+}
+
+#[test]
+fn find_adls_definition_by_uri() {
+    let resolver =
+        resolver_with_definitions(vec![adls_def("adls_store", "mycontainer", "myaccount")]);
+    assert_eq!(
+        resolver.find_definition_name_for_uri("abfs://mycontainer@myaccount/reports/run1/"),
+        Some("adls_store".to_string())
+    );
+}
+
+#[test]
+fn find_definition_returns_none_when_no_match() {
+    let resolver = resolver_with_definitions(vec![s3_def("other", "different-bucket")]);
+    assert_eq!(
+        resolver.find_definition_name_for_uri("s3://my-reports/path/"),
+        None
+    );
+}
+
+#[test]
+fn register_definition_makes_it_discoverable() {
+    let mut resolver = resolver_with_definitions(vec![s3_def("existing", "existing-bucket")]);
+    let new_def = s3_def("__report_s3__", "new-bucket");
+    resolver.register_definition(new_def);
+    assert_eq!(
+        resolver.find_definition_name_for_uri("s3://new-bucket/reports/"),
+        Some("__report_s3__".to_string())
+    );
+    assert!(resolver.definition("__report_s3__").is_some());
+}

--- a/crates/floe-core/tests/unit/config/storage_resolver_uri.rs
+++ b/crates/floe-core/tests/unit/config/storage_resolver_uri.rs
@@ -107,12 +107,9 @@ fn find_adls_definition_by_uri() {
 #[test]
 fn adls_account_prefix_does_not_match() {
     // "acct" must not match a URI containing "acct2" as the account.
-    let resolver =
-        resolver_with_definitions(vec![adls_def("adls_store", "cont", "acct")]);
+    let resolver = resolver_with_definitions(vec![adls_def("adls_store", "cont", "acct")]);
     assert_eq!(
-        resolver.find_definition_name_for_uri(
-            "abfs://cont@acct2.dfs.core.windows.net/reports/"
-        ),
+        resolver.find_definition_name_for_uri("abfs://cont@acct2.dfs.core.windows.net/reports/"),
         None
     );
 }

--- a/crates/floe-core/tests/unit/config/storage_resolver_uri.rs
+++ b/crates/floe-core/tests/unit/config/storage_resolver_uri.rs
@@ -97,8 +97,23 @@ fn find_adls_definition_by_uri() {
     let resolver =
         resolver_with_definitions(vec![adls_def("adls_store", "mycontainer", "myaccount")]);
     assert_eq!(
-        resolver.find_definition_name_for_uri("abfs://mycontainer@myaccount/reports/run1/"),
+        resolver.find_definition_name_for_uri(
+            "abfs://mycontainer@myaccount.dfs.core.windows.net/reports/run1/"
+        ),
         Some("adls_store".to_string())
+    );
+}
+
+#[test]
+fn adls_account_prefix_does_not_match() {
+    // "acct" must not match a URI containing "acct2" as the account.
+    let resolver =
+        resolver_with_definitions(vec![adls_def("adls_store", "cont", "acct")]);
+    assert_eq!(
+        resolver.find_definition_name_for_uri(
+            "abfs://cont@acct2.dfs.core.windows.net/reports/"
+        ),
+        None
     );
 }
 

--- a/orchestrators/airflow-floe/src/airflow_floe/kubernetes_runner.py
+++ b/orchestrators/airflow-floe/src/airflow_floe/kubernetes_runner.py
@@ -248,6 +248,10 @@ def run_kubernetes_job(
         job=last_job,
         pod_ctx=pod_ctx,
     )
+    if "report_base" in run_finished:
+        payload["report_base"] = run_finished["report_base"]
+    if "entity_report_uris" in run_finished:
+        payload["entity_report_uris"] = run_finished["entity_report_uris"]
     if entities and len(entities) == 1:
         payload["entity"] = entities[0]
     return payload

--- a/orchestrators/airflow-floe/src/airflow_floe/operators.py
+++ b/orchestrators/airflow-floe/src/airflow_floe/operators.py
@@ -146,6 +146,10 @@ class FloeRunHook:
         }
         if entities and len(entities) == 1:
             payload["entity"] = entities[0]
+        if "report_base" in run_finished:
+            payload["report_base"] = run_finished["report_base"]
+        if "entity_report_uris" in run_finished:
+            payload["entity_report_uris"] = run_finished["entity_report_uris"]
         return payload
 
 

--- a/orchestrators/airflow-floe/tests/test_kubernetes_runner.py
+++ b/orchestrators/airflow-floe/tests/test_kubernetes_runner.py
@@ -515,6 +515,49 @@ class RunKubernetesJobTests(unittest.TestCase):
 
         self.assertNotIn("entity", payload)
 
+    def test_new_run_finished_fields_passed_through_to_payload(self) -> None:
+        logs = _run_finished_line(
+            report_base="s3://bucket/reports",
+            entity_report_uris={"orders": "s3://bucket/reports/run_1/entities/orders.report.json"},
+        )
+        jobs_api = _make_mock_jobs_api(
+            poll_responses=[_make_job_status(succeeded=1)]
+        )
+        core_api = _make_mock_core_api(logs=logs)
+
+        with patch("time.sleep"):
+            payload = run_kubernetes_job(
+                ["floe", "run", "-c", "/cfg.yml"],
+                "/cfg.yml",
+                ["orders"],
+                runner=self._runner(),
+                jobs_api=jobs_api,
+                core_api=core_api,
+            )
+
+        self.assertEqual(payload["report_base"], "s3://bucket/reports")
+        self.assertIn("orders", payload["entity_report_uris"])
+
+    def test_new_fields_absent_when_not_in_event(self) -> None:
+        logs = _run_finished_line()  # fixture has no report_base / entity_report_uris
+        jobs_api = _make_mock_jobs_api(
+            poll_responses=[_make_job_status(succeeded=1)]
+        )
+        core_api = _make_mock_core_api(logs=logs)
+
+        with patch("time.sleep"):
+            payload = run_kubernetes_job(
+                ["floe", "run", "-c", "/cfg.yml"],
+                "/cfg.yml",
+                ["orders"],
+                runner=self._runner(),
+                jobs_api=jobs_api,
+                core_api=core_api,
+            )
+
+        self.assertNotIn("report_base", payload)
+        self.assertNotIn("entity_report_uris", payload)
+
     def test_job_submitted_to_correct_namespace(self) -> None:
         runner = self._runner()
         jobs_api = _make_mock_jobs_api(

--- a/orchestrators/dagster-floe/src/floe_dagster/assets.py
+++ b/orchestrators/dagster-floe/src/floe_dagster/assets.py
@@ -236,11 +236,15 @@ def _make_entity_multi_asset(
         entity_report_json: dict[str, Any] | None = None
         entity_report_uri: str | None = None
 
+        # Prefer entity_report_uris from the event (richer contract); fall back to
+        # loading the run summary and extracting entity_report_file from it.
+        entity_report_uri = finished.entity_report_uris.get(entity_name)
         if summary_uri:
             try:
                 summary_json = _load_summary_json(summary_uri, config_uri)
                 entity_stats = _extract_entity_stats(summary_json, entity_name)
-                entity_report_uri = _as_optional_str(entity_stats.get("entity_report_file"))
+                if not entity_report_uri:
+                    entity_report_uri = _as_optional_str(entity_stats.get("entity_report_file"))
                 if entity_report_uri:
                     entity_report_json = _load_entity_report_json(entity_report_uri, config_uri)
             except Exception as exc:  # noqa: BLE001

--- a/orchestrators/dagster-floe/src/floe_dagster/events.py
+++ b/orchestrators/dagster-floe/src/floe_dagster/events.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import json
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any, Iterable
 
 
@@ -11,6 +11,8 @@ class FloeRunFinished:
     status: str
     exit_code: int
     summary_uri: str | None
+    report_base: str | None = None
+    entity_report_uris: dict[str, str] = field(default_factory=dict)
 
 
 def parse_ndjson_events(stdout: str) -> list[dict[str, Any]]:
@@ -49,4 +51,6 @@ def parse_run_finished(
         status=str(event.get("status")),
         exit_code=int(event.get("exit_code")),
         summary_uri=event.get(summary_uri_field),
+        report_base=event.get("report_base"),
+        entity_report_uris=event.get("entity_report_uris") or {},
     )

--- a/orchestrators/dagster-floe/tests/test_events.py
+++ b/orchestrators/dagster-floe/tests/test_events.py
@@ -23,3 +23,33 @@ def test_parse_run_finished_supports_custom_summary_field():
     finished = parse_run_finished(event, summary_uri_field="custom_summary")
     assert finished.summary_uri == "local:///tmp/run.summary.json"
 
+
+def test_parse_run_finished_extracts_new_fields():
+    event = {
+        "event": "run_finished",
+        "run_id": "run-2",
+        "status": "success",
+        "exit_code": 0,
+        "summary_uri": "s3://bucket/reports/run_2/run.summary.json",
+        "report_base": "s3://bucket/reports",
+        "entity_report_uris": {
+            "customers": "s3://bucket/reports/run_2/entities/customers.report.json",
+        },
+    }
+    finished = parse_run_finished(event)
+    assert finished.report_base == "s3://bucket/reports"
+    assert finished.entity_report_uris["customers"].endswith("customers.report.json")
+
+
+def test_parse_run_finished_defaults_new_fields_when_absent():
+    event = {
+        "event": "run_finished",
+        "run_id": "run-3",
+        "status": "success",
+        "exit_code": 0,
+        "summary_uri": None,
+    }
+    finished = parse_run_finished(event)
+    assert finished.report_base is None
+    assert finished.entity_report_uris == {}
+


### PR DESCRIPTION
Closes #354

## Summary

- **Bug**: In manifest mode (`floe run --manifest s3://...`), `RunContext::from_config()` was deliberately skipping `Target` construction for remote report URIs, so the run summary was never uploaded and `run_finished.summary_uri` was always `null`.
- **Enrichment**: `run_finished` now carries `report_base` and `entity_report_uris` so orchestrators can locate per-entity reports without parsing the summary JSON.
- **Connectors**: `dagster-floe` and `airflow-floe` updated to consume the new fields.

## Changes

### Patch — fix null `summary_uri`

**`crates/floe-core/src/config/storage.rs`**
- `find_definition_name_for_uri(&self, uri)` — scans named `StorageDefinition` entries to find one whose scheme+bucket matches the URI (S3 / GCS / ADLS).
- `register_definition(&mut self, def)` — inserts a synthetic definition at runtime when no named entry matches the report bucket.

**`crates/floe-core/src/run/context.rs`**
- `RunContext::from_config()` now builds a proper `Target` for remote report URIs by calling `find_definition_name_for_uri` first, then falling back to a synthetic `StorageDefinition` (default credential chain). Only local-path and empty-report cases remain unchanged.
- New private helpers: `build_remote_report_target` and `synthetic_storage_for_uri`.

**`crates/floe-core/src/run/mod.rs`**
- Capture the `String` URI returned by `write_summary_report()` instead of discarding it; use it as `summary_uri` in the `RunFinished` event.

### Rework — enriched `run_finished` contract

**`crates/floe-core/src/run/events.rs`**
- `RunFinished` gains `report_base: Option<String>` and `entity_report_uris: HashMap<String, String>`, both `#[serde(skip_serializing_if = …)]`-guarded so existing log parsers see identical JSON when no report is configured.

**`crates/floe-core/src/run/mod.rs`**
- Populates `report_base` from `context.report_base_path` and `entity_report_uris` from the entity outcomes.

### Connector updates

**`orchestrators/dagster-floe/`**
- `FloeRunFinished` dataclass gains `report_base` and `entity_report_uris` with backward-compatible defaults.
- `parse_run_finished()` extracts the new fields.
- `assets.py` uses `entity_report_uris` from the event directly (falls back to summary-load path for older Floe versions).

**`orchestrators/airflow-floe/`**
- `operators.py` (`FloeRunHook._build_payload`) and `kubernetes_runner.py` (`run_kubernetes_job`) both pass through `report_base` and `entity_report_uris` to the XCom payload when present.

## Tests

- `crates/floe-core/tests/unit/config/storage_resolver_uri.rs` — 6 new tests covering S3/GCS/ADLS URI matching, no-match, and `register_definition`.
- `orchestrators/dagster-floe/tests/test_events.py` — 3 new tests for new field extraction and backward-compat defaults.
- `orchestrators/airflow-floe/tests/test_kubernetes_runner.py` — 2 new tests for XCom payload pass-through.

## Test plan

- [ ] `cargo test -p floe-core` — 524 passed
- [ ] `dagster-floe` pytest — 91 passed, 1 skipped
- [ ] `airflow-floe` pytest — 77 passed, 1 pre-existing flaky failure (`test_run_operator_execute_uses_hook` fails when run after certain tests due to Airflow logger state leak; passes in isolation and was failing before this PR)
