### PR TITLE
fix(dagster-floe): load remote report URIs via fsspec (issue #361)

### DIFF
--- a/orchestrators/dagster-floe/pyproject.toml
+++ b/orchestrators/dagster-floe/pyproject.toml
@@ -34,6 +34,9 @@ kubernetes = [
 ]
 remote = [
   "fsspec",
+  "s3fs",
+  "gcsfs",
+  "adlfs",
 ]
 dev = [
   "pytest>=7",

--- a/orchestrators/dagster-floe/pyproject.toml
+++ b/orchestrators/dagster-floe/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "dagster-floe"
-version = "0.1.8"
+version = "0.1.9"
 description = "Dagster connector for Floe CLI (config-driven ingestion)"
 requires-python = ">=3.10"
 readme = "README.md"
@@ -31,6 +31,9 @@ Documentation = "https://github.com/malon64/floe/tree/main/orchestrators/dagster
 [project.optional-dependencies]
 kubernetes = [
   "kubernetes>=28",
+]
+remote = [
+  "fsspec",
 ]
 dev = [
   "pytest>=7",

--- a/orchestrators/dagster-floe/src/floe_dagster/assets.py
+++ b/orchestrators/dagster-floe/src/floe_dagster/assets.py
@@ -315,36 +315,48 @@ def _make_entity_multi_asset(
 
 
 def _load_summary_json(summary_uri: str, config_uri: str) -> dict[str, Any]:
-    return _load_local_json_document(summary_uri, config_uri, label="summary")
+    return _load_json_document(summary_uri, config_uri, label="summary")
 
 
 def _load_entity_report_json(entity_report_uri: str, config_uri: str) -> dict[str, Any]:
-    return _load_local_json_document(entity_report_uri, config_uri, label="entity report")
+    return _load_json_document(entity_report_uri, config_uri, label="entity report")
 
 
-def _load_local_json_document(ref: str, config_uri: str, *, label: str) -> dict[str, Any]:
-    path = _resolve_local_json_path(ref, config_uri)
-    data = json.loads(path.read_text(encoding="utf-8"))
+def _load_json_document(ref: str, config_uri: str, *, label: str) -> dict[str, Any]:
+    data = json.loads(_read_json_text(ref, config_uri))
     if not isinstance(data, dict):
         raise ValueError(f"{label} JSON must be an object")
     return data
 
 
-def _resolve_local_json_path(ref: str, config_uri: str) -> Path:
+def _read_json_text(ref: str, config_uri: str) -> str:
     if ref.startswith("local://"):
-        raw_path = unquote(ref[len("local://") :])
+        raw_path = unquote(ref[len("local://"):])
         path = Path(raw_path)
-    elif ref.startswith("file://"):
+        if not path.is_absolute() and "://" not in config_uri:
+            path = (Path(config_uri).resolve().parent / path).resolve()
+        return path.read_text(encoding="utf-8")
+    if ref.startswith("file://"):
         parsed = urlparse(ref)
-        path = Path(unquote(parsed.path))
-    elif "://" in ref:
-        raise ValueError(f"unsupported non-local JSON URI: {ref}")
-    else:
-        path = Path(ref)
-
+        return Path(unquote(parsed.path)).read_text(encoding="utf-8")
+    if "://" in ref:
+        return _fsspec_read_text(ref)
+    path = Path(ref)
     if not path.is_absolute() and "://" not in config_uri:
         path = (Path(config_uri).resolve().parent / path).resolve()
-    return path
+    return path.read_text(encoding="utf-8")
+
+
+def _fsspec_read_text(uri: str) -> str:
+    try:
+        import fsspec
+    except ImportError as exc:
+        raise ImportError(
+            "reading remote report URIs requires fsspec; "
+            "install it with: pip install fsspec"
+        ) from exc
+    with fsspec.open(uri, "r", encoding="utf-8") as f:
+        return f.read()
 
 
 def _extract_entity_stats(summary_json: dict[str, Any], entity_name: str) -> dict[str, Any]:

--- a/orchestrators/dagster-floe/tests/test_remote_json.py
+++ b/orchestrators/dagster-floe/tests/test_remote_json.py
@@ -1,0 +1,126 @@
+from __future__ import annotations
+
+import io
+import json
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from floe_dagster.assets import _load_json_document, _read_json_text
+
+
+# ── local plain path ──────────────────────────────────────────────────────────
+
+def test_load_json_document_local_path(tmp_path: Path) -> None:
+    payload = {"entities": [{"name": "orders"}]}
+    doc = tmp_path / "report.json"
+    doc.write_text(json.dumps(payload), encoding="utf-8")
+    result = _load_json_document(str(doc), str(tmp_path / "config.yml"), label="test")
+    assert result == payload
+
+
+def test_load_json_document_local_relative_path(tmp_path: Path) -> None:
+    payload = {"status": "ok"}
+    doc = tmp_path / "report.json"
+    doc.write_text(json.dumps(payload), encoding="utf-8")
+    config_uri = str(tmp_path / "config.yml")
+    result = _load_json_document("report.json", config_uri, label="test")
+    assert result == payload
+
+
+# ── local:// URI ──────────────────────────────────────────────────────────────
+
+def test_load_json_document_local_uri(tmp_path: Path) -> None:
+    payload = {"files": []}
+    doc = tmp_path / "entity.json"
+    doc.write_text(json.dumps(payload), encoding="utf-8")
+    ref = "local://" + str(doc).replace("\\", "/")
+    result = _load_json_document(ref, "/any/config.yml", label="test")
+    assert result == payload
+
+
+# ── file:// URI ───────────────────────────────────────────────────────────────
+
+def test_load_json_document_file_uri(tmp_path: Path) -> None:
+    payload = {"rows": 42}
+    doc = tmp_path / "summary.json"
+    doc.write_text(json.dumps(payload), encoding="utf-8")
+    ref = doc.as_uri()  # produces file:///... on all platforms
+    result = _load_json_document(ref, "/any/config.yml", label="test")
+    assert result == payload
+
+
+# ── remote URIs via fsspec ────────────────────────────────────────────────────
+
+def _make_fsspec_mock(payload_text: str) -> MagicMock:
+    mock_fsspec = MagicMock()
+    ctx = MagicMock()
+    ctx.__enter__ = MagicMock(return_value=io.StringIO(payload_text))
+    ctx.__exit__ = MagicMock(return_value=False)
+    mock_fsspec.open.return_value = ctx
+    return mock_fsspec
+
+
+def test_load_json_document_s3_uri_calls_fsspec() -> None:
+    payload = {"entities": []}
+    mock_fsspec = _make_fsspec_mock(json.dumps(payload))
+    with patch.dict(sys.modules, {"fsspec": mock_fsspec}):
+        result = _load_json_document(
+            "s3://my-bucket/floe/reports/run.json",
+            "s3://my-bucket/floe/config.yml",
+            label="test",
+        )
+    mock_fsspec.open.assert_called_once_with(
+        "s3://my-bucket/floe/reports/run.json", "r", encoding="utf-8"
+    )
+    assert result == payload
+
+
+def test_load_json_document_gs_uri_calls_fsspec() -> None:
+    payload = {"status": "success"}
+    mock_fsspec = _make_fsspec_mock(json.dumps(payload))
+    with patch.dict(sys.modules, {"fsspec": mock_fsspec}):
+        result = _load_json_document(
+            "gs://bucket/report.json",
+            "gs://bucket/config.yml",
+            label="test",
+        )
+    mock_fsspec.open.assert_called_once()
+    assert result == payload
+
+
+def test_load_json_document_abfs_uri_calls_fsspec() -> None:
+    payload = {"rows": 100}
+    mock_fsspec = _make_fsspec_mock(json.dumps(payload))
+    with patch.dict(sys.modules, {"fsspec": mock_fsspec}):
+        result = _load_json_document(
+            "abfs://container@account.dfs.core.windows.net/report.json",
+            "abfs://container@account.dfs.core.windows.net/config.yml",
+            label="test",
+        )
+    mock_fsspec.open.assert_called_once()
+    assert result == payload
+
+
+# ── missing fsspec → helpful ImportError ─────────────────────────────────────
+
+def test_load_json_document_remote_missing_fsspec_raises_import_error() -> None:
+    original = sys.modules.pop("fsspec", None)
+    try:
+        with patch.dict(sys.modules, {"fsspec": None}):
+            with pytest.raises(ImportError, match="pip install fsspec"):
+                _read_json_text("s3://bucket/report.json", "s3://bucket/config.yml")
+    finally:
+        if original is not None:
+            sys.modules["fsspec"] = original
+
+
+# ── non-dict JSON root raises ValueError ─────────────────────────────────────
+
+def test_load_json_document_non_dict_root_raises(tmp_path: Path) -> None:
+    doc = tmp_path / "bad.json"
+    doc.write_text("[1, 2, 3]", encoding="utf-8")
+    with pytest.raises(ValueError, match="must be an object"):
+        _load_json_document(str(doc), str(tmp_path / "config.yml"), label="entity report")


### PR DESCRIPTION
Replaces the local-only `_resolve_local_json_path` helper with a unified `_read_json_text` + `_fsspec_read_text` pair (lazy fsspec import) so that `summary_uri` and `entity_report_uri` values like `s3://`, `gs://`, and `abfs://` are fetched correctly instead of raising an unsupported-URI ValueError that was silently swallowed, causing asset checks to fall back to summary-only mode.

Adds a `remote = ["fsspec"]` optional extra in pyproject.toml and a new test module covering local, file://, local://, and remote URI paths including the missing-fsspec ImportError path.

Bumps dagster-floe to 0.1.9.

## Summary
What does this change do?

## Scope
- In scope:
- Out of scope:

## Success criteria
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- Tests run:
  - Unit tests for affected modules
  - Local integration test (if applicable)
- Docs updated (config/CLI/support matrix/etc.)

## Testing
Commands run:
- 

## Docs
Updated files:
- 

## Risks / notes
- 

## Checklist
- [ ] I ran fmt/clippy/tests
- [ ] I added/updated unit tests for affected modules
- [ ] I added a simple local integration test when applicable
- [ ] I updated docs where behavior or config changed
