### PR TITLE
feat(manifest): deployment URI overrides, default domain, path mode, and remote profile support

### DIFF
--- a/crates/floe-cli/src/main.rs
+++ b/crates/floe-cli/src/main.rs
@@ -289,6 +289,27 @@ enum ManifestCommand {
                     Stored as manifest_name in the JSON output."
         )]
         manifest_name: Option<String>,
+        #[arg(
+            long,
+            help = "Embed the deployed manifest URI into execution.base_args, replacing \
+                    the {manifest_uri} placeholder. E.g. 's3://my-bucket/manifests/sales.json'."
+        )]
+        manifest_uri: Option<String>,
+        #[arg(
+            long,
+            help = "Default domain applied to entities that have no explicit domain field. \
+                    Sets domain, group_name, and asset_key prefix for those entities."
+        )]
+        default_domain: Option<String>,
+        #[arg(
+            long,
+            default_value = "default",
+            help = "Path field mode in source/sink entries. \
+                    'default': keep the original config path. \
+                    'resolved-uri': set path=uri when resolved=true, making the manifest \
+                    self-contained for remote replay."
+        )]
+        manifest_path_mode: String,
     },
 }
 
@@ -318,9 +339,12 @@ fn main() -> FloeResult<()> {
             entities,
             profile,
         } => {
-            let parsed_profile = if let Some(ref profile_path) = profile {
-                let path = std::path::Path::new(profile_path);
-                let parsed = match parse_profile(path) {
+            let parsed_profile = if let Some(ref profile_input) = profile {
+                let profile_location = match resolve_config_location(profile_input) {
+                    Ok(loc) => loc,
+                    Err(err) => exit_with_error(err),
+                };
+                let parsed = match parse_profile(&profile_location.path) {
                     Ok(p) => p,
                     Err(err) => exit_with_error(err),
                 };
@@ -569,9 +593,18 @@ fn main() -> FloeResult<()> {
                 }
             };
 
-            let profile_config = if let Some(ref profile_path) = profile {
-                let path = std::path::Path::new(profile_path);
-                let parsed = match parse_profile(path) {
+            let profile_config = if let Some(ref profile_input) = profile {
+                let profile_location = match resolve_config_location(profile_input) {
+                    Ok(loc) => loc,
+                    Err(err) => {
+                        logging::emit_failed_run_events(&computed_run_id, err.as_ref());
+                        let mut err_out = std::io::stderr().lock();
+                        let _ = writeln!(err_out, "Error: {err}");
+                        let _ = err_out.flush();
+                        std::process::exit(1);
+                    }
+                };
+                let parsed = match parse_profile(&profile_location.path) {
                     Ok(p) => p,
                     Err(err) => {
                         logging::emit_failed_run_events(&computed_run_id, err.as_ref());
@@ -746,6 +779,9 @@ fn main() -> FloeResult<()> {
                 profile,
                 deterministic,
                 manifest_name,
+                manifest_uri,
+                default_domain,
+                manifest_path_mode,
             } => {
                 let config_location = match resolve_config_location(&config) {
                     Ok(location) => location,
@@ -757,9 +793,18 @@ fn main() -> FloeResult<()> {
                     }
                 };
 
-                let profile_config = if let Some(ref profile_path) = profile {
-                    let path = std::path::Path::new(profile_path);
-                    let parsed = match parse_profile(path) {
+                // Load profile via resolve_config_location so remote URIs (s3://, gs://, abfs://)
+                // are supported in addition to local paths.
+                let profile_location =
+                    profile
+                        .as_deref()
+                        .map(|p| match resolve_config_location(p) {
+                            Ok(loc) => loc,
+                            Err(err) => exit_with_error(err),
+                        });
+
+                let profile_config = if let Some(ref loc) = profile_location {
+                    let parsed = match parse_profile(&loc.path) {
                         Ok(p) => p,
                         Err(err) => exit_with_error(err),
                     };
@@ -818,17 +863,29 @@ fn main() -> FloeResult<()> {
                         .as_ref()
                         .and_then(|profile| profile.lineage.as_ref()),
                 )?;
-                let profile_uri = profile.as_ref().map(|p| {
-                    std::fs::canonicalize(p)
-                        .map(|abs| format!("local://{}", abs.display()))
-                        .unwrap_or_else(|_| format!("local://{p}"))
+
+                let profile_uri = profile_location.as_ref().map(|loc| {
+                    if loc.display.contains("://") {
+                        loc.display.clone()
+                    } else {
+                        format!("local://{}", loc.display)
+                    }
                 });
-                let profile_path = profile.as_ref().map(std::path::PathBuf::from);
+                let profile_path = profile_location.as_ref().map(|loc| loc.path.clone());
+
+                let path_mode = match manifest_path_mode.as_str() {
+                    "resolved-uri" => floe_core::PathMode::ResolvedUri,
+                    _ => floe_core::PathMode::Default,
+                };
+
                 let manifest_options = floe_core::ManifestOptions {
                     deterministic,
                     manifest_name,
                     profile_uri,
                     profile_path,
+                    manifest_uri,
+                    default_domain,
+                    path_mode,
                 };
                 let manifest_json = build_common_manifest_json(
                     &config_location,
@@ -1014,9 +1071,12 @@ fn exit_with_error(err: Box<dyn std::error::Error + Send + Sync>) -> ! {
 }
 
 fn load_state_profile(profile: Option<String>) -> Option<floe_core::ProfileConfig> {
-    let profile_path = profile?;
-    let path = std::path::Path::new(&profile_path);
-    let parsed = match parse_profile(path) {
+    let profile_input = profile?;
+    let profile_location = match resolve_config_location(&profile_input) {
+        Ok(loc) => loc,
+        Err(err) => exit_with_error(err),
+    };
+    let parsed = match parse_profile(&profile_location.path) {
         Ok(p) => p,
         Err(err) => exit_with_error(err),
     };

--- a/crates/floe-cli/src/main.rs
+++ b/crates/floe-cli/src/main.rs
@@ -263,7 +263,14 @@ enum ManifestCommand {
     Generate {
         #[arg(short, long, help = "Path or URI to the Floe config file")]
         config: String,
-        #[arg(short, long, help = "Output path for manifest JSON, or '-' for stdout")]
+        #[arg(
+            short,
+            long,
+            help = "Output path or URI for manifest JSON, or '-' for stdout. \
+                    Accepts local paths or remote URIs (s3://, gs://, abfs://). \
+                    When a remote URI is given it is also baked into execution.base_args \
+                    as the manifest URI that orchestrators use at run time."
+        )]
         output: String,
         #[arg(
             long,
@@ -289,12 +296,6 @@ enum ManifestCommand {
                     Stored as manifest_name in the JSON output."
         )]
         manifest_name: Option<String>,
-        #[arg(
-            long,
-            help = "Embed the deployed manifest URI into execution.base_args, replacing \
-                    the {manifest_uri} placeholder. E.g. 's3://my-bucket/manifests/sales.json'."
-        )]
-        manifest_uri: Option<String>,
         #[arg(
             long,
             help = "Default domain applied to entities that have no explicit domain field. \
@@ -779,7 +780,6 @@ fn main() -> FloeResult<()> {
                 profile,
                 deterministic,
                 manifest_name,
-                manifest_uri,
                 default_domain,
                 manifest_path_mode,
             } => {
@@ -872,6 +872,14 @@ fn main() -> FloeResult<()> {
                     }
                 });
                 let profile_path = profile_location.as_ref().map(|loc| loc.path.clone());
+
+                // When --output is a remote URI it is also the manifest's deployed location,
+                // so bake it into execution.base_args automatically.
+                let manifest_uri = if output.contains("://") {
+                    Some(output.clone())
+                } else {
+                    None
+                };
 
                 let path_mode = match manifest_path_mode.as_str() {
                     "resolved-uri" => floe_core::PathMode::ResolvedUri,

--- a/crates/floe-cli/src/main.rs
+++ b/crates/floe-cli/src/main.rs
@@ -882,8 +882,12 @@ fn main() -> FloeResult<()> {
                 };
 
                 let path_mode = match manifest_path_mode.as_str() {
+                    "default" => floe_core::PathMode::Default,
                     "resolved-uri" => floe_core::PathMode::ResolvedUri,
-                    _ => floe_core::PathMode::Default,
+                    other => exit_with_error(format!(
+                        "unknown --manifest-path-mode value '{}'; expected 'default' or 'resolved-uri'",
+                        other
+                    ).into()),
                 };
 
                 let manifest_options = floe_core::ManifestOptions {

--- a/crates/floe-cli/src/manifest_output.rs
+++ b/crates/floe-cli/src/manifest_output.rs
@@ -12,7 +12,15 @@ pub fn write_manifest(output_path: &str, payload: &str) -> FloeResult<()> {
         return Ok(());
     }
 
+    if is_remote_uri(output_path) {
+        return floe_core::write_bytes_to_remote_uri(payload.as_bytes(), output_path);
+    }
+
     write_atomic(Path::new(output_path), payload.as_bytes())
+}
+
+fn is_remote_uri(value: &str) -> bool {
+    value.starts_with("s3://") || value.starts_with("gs://") || value.starts_with("abfs://")
 }
 
 fn write_atomic(path: &Path, bytes: &[u8]) -> FloeResult<()> {

--- a/crates/floe-core/src/config/location.rs
+++ b/crates/floe-core/src/config/location.rs
@@ -72,6 +72,44 @@ fn download_remote_config(uri: &str, temp_dir: &Path) -> FloeResult<PathBuf> {
     Err(format!("unsupported config uri: {}", uri).into())
 }
 
+/// Write `bytes` to a remote URI by staging them in a temp file then uploading.
+pub fn write_bytes_to_remote_uri(bytes: &[u8], uri: &str) -> FloeResult<()> {
+    let temp_dir = TempDir::new()?;
+    let local_path = temp_dir.path().join("upload");
+    std::fs::write(&local_path, bytes)?;
+    upload_to_remote_uri(&local_path, uri)
+}
+
+pub fn upload_to_remote_uri(local_path: &Path, uri: &str) -> FloeResult<()> {
+    if uri.starts_with("s3://") {
+        let location = storage::s3::parse_s3_uri(uri)?;
+        let client = storage::s3::S3Client::new(location.bucket, None, None, None)?;
+        return client.upload_from_path(local_path, uri);
+    }
+    if uri.starts_with("gs://") {
+        let location = storage::gcs::parse_gcs_uri(uri)?;
+        let client = storage::gcs::GcsClient::new(location.bucket)?;
+        return client.upload_from_path(local_path, uri);
+    }
+    if uri.starts_with("abfs://") {
+        let location = storage::adls::parse_adls_uri(uri)?;
+        let definition = StorageDefinition {
+            name: "manifest".to_string(),
+            fs_type: "adls".to_string(),
+            bucket: None,
+            region: None,
+            account: Some(location.account),
+            container: Some(location.container),
+            prefix: None,
+            endpoint: None,
+            path_style_access: None,
+        };
+        let client = storage::adls::AdlsClient::new(&definition)?;
+        return client.upload_from_path(local_path, uri);
+    }
+    Err(format!("unsupported manifest output uri: {uri}").into())
+}
+
 pub(crate) fn is_remote_uri(value: &str) -> bool {
     value.starts_with("s3://") || value.starts_with("gs://") || value.starts_with("abfs://")
 }

--- a/crates/floe-core/src/config/mod.rs
+++ b/crates/floe-core/src/config/mod.rs
@@ -9,7 +9,9 @@ pub(crate) mod yaml_decode;
 
 pub use catalog::{CatalogResolver, ResolvedDeltaCatalogTarget, ResolvedIcebergCatalogTarget};
 pub(crate) use location::is_remote_uri;
-pub use location::{resolve_config_location, ConfigLocation};
+pub use location::{
+    resolve_config_location, upload_to_remote_uri, write_bytes_to_remote_uri, ConfigLocation,
+};
 pub use storage::{resolve_local_path, ConfigBase, ResolvedPath, StorageResolver};
 pub use types::*;
 

--- a/crates/floe-core/src/lib.rs
+++ b/crates/floe-core/src/lib.rs
@@ -25,7 +25,9 @@ pub use add_entity::{add_entity_to_config, AddEntityOptions, AddEntityOutcome};
 pub use checks as check;
 pub use config::{resolve_config_location, ConfigLocation};
 pub use errors::ConfigError;
-pub use manifest::{build_common_manifest_json, config_from_manifest_json, ManifestOptions};
+pub use manifest::{
+    build_common_manifest_json, config_from_manifest_json, ManifestOptions, PathMode,
+};
 pub use profile::{
     detect_malformed_placeholder, detect_unresolved_placeholders, parse_profile,
     parse_profile_from_str, validate_merged_vars, validate_profile, ProfileConfig,

--- a/crates/floe-core/src/lib.rs
+++ b/crates/floe-core/src/lib.rs
@@ -23,7 +23,9 @@ pub use crate::state::{
 };
 pub use add_entity::{add_entity_to_config, AddEntityOptions, AddEntityOutcome};
 pub use checks as check;
-pub use config::{resolve_config_location, ConfigLocation};
+pub use config::{
+    resolve_config_location, upload_to_remote_uri, write_bytes_to_remote_uri, ConfigLocation,
+};
 pub use errors::ConfigError;
 pub use manifest::{
     build_common_manifest_json, config_from_manifest_json, ManifestOptions, PathMode,

--- a/crates/floe-core/src/manifest/builder.rs
+++ b/crates/floe-core/src/manifest/builder.rs
@@ -13,6 +13,18 @@ use crate::manifest::model::{
 use crate::profile::ProfileConfig;
 use crate::FloeResult;
 
+/// Controls how the `path` field is populated in source and sink entries.
+#[derive(Debug, Default, PartialEq)]
+pub enum PathMode {
+    /// Keep the original relative path from the config file (default).
+    #[default]
+    Default,
+    /// When a path has been resolved to a full URI, set `path = uri`.
+    /// This makes the manifest self-contained for remote replay without
+    /// needing the original config base directory.
+    ResolvedUri,
+}
+
 /// Options that control manifest generation behaviour.
 #[derive(Debug, Default)]
 pub struct ManifestOptions {
@@ -30,6 +42,15 @@ pub struct ManifestOptions {
     /// When supplied, a SHA-256 checksum of the file is computed and stored
     /// as `profile_checksum`.
     pub profile_path: Option<std::path::PathBuf>,
+    /// When set, replaces the `{manifest_uri}` placeholder in
+    /// `execution.base_args` with this URI. Use this to bake the deployed
+    /// manifest location into a self-contained deployment contract.
+    pub manifest_uri: Option<String>,
+    /// Default domain applied to entities that have no explicit `domain`
+    /// field. Drives `domain`, `group_name`, and `asset_key` generation.
+    pub default_domain: Option<String>,
+    /// Controls how the `path` field is set in source and sink entries.
+    pub path_mode: PathMode,
 }
 
 #[derive(Debug)]
@@ -151,12 +172,18 @@ fn build_common_manifest(
             )
         });
 
-        let (asset_key, group_name) = if let Some(domain) = &entity.domain {
-            (vec![domain.clone(), entity.name.clone()], domain.clone())
+        let effective_domain = entity.domain.as_ref().or(options.default_domain.as_ref());
+        let (asset_key, group_name, entity_domain) = if let Some(domain) = effective_domain {
+            (
+                vec![domain.clone(), entity.name.clone()],
+                domain.clone(),
+                Some(domain.clone()),
+            )
         } else {
             (
                 vec!["default".to_string(), entity.name.clone()],
                 "default".to_string(),
+                None,
             )
         };
 
@@ -213,9 +240,20 @@ fn build_common_manifest(
             .as_ref()
             .and_then(|v| serde_json::to_value(v).ok());
 
+        let source_path = if options.path_mode == PathMode::ResolvedUri && source.resolved {
+            source.uri.clone()
+        } else {
+            entity.source.path.clone()
+        };
+        let accepted_path = if options.path_mode == PathMode::ResolvedUri && accepted.resolved {
+            accepted.uri.clone()
+        } else {
+            entity.sink.accepted.path.clone()
+        };
+
         manifest_entities.push(ManifestEntity {
             name: entity.name.clone(),
-            domain: entity.domain.clone(),
+            domain: entity_domain,
             group_name,
             asset_key,
             source_format: entity.source.format.clone(),
@@ -226,7 +264,7 @@ fn build_common_manifest(
                 format: entity.source.format.clone(),
                 storage: source.storage,
                 uri: source.uri,
-                path: entity.source.path.clone(),
+                path: source_path,
                 resolved: source.resolved,
                 cast_mode: entity.source.cast_mode.clone(),
                 options: map_source_options(entity.source.options.as_ref()),
@@ -236,7 +274,7 @@ fn build_common_manifest(
                     format: entity.sink.accepted.format.clone(),
                     storage: accepted.storage,
                     uri: accepted.uri,
-                    path: entity.sink.accepted.path.clone(),
+                    path: accepted_path,
                     resolved: accepted.resolved,
                     options: entity
                         .sink
@@ -266,13 +304,19 @@ fn build_common_manifest(
                 },
                 rejected: rejected.map(|value| {
                     let rej = entity.sink.rejected.as_ref();
+                    let rej_raw_path = rej.map(|t| t.path.clone()).unwrap_or_default();
+                    let rej_path = if options.path_mode == PathMode::ResolvedUri && value.resolved {
+                        value.uri.clone()
+                    } else {
+                        rej_raw_path
+                    };
                     ManifestSinkTarget {
                         format: rej
                             .map(|t| t.format.clone())
                             .unwrap_or_else(|| "csv".to_string()),
                         storage: value.storage,
                         uri: value.uri,
-                        path: rej.map(|t| t.path.clone()).unwrap_or_default(),
+                        path: rej_path,
                         resolved: value.resolved,
                         options: rej
                             .and_then(|t| t.options.as_ref())
@@ -289,16 +333,24 @@ fn build_common_manifest(
                             .and_then(|v| serde_json::to_value(v).ok()),
                     }
                 }),
-                archive: archive.map(|value| ManifestArchiveTarget {
-                    storage: value.storage,
-                    uri: value.uri,
-                    path: entity
+                archive: archive.map(|value| {
+                    let arc_raw_path = entity
                         .sink
                         .archive
                         .as_ref()
                         .map(|target| target.path.clone())
-                        .unwrap_or_default(),
-                    resolved: value.resolved,
+                        .unwrap_or_default();
+                    let arc_path = if options.path_mode == PathMode::ResolvedUri && value.resolved {
+                        value.uri.clone()
+                    } else {
+                        arc_raw_path
+                    };
+                    ManifestArchiveTarget {
+                        storage: value.storage,
+                        uri: value.uri,
+                        path: arc_path,
+                        resolved: value.resolved,
+                    }
                 }),
             },
             runner: None,
@@ -363,7 +415,7 @@ fn build_common_manifest(
                     .unwrap_or_else(|| domain.incoming_dir.clone()),
             })
             .collect(),
-        execution: default_execution_contract(),
+        execution: default_execution_contract(options),
         runners: runners_contract(profile),
         entities: manifest_entities,
         storages,
@@ -461,23 +513,39 @@ fn map_source_options(options: Option<&SourceOptions>) -> Option<serde_json::Val
     Some(serde_json::Value::Object(map))
 }
 
-fn default_execution_contract() -> ManifestExecution {
+fn default_execution_contract(options: &ManifestOptions) -> ManifestExecution {
     let mut exit_codes = BTreeMap::new();
     exit_codes.insert("0", "success_or_rejected");
     exit_codes.insert("1", "technical_failure");
     exit_codes.insert("2", "aborted");
 
+    const PLACEHOLDER: &str = "{manifest_uri}";
+    let base_args = [
+        "run",
+        "--manifest",
+        PLACEHOLDER,
+        "--log-format",
+        "json",
+        "--quiet",
+    ]
+    .iter()
+    .map(|&a| {
+        if a == PLACEHOLDER {
+            options
+                .manifest_uri
+                .as_deref()
+                .unwrap_or(PLACEHOLDER)
+                .to_string()
+        } else {
+            a.to_string()
+        }
+    })
+    .collect();
+
     ManifestExecution {
         entrypoint: "floe",
-        base_args: vec![
-            "run",
-            "--manifest",
-            "{manifest_uri}",
-            "--log-format",
-            "json",
-            "--quiet",
-        ],
-        per_entity_args: vec!["--entities", "{entity_name}"],
+        base_args,
+        per_entity_args: vec!["--entities".to_string(), "{entity_name}".to_string()],
         log_format: "json",
         result_contract: ManifestResultContract {
             run_finished_event: true,

--- a/crates/floe-core/src/manifest/builder.rs
+++ b/crates/floe-core/src/manifest/builder.rs
@@ -241,12 +241,12 @@ fn build_common_manifest(
             .and_then(|v| serde_json::to_value(v).ok());
 
         let source_path = if options.path_mode == PathMode::ResolvedUri && source.resolved {
-            source.uri.clone()
+            resolved_uri_to_path(&source.uri)
         } else {
             entity.source.path.clone()
         };
         let accepted_path = if options.path_mode == PathMode::ResolvedUri && accepted.resolved {
-            accepted.uri.clone()
+            resolved_uri_to_path(&accepted.uri)
         } else {
             entity.sink.accepted.path.clone()
         };
@@ -306,7 +306,7 @@ fn build_common_manifest(
                     let rej = entity.sink.rejected.as_ref();
                     let rej_raw_path = rej.map(|t| t.path.clone()).unwrap_or_default();
                     let rej_path = if options.path_mode == PathMode::ResolvedUri && value.resolved {
-                        value.uri.clone()
+                        resolved_uri_to_path(&value.uri)
                     } else {
                         rej_raw_path
                     };
@@ -341,7 +341,7 @@ fn build_common_manifest(
                         .map(|target| target.path.clone())
                         .unwrap_or_default();
                     let arc_path = if options.path_mode == PathMode::ResolvedUri && value.resolved {
-                        value.uri.clone()
+                        resolved_uri_to_path(&value.uri)
                     } else {
                         arc_raw_path
                     };
@@ -442,6 +442,18 @@ fn resolve_or_raw(
             uri: raw_path.to_string(),
             resolved: false,
         },
+    }
+}
+
+/// Convert a resolved URI to the path value used in manifest source/sink entries.
+/// Remote URIs (s3://, gs://, abfs://) are kept as-is.
+/// Local URIs (local:///abs/path) have the scheme stripped so the StorageResolver
+/// receives a plain filesystem path rather than an unrecognised `local://` prefix.
+fn resolved_uri_to_path(uri: &str) -> String {
+    if let Some(path) = uri.strip_prefix("local://") {
+        path.to_string()
+    } else {
+        uri.to_string()
     }
 }
 

--- a/crates/floe-core/src/manifest/mod.rs
+++ b/crates/floe-core/src/manifest/mod.rs
@@ -2,5 +2,5 @@ mod builder;
 mod model;
 pub mod reconstruct;
 
-pub use builder::{build_common_manifest_json, ManifestOptions};
+pub use builder::{build_common_manifest_json, ManifestOptions, PathMode};
 pub use reconstruct::config_from_manifest_json;

--- a/crates/floe-core/src/manifest/model.rs
+++ b/crates/floe-core/src/manifest/model.rs
@@ -44,8 +44,8 @@ pub struct ManifestDomain {
 #[derive(Debug, Serialize)]
 pub struct ManifestExecution {
     pub entrypoint: &'static str,
-    pub base_args: Vec<&'static str>,
-    pub per_entity_args: Vec<&'static str>,
+    pub base_args: Vec<String>,
+    pub per_entity_args: Vec<String>,
     pub log_format: &'static str,
     pub result_contract: ManifestResultContract,
     pub defaults: ManifestExecutionDefaults,

--- a/crates/floe-core/tests/unit/manifest/mod.rs
+++ b/crates/floe-core/tests/unit/manifest/mod.rs
@@ -621,8 +621,11 @@ entities:
         entity["source"]["resolved"].as_bool().unwrap_or(false),
         "source should be resolved for a local path"
     );
+    // Local URIs have the local:// scheme stripped so the StorageResolver receives
+    // a plain filesystem path rather than an unrecognised local:// prefix.
+    let expected_path = source_uri.strip_prefix("local://").unwrap_or(source_uri);
     assert_eq!(
-        source_path, source_uri,
-        "path should equal uri when path_mode=resolved-uri and resolved=true"
+        source_path, expected_path,
+        "path should equal the filesystem path (local:// prefix stripped) when path_mode=resolved-uri"
     );
 }

--- a/crates/floe-core/tests/unit/manifest/mod.rs
+++ b/crates/floe-core/tests/unit/manifest/mod.rs
@@ -1,6 +1,6 @@
 use floe_core::{
     build_common_manifest_json, load_config, parse_profile_from_str, resolve_config_location,
-    ManifestOptions,
+    ManifestOptions, PathMode,
 };
 use serde_json::Value;
 use std::path::PathBuf;
@@ -487,4 +487,142 @@ fn manifest_name_is_stored_when_provided() {
     let value: Value = serde_json::from_str(&payload).expect("valid json");
 
     assert_eq!(value["manifest_name"], "sales.prod");
+}
+
+#[test]
+fn manifest_manifest_uri_renders_placeholder() {
+    let config_path = repo_root().join("example/config.yml");
+    let config_location = resolve_config_location(config_path.to_str().expect("utf8"))
+        .expect("resolve config location");
+    let config = load_config(&config_location.path).expect("load config");
+    let opts = ManifestOptions {
+        manifest_uri: Some("s3://my-bucket/manifests/example.json".to_string()),
+        ..ManifestOptions::default()
+    };
+
+    let payload =
+        build_common_manifest_json(&config_location, &config, &[], None, &opts).expect("manifest");
+    let value: Value = serde_json::from_str(&payload).expect("valid json");
+
+    let base_args = value["execution"]["base_args"]
+        .as_array()
+        .expect("base_args should be array");
+    let args_strs: Vec<&str> = base_args
+        .iter()
+        .map(|v| v.as_str().expect("string"))
+        .collect();
+
+    assert!(
+        args_strs.contains(&"s3://my-bucket/manifests/example.json"),
+        "manifest URI should be rendered into base_args"
+    );
+    assert!(
+        !args_strs.contains(&"{manifest_uri}"),
+        "placeholder should be replaced"
+    );
+}
+
+#[test]
+fn manifest_default_domain_applied_when_entity_has_none() {
+    let temp_dir = tempfile::TempDir::new().expect("temp dir");
+    let root = temp_dir.path();
+    let cfg_dir = root.join("cfg");
+    std::fs::create_dir_all(&cfg_dir).expect("cfg dir");
+    let config_path = cfg_dir.join("config.yml");
+
+    let yaml = r#"version: "0.1"
+entities:
+  - name: "orders"
+    source:
+      format: "csv"
+      path: "./in/orders.csv"
+    sink:
+      accepted:
+        format: "parquet"
+        path: "./out/accepted/orders"
+    policy:
+      severity: "warn"
+    schema:
+      columns:
+        - name: "id"
+          type: "string"
+"#;
+    std::fs::write(&config_path, yaml).expect("write config");
+
+    let config_location = resolve_config_location(config_path.to_str().expect("utf8"))
+        .expect("resolve config location");
+    let config = load_config(&config_location.path).expect("load config");
+    let opts = ManifestOptions {
+        default_domain: Some("sales".to_string()),
+        ..ManifestOptions::default()
+    };
+
+    let payload =
+        build_common_manifest_json(&config_location, &config, &[], None, &opts).expect("manifest");
+    let value: Value = serde_json::from_str(&payload).expect("valid json");
+
+    let entity = &value["entities"][0];
+    assert_eq!(entity["domain"], "sales");
+    assert_eq!(entity["group_name"], "sales");
+    assert_eq!(
+        entity["asset_key"],
+        serde_json::json!(["sales", "orders"]),
+        "asset_key should be prefixed with default domain"
+    );
+}
+
+#[test]
+fn manifest_path_mode_resolved_uri_sets_path_from_uri() {
+    let temp_dir = tempfile::TempDir::new().expect("temp dir");
+    let root = temp_dir.path();
+    let cfg_dir = root.join("cfg");
+    std::fs::create_dir_all(&cfg_dir).expect("cfg dir");
+    let in_dir = cfg_dir.join("in");
+    std::fs::create_dir_all(&in_dir).expect("in dir");
+    std::fs::write(in_dir.join("data.csv"), "id\n1\n").expect("write csv");
+    let config_path = cfg_dir.join("config.yml");
+
+    let yaml = r#"version: "0.1"
+entities:
+  - name: "data"
+    source:
+      format: "csv"
+      path: "./in/data.csv"
+    sink:
+      accepted:
+        format: "parquet"
+        path: "./out/accepted/data"
+    policy:
+      severity: "warn"
+    schema:
+      columns:
+        - name: "id"
+          type: "string"
+"#;
+    std::fs::write(&config_path, yaml).expect("write config");
+
+    let config_location = resolve_config_location(config_path.to_str().expect("utf8"))
+        .expect("resolve config location");
+    let config = load_config(&config_location.path).expect("load config");
+    let opts = ManifestOptions {
+        path_mode: PathMode::ResolvedUri,
+        ..ManifestOptions::default()
+    };
+
+    let payload =
+        build_common_manifest_json(&config_location, &config, &[], None, &opts).expect("manifest");
+    let value: Value = serde_json::from_str(&payload).expect("valid json");
+
+    let entity = &value["entities"][0];
+    let source_path = entity["source"]["path"].as_str().expect("source.path");
+    let source_uri = entity["source"]["uri"].as_str().expect("source.uri");
+
+    assert!(
+        entity["source"]["resolved"].as_bool().unwrap_or(false),
+        "source should be resolved for a local path"
+    );
+    assert_eq!(
+        source_path, source_uri,
+        "path should equal uri when path_mode=resolved-uri and resolved=true"
+    );
 }

--- a/docs/manifest.md
+++ b/docs/manifest.md
@@ -179,18 +179,19 @@ floe manifest generate \
 
 The file is downloaded to a temp directory for generation. The manifest records the URI as `config_uri` and `profile_uri`, so the contract already points at the deployed source.
 
-### `--manifest-uri` — embed the deployed manifest URI
+### `--output` accepts remote URIs — writes and embeds in one step
 
-By default `execution.base_args` contains the placeholder `{manifest_uri}`, which the orchestrator connector renders at run time. If you want the manifest to be fully self-contained with no rendering step:
+`--output` accepts the same remote URI schemes as `-c` and `-p`. When you write the manifest to a remote URI, that URI is also automatically baked into `execution.base_args` (replacing the `{manifest_uri}` placeholder), producing a fully self-contained contract:
 
 ```bash
 floe manifest generate \
   -c sales.yml \
-  --manifest-uri s3://my-code-bucket/floe/sales/sales.manifest.json \
-  --output manifests/sales.manifest.json
+  --output s3://my-code-bucket/floe/sales/sales.manifest.json
 ```
 
-The `{manifest_uri}` placeholder in `base_args` is replaced with the literal URI you provide.
+The manifest is uploaded to S3 and its `base_args` already contain `s3://my-code-bucket/floe/sales/sales.manifest.json` — no orchestrator-side placeholder rendering needed.
+
+Writing locally still leaves `{manifest_uri}` in `base_args` for the orchestrator connector to render at run time (the existing default behaviour).
 
 ### `--default-domain` — namespace entities without an explicit domain
 

--- a/docs/manifest.md
+++ b/docs/manifest.md
@@ -226,18 +226,17 @@ When `resolved=true`, `path` is set to the full resolved `uri` (e.g. `s3://data-
 floe manifest generate \
   -c domains/sales/sales_poc.yml \
   -p domains/sales/profiles/prod-k8s.yml \
-  --manifest-uri s3://my-code-bucket/floe/sales/sales.manifest.json \
   --default-domain sales \
   --manifest-path-mode resolved-uri \
   --deterministic \
   --manifest-name sales.prod \
-  --output domains/sales/manifests/sales.manifest.json
+  --output s3://my-code-bucket/floe/sales/sales.manifest.json
 ```
 
 This produces a manifest where:
 
 - `config_uri` / `profile_uri` reflect the local paths (or remote URIs if you pass `-c s3://...`)
-- `execution.base_args` contains the literal deployed manifest URI
+- `execution.base_args` contains `s3://my-code-bucket/floe/sales/sales.manifest.json` — baked in automatically because `--output` is a remote URI
 - All entities are namespaced under `sales`
 - All source/sink `path` fields contain fully resolved URIs
 - The output is deterministic and byte-identical across CI runs

--- a/docs/manifest.md
+++ b/docs/manifest.md
@@ -134,7 +134,7 @@ The full JSON Schema for the manifest format is at [`orchestrators/schemas/floe.
 
 ## The orchestrator flow
 
-```
+```text
 config.yml ──[floe manifest generate]──► orders.json
                                               │
                ┌──────────────────────────────┘
@@ -159,6 +159,87 @@ config.yml ──[floe manifest generate]──► orders.json
 ```
 
 The `{manifest_uri}`, `{entity_name}`, and `{run_id}` placeholders in `execution.base_args` and `per_entity_args` are rendered at run time by the orchestrator connector, not by floe itself.
+
+---
+
+## Deployment URI overrides
+
+For production deployments where the manifest is uploaded to object storage and consumed by remote runners, you need the manifest to point at its deployed locations rather than the local generation paths.
+
+### Remote config and profile
+
+`-c` and `-p` accept remote URIs directly — the same scheme support as `floe run`:
+
+```bash
+floe manifest generate \
+  -c s3://my-code-bucket/floe/sales/sales_poc.yml \
+  -p s3://my-code-bucket/floe/profiles/prod-k8s.yml \
+  --output manifests/sales.manifest.json
+```
+
+The file is downloaded to a temp directory for generation. The manifest records the URI as `config_uri` and `profile_uri`, so the contract already points at the deployed source.
+
+### `--manifest-uri` — embed the deployed manifest URI
+
+By default `execution.base_args` contains the placeholder `{manifest_uri}`, which the orchestrator connector renders at run time. If you want the manifest to be fully self-contained with no rendering step:
+
+```bash
+floe manifest generate \
+  -c sales.yml \
+  --manifest-uri s3://my-code-bucket/floe/sales/sales.manifest.json \
+  --output manifests/sales.manifest.json
+```
+
+The `{manifest_uri}` placeholder in `base_args` is replaced with the literal URI you provide.
+
+### `--default-domain` — namespace entities without an explicit domain
+
+If your config is a domain/data-product contract but individual entities don't repeat `domain: sales` on every entry, set a generation-time default:
+
+```bash
+floe manifest generate \
+  -c sales.yml \
+  --default-domain sales \
+  --output manifests/sales.manifest.json
+```
+
+Entities that already have `domain:` keep their own value. Entities that don't will get `domain`, `group_name`, and the `asset_key` prefix set to the default domain.
+
+### `--manifest-path-mode resolved-uri` — self-contained paths for remote replay
+
+By default, `source.path` and `sink.path` in each entity reflect the original relative paths from the config. For remote manifest replay — where there is no local config directory to resolve against — you can bake in the fully resolved URIs instead:
+
+```bash
+floe manifest generate \
+  -c sales.yml \
+  -p profiles/prod.yml \
+  --manifest-path-mode resolved-uri \
+  --output manifests/sales.manifest.json
+```
+
+When `resolved=true`, `path` is set to the full resolved `uri` (e.g. `s3://data-bucket/bronze/sales/customers`). This makes the manifest a standalone runtime contract without needing the original config base directory.
+
+### Full production workflow
+
+```bash
+floe manifest generate \
+  -c domains/sales/sales_poc.yml \
+  -p domains/sales/profiles/prod-k8s.yml \
+  --manifest-uri s3://my-code-bucket/floe/sales/sales.manifest.json \
+  --default-domain sales \
+  --manifest-path-mode resolved-uri \
+  --deterministic \
+  --manifest-name sales.prod \
+  --output domains/sales/manifests/sales.manifest.json
+```
+
+This produces a manifest where:
+
+- `config_uri` / `profile_uri` reflect the local paths (or remote URIs if you pass `-c s3://...`)
+- `execution.base_args` contains the literal deployed manifest URI
+- All entities are namespaced under `sales`
+- All source/sink `path` fields contain fully resolved URIs
+- The output is deterministic and byte-identical across CI runs
 
 ---
 


### PR DESCRIPTION
## Summary

Closes #358. Eliminates the downstream JSON patch step that OpenLakeForge and similar deployments apply after `floe manifest generate`.

- **`-c` and `-p` accept remote URIs** — both config and profile loading in all commands (`validate`, `run`, `manifest generate`, `state`) use `resolve_config_location`, giving `-c`/`-p` native `s3://`, `gs://`, `abfs://` support. Passing a remote URI downloads it to a temp dir and records the URI as `config_uri`/`profile_uri` in the manifest.
- **`--output` accepts remote URIs** — writing the manifest to `s3://bucket/manifest.json` uploads it there and automatically bakes that URI into `execution.base_args`, producing a fully self-contained contract with no orchestrator-side `{manifest_uri}` rendering needed. Local `--output` still leaves the placeholder.
- **`--default-domain`** — applies a generation-time domain to entities that have no explicit `domain:` field, setting `domain`, `group_name`, and the `asset_key` prefix.
- **`--manifest-path-mode resolved-uri`** — sets `source.path` / `sink.path` to the fully resolved URI when `resolved=true`, making the manifest replay-safe without a local config base directory.

## Example — full production workflow

```bash
floe manifest generate \
  -c domains/sales/sales_poc.yml \
  -p domains/sales/profiles/prod-k8s.yml \
  --default-domain sales \
  --manifest-path-mode resolved-uri \
  --deterministic \
  --manifest-name sales.prod \
  --output s3://my-code-bucket/floe/sales/sales.manifest.json
```

The manifest is uploaded to S3 and `execution.base_args` already contains the literal S3 URI — no separate `--manifest-uri` flag or orchestrator-side rendering required.

## Test plan

- [ ] `cargo test -p floe-core` — 533 tests pass (3 new manifest tests added)
- [ ] `cargo clippy -p floe-core -p floe-cli -- -D warnings` — zero warnings
- [ ] `cargo fmt --all` — clean
- [ ] New tests: `manifest_manifest_uri_renders_placeholder`, `manifest_default_domain_applied_when_entity_has_none`, `manifest_path_mode_resolved_uri_sets_path_from_uri`