### PR TITLE
feat(manifest): deterministic generation, source checksums, and content revision

### DIFF
--- a/crates/floe-cli/src/main.rs
+++ b/crates/floe-cli/src/main.rs
@@ -277,6 +277,18 @@ enum ManifestCommand {
             help = "Optional path to a Floe environment profile YAML file"
         )]
         profile: Option<String>,
+        #[arg(
+            long,
+            help = "Produce a fully deterministic manifest (sets generated_at_ts_ms=0); \
+                    same config + profile + Floe version always produce identical output"
+        )]
+        deterministic: bool,
+        #[arg(
+            long,
+            help = "Stable logical name for this manifest, e.g. 'sales.prod'. \
+                    Stored as manifest_name in the JSON output."
+        )]
+        manifest_name: Option<String>,
     },
 }
 
@@ -732,6 +744,8 @@ fn main() -> FloeResult<()> {
                 output,
                 entities,
                 profile,
+                deterministic,
+                manifest_name,
             } => {
                 let config_location = match resolve_config_location(&config) {
                     Ok(location) => location,
@@ -804,11 +818,24 @@ fn main() -> FloeResult<()> {
                         .as_ref()
                         .and_then(|profile| profile.lineage.as_ref()),
                 )?;
+                let profile_uri = profile.as_ref().map(|p| {
+                    std::fs::canonicalize(p)
+                        .map(|abs| format!("local://{}", abs.display()))
+                        .unwrap_or_else(|_| format!("local://{p}"))
+                });
+                let profile_path = profile.as_ref().map(std::path::PathBuf::from);
+                let manifest_options = floe_core::ManifestOptions {
+                    deterministic,
+                    manifest_name,
+                    profile_uri,
+                    profile_path,
+                };
                 let manifest_json = build_common_manifest_json(
                     &config_location,
                     &config,
                     &entities,
                     profile_config.as_ref(),
+                    &manifest_options,
                 )?;
                 manifest_output::write_manifest(&output, &manifest_json)?;
                 if output != "-" {

--- a/crates/floe-core/src/lib.rs
+++ b/crates/floe-core/src/lib.rs
@@ -25,7 +25,7 @@ pub use add_entity::{add_entity_to_config, AddEntityOptions, AddEntityOutcome};
 pub use checks as check;
 pub use config::{resolve_config_location, ConfigLocation};
 pub use errors::ConfigError;
-pub use manifest::{build_common_manifest_json, config_from_manifest_json};
+pub use manifest::{build_common_manifest_json, config_from_manifest_json, ManifestOptions};
 pub use profile::{
     detect_malformed_placeholder, detect_unresolved_placeholders, parse_profile,
     parse_profile_from_str, validate_merged_vars, validate_profile, ProfileConfig,

--- a/crates/floe-core/src/manifest/builder.rs
+++ b/crates/floe-core/src/manifest/builder.rs
@@ -1,5 +1,7 @@
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 use std::time::{SystemTime, UNIX_EPOCH};
+
+use sha2::{Digest, Sha256};
 
 use crate::config::{ConfigLocation, RootConfig, SourceOptions, StorageResolver};
 use crate::manifest::model::{
@@ -10,6 +12,25 @@ use crate::manifest::model::{
 };
 use crate::profile::ProfileConfig;
 use crate::FloeResult;
+
+/// Options that control manifest generation behaviour.
+#[derive(Debug, Default)]
+pub struct ManifestOptions {
+    /// When true, `generated_at_ts_ms` is set to `0` so that the same inputs
+    /// always produce byte-identical output. Use this for committed deployment
+    /// artifacts that are diffed in CI.
+    pub deterministic: bool,
+    /// Optional stable logical name for this manifest (e.g. `"sales.prod"`).
+    /// Stored as `manifest_name` in the output JSON.
+    pub manifest_name: Option<String>,
+    /// Display URI of the profile file (e.g. `local:///path/to/prod.yml`).
+    /// Stored as `profile_uri` in the output JSON.
+    pub profile_uri: Option<String>,
+    /// Local filesystem path to the profile file used during generation.
+    /// When supplied, a SHA-256 checksum of the file is computed and stored
+    /// as `profile_checksum`.
+    pub profile_path: Option<std::path::PathBuf>,
+}
 
 #[derive(Debug)]
 struct ResolvedOrRaw {
@@ -23,16 +44,40 @@ pub fn build_common_manifest_json(
     config: &RootConfig,
     selected_entities: &[String],
     profile: Option<&ProfileConfig>,
+    options: &ManifestOptions,
 ) -> FloeResult<String> {
     let resolver = StorageResolver::new(config, config_location.base.clone())?;
-    let manifest = build_common_manifest(
+    let mut manifest = build_common_manifest(
         config_location,
         config,
         selected_entities,
         &resolver,
         profile,
+        options,
     );
+
+    // Compute manifest_revision: SHA-256 of the canonical content, which
+    // excludes volatile fields (generated_at_ts_ms, manifest_revision itself).
+    let revision = compute_manifest_revision(&manifest)?;
+    manifest.manifest_revision = Some(revision);
+
     Ok(serde_json::to_string_pretty(&manifest)?)
+}
+
+/// Compute a stable content hash over the manifest, excluding fields that
+/// change on every generation (timestamp) or are themselves the hash output.
+fn compute_manifest_revision(manifest: &CommonManifest) -> FloeResult<String> {
+    let mut value: serde_json::Value = serde_json::to_value(manifest)?;
+    if let Some(obj) = value.as_object_mut() {
+        obj.remove("generated_at_ts_ms");
+        obj.remove("manifest_revision");
+    }
+    let canonical = serde_json::to_string(&value)?;
+    Ok(sha256_hex(canonical.as_bytes()))
+}
+
+fn sha256_hex(bytes: &[u8]) -> String {
+    format!("sha256:{:x}", Sha256::digest(bytes))
 }
 
 fn build_common_manifest(
@@ -41,6 +86,7 @@ fn build_common_manifest(
     selected_entities: &[String],
     resolver: &StorageResolver,
     profile: Option<&ProfileConfig>,
+    options: &ManifestOptions,
 ) -> CommonManifest {
     let mut entities: Vec<_> = if selected_entities.is_empty() {
         config.entities.iter().collect()
@@ -114,7 +160,7 @@ fn build_common_manifest(
             )
         };
 
-        let mut tags = HashMap::new();
+        let mut tags = BTreeMap::new();
         if let Some(metadata) = &entity.metadata {
             if let Some(owner) = &metadata.owner {
                 tags.insert("owner".to_string(), owner.clone());
@@ -266,7 +312,21 @@ fn build_common_manifest(
     }
 
     let config_uri = canonical_config_uri(&config_location.display);
-    let config_checksum = None;
+    let config_checksum = std::fs::read(&config_location.path)
+        .ok()
+        .map(|b| sha256_hex(&b));
+
+    let profile_checksum = options
+        .profile_path
+        .as_ref()
+        .and_then(|p| std::fs::read(p).ok())
+        .map(|b| sha256_hex(&b));
+
+    let generated_at_ts_ms = if options.deterministic {
+        0
+    } else {
+        now_ts_ms()
+    };
 
     // Serialize profile sections as opaque JSON values so they can be re-applied at run time.
     let storages = profile
@@ -281,12 +341,16 @@ fn build_common_manifest(
 
     CommonManifest {
         schema: "floe.manifest.v1",
-        generated_at_ts_ms: now_ts_ms(),
+        generated_at_ts_ms,
         floe_version: env!("CARGO_PKG_VERSION"),
         spec_version: config.version.clone(),
-        manifest_id: build_manifest_id(&config_uri, config_checksum),
+        manifest_name: options.manifest_name.clone(),
+        manifest_id: build_manifest_id(&config_uri, config_checksum.as_deref()),
+        manifest_revision: None,
         config_uri,
-        config_checksum: config_checksum.map(ToString::to_string),
+        config_checksum,
+        profile_uri: options.profile_uri.clone(),
+        profile_checksum,
         report_base_uri: report_base.uri,
         domains: config
             .domains
@@ -398,7 +462,7 @@ fn map_source_options(options: Option<&SourceOptions>) -> Option<serde_json::Val
 }
 
 fn default_execution_contract() -> ManifestExecution {
-    let mut exit_codes = HashMap::new();
+    let mut exit_codes = BTreeMap::new();
     exit_codes.insert("0", "success_or_rejected");
     exit_codes.insert("1", "technical_failure");
     exit_codes.insert("2", "aborted");
@@ -421,7 +485,7 @@ fn default_execution_contract() -> ManifestExecution {
             exit_codes,
         },
         defaults: ManifestExecutionDefaults {
-            env: HashMap::new(),
+            env: BTreeMap::new(),
             workdir: None,
         },
     }
@@ -437,7 +501,7 @@ fn runners_contract(profile: Option<&ProfileConfig>) -> ManifestRunners {
             let profile_runner = profile
                 .and_then(|p| p.execution.as_ref())
                 .map(|e| &e.runner);
-            let mut definitions = HashMap::new();
+            let mut definitions = BTreeMap::new();
             definitions.insert(
                 "default",
                 ManifestRunnerDefinition {
@@ -469,7 +533,11 @@ fn runners_contract(profile: Option<&ProfileConfig>) -> ManifestRunners {
                             memory_mb: res.memory_mb,
                         })
                     }),
-                    env: profile_runner.and_then(|r| r.env.clone()),
+                    env: profile_runner.and_then(|r| {
+                        r.env
+                            .as_ref()
+                            .map(|m| m.iter().map(|(k, v)| (k.clone(), v.clone())).collect())
+                    }),
                     workspace_url: None,
                     existing_cluster_id: None,
                     config_uri: None,
@@ -488,7 +556,7 @@ fn runners_contract(profile: Option<&ProfileConfig>) -> ManifestRunners {
             let profile_runner = profile
                 .and_then(|p| p.execution.as_ref())
                 .map(|e| &e.runner);
-            let mut definitions = HashMap::new();
+            let mut definitions = BTreeMap::new();
             definitions.insert(
                 "default",
                 ManifestRunnerDefinition {
@@ -516,7 +584,11 @@ fn runners_contract(profile: Option<&ProfileConfig>) -> ManifestRunners {
                             service_principal_oauth_ref: auth.service_principal_oauth_ref.clone(),
                         })
                     }),
-                    env_parameters: profile_runner.and_then(|r| r.env_parameters.clone()),
+                    env_parameters: profile_runner.and_then(|r| {
+                        r.env_parameters
+                            .as_ref()
+                            .map(|m| m.iter().map(|(k, v)| (k.clone(), v.clone())).collect())
+                    }),
                 },
             );
             ManifestRunners {
@@ -526,7 +598,7 @@ fn runners_contract(profile: Option<&ProfileConfig>) -> ManifestRunners {
         }
         // "local" or absent → local_process (backward-compatible default)
         _ => {
-            let mut definitions = HashMap::new();
+            let mut definitions = BTreeMap::new();
             definitions.insert(
                 "local",
                 ManifestRunnerDefinition {

--- a/crates/floe-core/src/manifest/mod.rs
+++ b/crates/floe-core/src/manifest/mod.rs
@@ -2,5 +2,5 @@ mod builder;
 mod model;
 pub mod reconstruct;
 
-pub use builder::build_common_manifest_json;
+pub use builder::{build_common_manifest_json, ManifestOptions};
 pub use reconstruct::config_from_manifest_json;

--- a/crates/floe-core/src/manifest/model.rs
+++ b/crates/floe-core/src/manifest/model.rs
@@ -1,5 +1,5 @@
 use serde::Serialize;
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 
 #[derive(Debug, Serialize)]
 pub struct CommonManifest {
@@ -7,9 +7,18 @@ pub struct CommonManifest {
     pub generated_at_ts_ms: u64,
     pub floe_version: &'static str,
     pub spec_version: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub manifest_name: Option<String>,
     pub manifest_id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub manifest_revision: Option<String>,
     pub config_uri: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub config_checksum: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub profile_uri: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub profile_checksum: Option<String>,
     pub report_base_uri: String,
     pub domains: Vec<ManifestDomain>,
     pub execution: ManifestExecution,
@@ -46,19 +55,19 @@ pub struct ManifestExecution {
 pub struct ManifestResultContract {
     pub run_finished_event: bool,
     pub summary_uri_field: &'static str,
-    pub exit_codes: HashMap<&'static str, &'static str>,
+    pub exit_codes: BTreeMap<&'static str, &'static str>,
 }
 
 #[derive(Debug, Serialize)]
 pub struct ManifestExecutionDefaults {
-    pub env: HashMap<String, String>,
+    pub env: BTreeMap<String, String>,
     pub workdir: Option<String>,
 }
 
 #[derive(Debug, Serialize)]
 pub struct ManifestRunners {
     pub default: &'static str,
-    pub definitions: HashMap<&'static str, ManifestRunnerDefinition>,
+    pub definitions: BTreeMap<&'static str, ManifestRunnerDefinition>,
 }
 
 #[derive(Debug, Serialize)]
@@ -82,14 +91,14 @@ pub struct ManifestRunnerDefinition {
     pub namespace: Option<String>,
     pub service_account: Option<String>,
     pub resources: Option<ManifestRunnerResources>,
-    pub env: Option<HashMap<String, String>>,
+    pub env: Option<BTreeMap<String, String>>,
     pub workspace_url: Option<String>,
     pub existing_cluster_id: Option<String>,
     pub config_uri: Option<String>,
     pub python_file_uri: Option<String>,
     pub job_name: Option<String>,
     pub auth: Option<ManifestRunnerAuth>,
-    pub env_parameters: Option<HashMap<String, String>>,
+    pub env_parameters: Option<BTreeMap<String, String>>,
 }
 
 #[derive(Debug, Serialize)]
@@ -112,7 +121,7 @@ pub struct ManifestEntity {
     pub source_format: String,
     pub accepted_sink_uri: String,
     pub rejected_sink_uri: Option<String>,
-    pub tags: Option<HashMap<String, String>>,
+    pub tags: Option<BTreeMap<String, String>>,
     pub source: ManifestSource,
     pub sinks: ManifestSinks,
     pub runner: Option<String>,

--- a/crates/floe-core/tests/unit/manifest/mod.rs
+++ b/crates/floe-core/tests/unit/manifest/mod.rs
@@ -1,5 +1,6 @@
 use floe_core::{
     build_common_manifest_json, load_config, parse_profile_from_str, resolve_config_location,
+    ManifestOptions,
 };
 use serde_json::Value;
 use std::path::PathBuf;
@@ -26,8 +27,14 @@ fn manifest_uses_local_uri_for_local_config() {
     .expect("resolve config location");
     let config = load_config(&config_location.path).expect("load config");
 
-    let payload = build_common_manifest_json(&config_location, &config, &[], None)
-        .expect("build common manifest");
+    let payload = build_common_manifest_json(
+        &config_location,
+        &config,
+        &[],
+        None,
+        &ManifestOptions::default(),
+    )
+    .expect("build common manifest");
     let value: Value = serde_json::from_str(&payload).expect("manifest is valid json");
 
     assert_eq!(value["schema"], "floe.manifest.v1");
@@ -45,9 +52,22 @@ fn manifest_id_is_stable_for_same_config() {
     .expect("resolve config location");
     let config = load_config(&config_location.path).expect("load config");
 
-    let first = build_common_manifest_json(&config_location, &config, &[], None).expect("manifest");
-    let second =
-        build_common_manifest_json(&config_location, &config, &[], None).expect("manifest");
+    let first = build_common_manifest_json(
+        &config_location,
+        &config,
+        &[],
+        None,
+        &ManifestOptions::default(),
+    )
+    .expect("manifest");
+    let second = build_common_manifest_json(
+        &config_location,
+        &config,
+        &[],
+        None,
+        &ManifestOptions::default(),
+    )
+    .expect("manifest");
 
     let first_value: Value = serde_json::from_str(&first).expect("valid json");
     let second_value: Value = serde_json::from_str(&second).expect("valid json");
@@ -96,8 +116,14 @@ entities:
     let config_location = resolve_config_location(config_path.to_str().expect("config path utf8"))
         .expect("resolve config location");
     let config = load_config(&config_location.path).expect("load config");
-    let payload = build_common_manifest_json(&config_location, &config, &[], None)
-        .expect("build common manifest");
+    let payload = build_common_manifest_json(
+        &config_location,
+        &config,
+        &[],
+        None,
+        &ManifestOptions::default(),
+    )
+    .expect("build common manifest");
     let value: Value = serde_json::from_str(&payload).expect("manifest json");
 
     let cfg_base = std::fs::canonicalize(&cfg_dir).expect("canonicalize cfg dir");
@@ -122,8 +148,14 @@ fn manifest_without_profile_has_local_runner() {
     let config_location = resolve_config_location(config_path.to_str().expect("utf8"))
         .expect("resolve config location");
     let config = load_config(&config_location.path).expect("load config");
-    let payload =
-        build_common_manifest_json(&config_location, &config, &[], None).expect("manifest");
+    let payload = build_common_manifest_json(
+        &config_location,
+        &config,
+        &[],
+        None,
+        &ManifestOptions::default(),
+    )
+    .expect("manifest");
     let value: Value = serde_json::from_str(&payload).expect("valid json");
 
     assert_eq!(value["runners"]["default"], "local");
@@ -149,8 +181,14 @@ execution:
     let config_location = resolve_config_location(config_path.to_str().expect("utf8"))
         .expect("resolve config location");
     let config = load_config(&config_location.path).expect("load config");
-    let payload = build_common_manifest_json(&config_location, &config, &[], Some(&profile))
-        .expect("manifest");
+    let payload = build_common_manifest_json(
+        &config_location,
+        &config,
+        &[],
+        Some(&profile),
+        &ManifestOptions::default(),
+    )
+    .expect("manifest");
     let value: Value = serde_json::from_str(&payload).expect("valid json");
 
     assert_eq!(value["runners"]["default"], "local");
@@ -176,8 +214,14 @@ execution:
     let config_location = resolve_config_location(config_path.to_str().expect("utf8"))
         .expect("resolve config location");
     let config = load_config(&config_location.path).expect("load config");
-    let payload = build_common_manifest_json(&config_location, &config, &[], Some(&profile))
-        .expect("manifest");
+    let payload = build_common_manifest_json(
+        &config_location,
+        &config,
+        &[],
+        Some(&profile),
+        &ManifestOptions::default(),
+    )
+    .expect("manifest");
     let value: Value = serde_json::from_str(&payload).expect("valid json");
 
     assert_eq!(value["runners"]["default"], "default");
@@ -223,8 +267,14 @@ execution:
     let config_location = resolve_config_location(config_path.to_str().expect("utf8"))
         .expect("resolve config location");
     let config = load_config(&config_location.path).expect("load config");
-    let payload = build_common_manifest_json(&config_location, &config, &[], Some(&profile))
-        .expect("manifest");
+    let payload = build_common_manifest_json(
+        &config_location,
+        &config,
+        &[],
+        Some(&profile),
+        &ManifestOptions::default(),
+    )
+    .expect("manifest");
     let value: Value = serde_json::from_str(&payload).expect("valid json");
 
     let runner = &value["runners"]["definitions"]["default"];
@@ -284,8 +334,14 @@ execution:
     let config_location = resolve_config_location(config_path.to_str().expect("utf8"))
         .expect("resolve config location");
     let config = load_config(&config_location.path).expect("load config");
-    let payload = build_common_manifest_json(&config_location, &config, &[], Some(&profile))
-        .expect("manifest");
+    let payload = build_common_manifest_json(
+        &config_location,
+        &config,
+        &[],
+        Some(&profile),
+        &ManifestOptions::default(),
+    )
+    .expect("manifest");
     let value: Value = serde_json::from_str(&payload).expect("valid json");
 
     let runner = &value["runners"]["definitions"]["default"];
@@ -303,4 +359,132 @@ execution:
         runner["auth"]["service_principal_oauth_ref"],
         "env://DATABRICKS_TOKEN"
     );
+}
+
+#[test]
+fn manifest_deterministic_mode_produces_stable_output() {
+    let config_path = repo_root().join("example/config.yml");
+    let config_location = resolve_config_location(config_path.to_str().expect("utf8"))
+        .expect("resolve config location");
+    let config = load_config(&config_location.path).expect("load config");
+    let opts = ManifestOptions {
+        deterministic: true,
+        ..ManifestOptions::default()
+    };
+
+    let first =
+        build_common_manifest_json(&config_location, &config, &[], None, &opts).expect("manifest");
+    let second =
+        build_common_manifest_json(&config_location, &config, &[], None, &opts).expect("manifest");
+
+    assert_eq!(
+        first, second,
+        "deterministic manifests must be byte-identical"
+    );
+}
+
+#[test]
+fn manifest_deterministic_mode_sets_timestamp_to_zero() {
+    let config_path = repo_root().join("example/config.yml");
+    let config_location = resolve_config_location(config_path.to_str().expect("utf8"))
+        .expect("resolve config location");
+    let config = load_config(&config_location.path).expect("load config");
+    let opts = ManifestOptions {
+        deterministic: true,
+        ..ManifestOptions::default()
+    };
+
+    let payload =
+        build_common_manifest_json(&config_location, &config, &[], None, &opts).expect("manifest");
+    let value: Value = serde_json::from_str(&payload).expect("valid json");
+
+    assert_eq!(value["generated_at_ts_ms"], 0);
+}
+
+#[test]
+fn manifest_config_checksum_is_populated() {
+    let config_path = repo_root().join("example/config.yml");
+    let config_location = resolve_config_location(config_path.to_str().expect("utf8"))
+        .expect("resolve config location");
+    let config = load_config(&config_location.path).expect("load config");
+
+    let payload = build_common_manifest_json(
+        &config_location,
+        &config,
+        &[],
+        None,
+        &ManifestOptions::default(),
+    )
+    .expect("manifest");
+    let value: Value = serde_json::from_str(&payload).expect("valid json");
+
+    let checksum = value["config_checksum"]
+        .as_str()
+        .expect("config_checksum should be present");
+    assert!(
+        checksum.starts_with("sha256:"),
+        "config_checksum should start with 'sha256:'"
+    );
+}
+
+#[test]
+fn manifest_revision_is_present_and_stable() {
+    let config_path = repo_root().join("example/config.yml");
+    let config_location = resolve_config_location(config_path.to_str().expect("utf8"))
+        .expect("resolve config location");
+    let config = load_config(&config_location.path).expect("load config");
+
+    let first = build_common_manifest_json(
+        &config_location,
+        &config,
+        &[],
+        None,
+        &ManifestOptions::default(),
+    )
+    .expect("manifest");
+    let second = build_common_manifest_json(
+        &config_location,
+        &config,
+        &[],
+        None,
+        &ManifestOptions::default(),
+    )
+    .expect("manifest");
+
+    let first_value: Value = serde_json::from_str(&first).expect("valid json");
+    let second_value: Value = serde_json::from_str(&second).expect("valid json");
+
+    let first_rev = first_value["manifest_revision"]
+        .as_str()
+        .expect("manifest_revision should be present");
+    let second_rev = second_value["manifest_revision"]
+        .as_str()
+        .expect("manifest_revision should be present");
+
+    assert!(
+        first_rev.starts_with("sha256:"),
+        "revision should be a sha256 hash"
+    );
+    assert_eq!(
+        first_rev, second_rev,
+        "manifest_revision must be stable across calls"
+    );
+}
+
+#[test]
+fn manifest_name_is_stored_when_provided() {
+    let config_path = repo_root().join("example/config.yml");
+    let config_location = resolve_config_location(config_path.to_str().expect("utf8"))
+        .expect("resolve config location");
+    let config = load_config(&config_location.path).expect("load config");
+    let opts = ManifestOptions {
+        manifest_name: Some("sales.prod".to_string()),
+        ..ManifestOptions::default()
+    };
+
+    let payload =
+        build_common_manifest_json(&config_location, &config, &[], None, &opts).expect("manifest");
+    let value: Value = serde_json::from_str(&payload).expect("valid json");
+
+    assert_eq!(value["manifest_name"], "sales.prod");
 }

--- a/docs/manifest.md
+++ b/docs/manifest.md
@@ -36,6 +36,37 @@ floe manifest generate -c orders.yml --entities orders,returns --output manifest
 
 ---
 
+## Deterministic generation
+
+For production deployments where manifests are committed to git and diffed in CI, use `--deterministic`:
+
+```bash
+floe manifest generate \
+  -c sales.yml \
+  -p profiles/prod.yml \
+  --deterministic \
+  --manifest-name sales.prod \
+  --output manifests/sales.prod.json
+```
+
+In deterministic mode:
+
+- `generated_at_ts_ms` is set to `0` — the same inputs always produce byte-identical output.
+- `config_checksum` and `profile_checksum` (SHA-256) trace the exact source files used.
+- `manifest_revision` (SHA-256 of canonical content) provides a stable content fingerprint.
+- Map fields (`exit_codes`, `env`, `definitions`, `tags`) use stable alphabetical key ordering.
+
+To verify a committed manifest has not drifted from the source config:
+
+```bash
+floe manifest generate -c sales.yml -p profiles/prod.yml --deterministic -o /tmp/check.json
+diff manifests/sales.prod.json /tmp/check.json
+```
+
+An empty diff means the manifest is up to date.
+
+---
+
 ## What's inside
 
 A manifest is a self-contained JSON document. Here's an annotated excerpt:
@@ -43,8 +74,13 @@ A manifest is a self-contained JSON document. Here's an annotated excerpt:
 ```jsonc
 {
   "schema": "floe.manifest.v1",          // version sentinel — never changes for v1
-  "manifest_id": "orders-2024",          // stable ID for tracking
+  "manifest_name": "sales.prod",         // optional stable logical name (--manifest-name)
+  "manifest_id": "mfv1-a1b2c3d4...",    // FNV-1a hash of config URI + content
+  "manifest_revision": "sha256:...",     // SHA-256 of canonical manifest content
   "config_uri": "./orders.yml",          // where the source YAML lives
+  "config_checksum": "sha256:...",       // SHA-256 of the config file
+  "profile_uri": "local:///prod.yml",   // profile used at generation time (if any)
+  "profile_checksum": "sha256:...",      // SHA-256 of the profile file (if any)
   "report_base_uri": "./report",         // where run reports are written
 
   // The exact CLI command the orchestrator must call
@@ -134,7 +170,14 @@ Regenerate the manifest whenever you change:
 - source or sink paths
 - runner definitions or execution args
 
-A simple CI check that catches drift. Strip `generated_at_ts_ms` before comparing — it changes on every `generate` call regardless of config changes:
+With `--deterministic`, drift detection is a clean diff:
+
+```bash
+floe manifest generate -c orders.yml --deterministic -o /tmp/fresh.json
+diff manifests/orders.json /tmp/fresh.json
+```
+
+If you are not using `--deterministic`, strip the volatile timestamp before comparing:
 
 ```bash
 diff \

--- a/orchestrators/airflow-floe/src/airflow_floe/manifest.py
+++ b/orchestrators/airflow-floe/src/airflow_floe/manifest.py
@@ -247,6 +247,10 @@ class AirflowManifest:
     execution: ManifestExecution
     runners: ManifestRunners
     entities: list[ManifestEntity]
+    manifest_name: str | None = None
+    manifest_revision: str | None = None
+    profile_uri: str | None = None
+    profile_checksum: str | None = None
 
     @staticmethod
     def from_dict(data: dict[str, Any]) -> "AirflowManifest":
@@ -273,6 +277,10 @@ class AirflowManifest:
             execution=ManifestExecution.from_dict(_required_object(data, "execution")),
             runners=ManifestRunners.from_dict(_required_object(data, "runners")),
             entities=entities,
+            manifest_name=_optional_str(data, "manifest_name"),
+            manifest_revision=_optional_str(data, "manifest_revision"),
+            profile_uri=_optional_str(data, "profile_uri"),
+            profile_checksum=_optional_str(data, "profile_checksum"),
         )
 
     def to_dict(self) -> dict[str, Any]:
@@ -280,8 +288,12 @@ class AirflowManifest:
             "schema": self.schema,
             "generated_at_ts_ms": self.generated_at_ts_ms,
             "floe_version": self.floe_version,
+            **({"manifest_name": self.manifest_name} if self.manifest_name is not None else {}),
+            **({"manifest_revision": self.manifest_revision} if self.manifest_revision is not None else {}),
             "config_uri": self.config_uri,
             "config_checksum": self.config_checksum,
+            **({"profile_uri": self.profile_uri} if self.profile_uri is not None else {}),
+            **({"profile_checksum": self.profile_checksum} if self.profile_checksum is not None else {}),
             "execution": {
                 "entrypoint": self.execution.entrypoint,
                 "base_args": self.execution.base_args,

--- a/orchestrators/dagster-floe/src/floe_dagster/manifest.py
+++ b/orchestrators/dagster-floe/src/floe_dagster/manifest.py
@@ -197,6 +197,10 @@ class DagsterManifest:
     storages: dict[str, Any] | None = None
     catalogs: dict[str, Any] | None = None
     lineage: dict[str, Any] | None = None
+    manifest_name: str | None = None
+    manifest_revision: str | None = None
+    profile_uri: str | None = None
+    profile_checksum: str | None = None
 
     @staticmethod
     def from_dict(data: dict[str, Any]) -> "DagsterManifest":
@@ -228,6 +232,10 @@ class DagsterManifest:
             storages=storages if isinstance(storages, dict) else None,
             catalogs=catalogs if isinstance(catalogs, dict) else None,
             lineage=lineage if isinstance(lineage, dict) else None,
+            manifest_name=_optional_str(data, "manifest_name"),
+            manifest_revision=_optional_str(data, "manifest_revision"),
+            profile_uri=_optional_str(data, "profile_uri"),
+            profile_checksum=_optional_str(data, "profile_checksum"),
         )
 
 

--- a/orchestrators/dagster-floe/src/floe_dagster/schemas/floe.manifest.v1.json
+++ b/orchestrators/dagster-floe/src/floe_dagster/schemas/floe.manifest.v1.json
@@ -47,6 +47,30 @@
         "null"
       ]
     },
+    "manifest_name": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "manifest_revision": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "profile_uri": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "profile_checksum": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
     "report_base_uri": {
       "type": "string",
       "minLength": 1

--- a/orchestrators/schemas/floe.manifest.v1.json
+++ b/orchestrators/schemas/floe.manifest.v1.json
@@ -47,6 +47,48 @@
         "null"
       ]
     },
+    "manifest_name": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "manifest_revision": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "profile_uri": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "profile_checksum": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "storages": {
+      "type": [
+        "object",
+        "null"
+      ]
+    },
+    "catalogs": {
+      "type": [
+        "object",
+        "null"
+      ]
+    },
+    "lineage": {
+      "type": [
+        "object",
+        "null"
+      ]
+    },
     "report_base_uri": {
       "type": "string",
       "minLength": 1


### PR DESCRIPTION
Closes #355.

## Summary

- **`--deterministic` flag** on `floe manifest generate`: sets `generated_at_ts_ms=0` so the same config + profile + Floe version always produce byte-identical output. Designed for committed deployment artifacts diffed in CI.
- **`--manifest-name` flag**: stores a stable logical name (e.g. `sales.prod`) as `manifest_name` in the JSON.
- **Source checksums**: `config_checksum` (SHA-256) is computed on every generation; `profile_checksum` is computed when a profile is supplied. Both trace the exact source files used.
- **`manifest_revision`**: SHA-256 of the canonical manifest content (excluding `generated_at_ts_ms`). Stable across repeated calls with the same inputs — usable as a content fingerprint in CI.
- **`profile_uri`**: records which profile file was used during generation.
- **Stable map ordering**: all `HashMap` fields in manifest structs replaced with `BTreeMap` (`exit_codes`, `env`, `definitions`, `tags`, `env_parameters`) for stable alphabetical key ordering in serialised JSON.
- **`manifest_id` now incorporates `config_checksum`** so it changes when source config content changes.
- **Orchestrator updates**: `DagsterManifest` and `AirflowManifest` dataclasses updated to parse and surface the four new optional fields.
- **Docs**: `docs/manifest.md` documents `--deterministic`, `--manifest-name`, new fields, and replaces the `jq del(.generated_at_ts_ms)` drift-check workaround with the clean `--deterministic` diff pattern.

## Test plan

- [x] `cargo fmt --all` — clean
- [x] `cargo clippy -p floe-core -p floe-cli -p floe-python -- -D warnings` — zero warnings
- [x] `cargo test -p floe-core` — 627 tests, all pass (includes 5 new manifest tests)
- [x] Manual smoke: `floe manifest generate -c example/config.yml --deterministic -o /tmp/a.json && floe manifest generate -c example/config.yml --deterministic -o /tmp/b.json && diff /tmp/a.json /tmp/b.json` — empty diff
- [x] Manual smoke: verify `config_checksum` and `manifest_revision` are present in generated output