### PR TITLE
[codex] Improve dagster-floe stdout parsing and log rendering

### DIFF
--- a/orchestrators/dagster-floe/src/floe_dagster/assets.py
+++ b/orchestrators/dagster-floe/src/floe_dagster/assets.py
@@ -19,7 +19,7 @@ from dagster import (
 from .k8s_status import STATUS_SUCCEEDED
 
 from .asset_checks import build_asset_check_results, build_asset_check_specs
-from .events import last_run_finished, parse_json_event_lines, parse_run_finished
+from .events import last_run_finished, parse_json_event_lines, parse_run_finished, render_log_event
 from .manifest import (
     DagsterManifest,
     ManifestExecution,
@@ -208,22 +208,20 @@ def _make_entity_multi_asset(
             dagster_job_name=dagster_job_name,
         )
 
-        if result.stderr.strip():
-            for line in result.stderr.splitlines():
-                context.log.info(line)
-        if result.stdout.strip():
-            for line in result.stdout.splitlines():
-                if line.strip():
-                    context.log.info(line)
-
         try:
             events = parse_json_event_lines(result.stdout)
+            _log_floe_output(context, result.stdout, events)
+            if result.stderr.strip():
+                _log_floe_stderr(context, result.stderr)
             finished_event = last_run_finished(events)
             finished = parse_run_finished(
                 finished_event,
                 summary_uri_field=execution.result_contract.summary_uri_field,
             )
         except ValueError as exc:
+            _log_floe_output(context, result.stdout, [])
+            if result.stderr.strip():
+                _log_floe_stderr(context, result.stderr)
             context.log.warning(f"failed to parse Floe run events: {exc}")
             synthetic_status = result.status or ("success" if result.exit_code == 0 else "failed")
             synthetic_exit_code = result.exit_code
@@ -317,6 +315,36 @@ def _make_entity_multi_asset(
             yield Output(value=None, output_name="rejected", metadata=rejected_metadata)
 
     return _multi_asset
+
+
+def _log_floe_stderr(context: Any, stderr: str) -> None:
+    for line in stderr.splitlines():
+        stripped = line.strip()
+        if stripped:
+            context.log.info(f"floe stderr | {stripped}")
+
+
+def _log_floe_output(context: Any, stdout: str, events: list[dict[str, Any]]) -> None:
+    rendered_by_raw = {
+        json.dumps(event, sort_keys=True, separators=(",", ":")): render_log_event(event)
+        for event in events
+    }
+    for line in stdout.splitlines():
+        stripped = line.strip()
+        if not stripped:
+            continue
+        rendered = None
+        if stripped.startswith("{"):
+            try:
+                event = json.loads(stripped)
+            except json.JSONDecodeError:
+                event = None
+            if isinstance(event, dict):
+                rendered = rendered_by_raw.get(
+                    json.dumps(event, sort_keys=True, separators=(",", ":")),
+                    render_log_event(event),
+                )
+        context.log.info(rendered or f"floe stdout | {stripped}")
 
 
 def _load_summary_json(summary_uri: str, config_uri: str) -> dict[str, Any]:

--- a/orchestrators/dagster-floe/src/floe_dagster/assets.py
+++ b/orchestrators/dagster-floe/src/floe_dagster/assets.py
@@ -19,7 +19,7 @@ from dagster import (
 from .k8s_status import STATUS_SUCCEEDED
 
 from .asset_checks import build_asset_check_results, build_asset_check_specs
-from .events import last_run_finished, parse_ndjson_events, parse_run_finished
+from .events import last_run_finished, parse_json_event_lines, parse_run_finished
 from .manifest import (
     DagsterManifest,
     ManifestExecution,
@@ -211,15 +211,20 @@ def _make_entity_multi_asset(
         if result.stderr.strip():
             for line in result.stderr.splitlines():
                 context.log.info(line)
+        if result.stdout.strip():
+            for line in result.stdout.splitlines():
+                if line.strip():
+                    context.log.info(line)
 
         try:
-            events = parse_ndjson_events(result.stdout)
+            events = parse_json_event_lines(result.stdout)
             finished_event = last_run_finished(events)
             finished = parse_run_finished(
                 finished_event,
                 summary_uri_field=execution.result_contract.summary_uri_field,
             )
-        except ValueError:
+        except ValueError as exc:
+            context.log.warning(f"failed to parse Floe run events: {exc}")
             synthetic_status = result.status or ("success" if result.exit_code == 0 else "failed")
             synthetic_exit_code = result.exit_code
             from .events import FloeRunFinished

--- a/orchestrators/dagster-floe/src/floe_dagster/events.py
+++ b/orchestrators/dagster-floe/src/floe_dagster/events.py
@@ -53,6 +53,101 @@ def parse_json_event_lines(stdout: str) -> list[dict[str, Any]]:
     return events
 
 
+def render_log_event(event: dict[str, Any]) -> str | None:
+    """Render a Floe JSON event as a compact Dagster log line."""
+    event_name = event.get("event")
+    if not isinstance(event_name, str) or not event_name:
+        return None
+
+    if event_name == "run_started":
+        return _format_parts(
+            "floe run started",
+            run_id=event.get("run_id"),
+            config=event.get("config"),
+            report_base=event.get("report_base"),
+        )
+    if event_name == "entity_started":
+        return _format_parts(
+            "floe entity started",
+            run_id=event.get("run_id"),
+            entity=event.get("name"),
+        )
+    if event_name == "file_started":
+        return _format_parts(
+            "floe file started",
+            run_id=event.get("run_id"),
+            entity=event.get("entity"),
+            input=event.get("input"),
+        )
+    if event_name == "file_finished":
+        return _format_parts(
+            "floe file finished",
+            run_id=event.get("run_id"),
+            entity=event.get("entity"),
+            input=event.get("input"),
+            status=event.get("status"),
+            rows=event.get("rows"),
+            accepted=event.get("accepted"),
+            rejected=event.get("rejected"),
+            elapsed_ms=event.get("elapsed_ms"),
+        )
+    if event_name == "entity_finished":
+        return _format_parts(
+            "floe entity finished",
+            run_id=event.get("run_id"),
+            entity=event.get("name"),
+            status=event.get("status"),
+            files=event.get("files"),
+            rows=event.get("rows"),
+            accepted=event.get("accepted"),
+            rejected=event.get("rejected"),
+            warnings=event.get("warnings"),
+            errors=event.get("errors"),
+        )
+    if event_name == "run_finished":
+        return _format_parts(
+            "floe run finished",
+            run_id=event.get("run_id"),
+            status=event.get("status"),
+            exit_code=event.get("exit_code"),
+            files=event.get("files"),
+            rows=event.get("rows"),
+            accepted=event.get("accepted"),
+            rejected=event.get("rejected"),
+            warnings=event.get("warnings"),
+            errors=event.get("errors"),
+            summary_uri=event.get("summary_uri"),
+        )
+    if event_name == "log":
+        return _format_parts(
+            "floe log",
+            run_id=event.get("run_id"),
+            level=event.get("log_level") or event.get("level"),
+            code=event.get("code"),
+            entity=event.get("entity"),
+            input=event.get("input"),
+            message=event.get("message"),
+        )
+    return _format_parts(f"floe {event_name}", run_id=event.get("run_id"))
+
+
+def _format_parts(prefix: str, **items: Any) -> str:
+    parts = [prefix]
+    for key, value in items.items():
+        if value is None:
+            continue
+        if isinstance(value, str) and value == "":
+            continue
+        parts.append(f"{key}={_format_value(value)}")
+    return " ".join(parts)
+
+
+def _format_value(value: Any) -> str:
+    if isinstance(value, str):
+        return value
+    return json.dumps(value, sort_keys=True, separators=(",", ":"))
+
+
 def last_run_finished(events: Iterable[dict[str, Any]]) -> dict[str, Any]:
     last: dict[str, Any] | None = None
     for event in events:

--- a/orchestrators/dagster-floe/src/floe_dagster/events.py
+++ b/orchestrators/dagster-floe/src/floe_dagster/events.py
@@ -31,6 +31,28 @@ def parse_ndjson_events(stdout: str) -> list[dict[str, Any]]:
     return events
 
 
+def parse_json_event_lines(stdout: str) -> list[dict[str, Any]]:
+    """Parse JSON object event lines from a mixed backend log stream.
+
+    Kubernetes and Databricks backends can return the complete container stdout.
+    Older Floe images may append human summary lines after the NDJSON events, so
+    Dagster integrations should extract JSON object lines instead of treating the
+    whole stream as strict NDJSON.
+    """
+    events: list[dict[str, Any]] = []
+    for line in stdout.splitlines():
+        stripped = line.strip()
+        if not stripped or not stripped.startswith("{"):
+            continue
+        try:
+            value = json.loads(stripped)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(value, dict):
+            events.append(value)
+    return events
+
+
 def last_run_finished(events: Iterable[dict[str, Any]]) -> dict[str, Any]:
     last: dict[str, Any] | None = None
     for event in events:

--- a/orchestrators/dagster-floe/tests/test_asset_checks.py
+++ b/orchestrators/dagster-floe/tests/test_asset_checks.py
@@ -245,6 +245,10 @@ def test_asset_emits_native_dagster_asset_checks_from_floe_reports(tmp_path: Pat
                     "summary_uri": f"local://{summary_path}",
                 }
             ),
+            "run id: run-123",
+            "Totals: files=2 rows=10 accepted=8 rejected=2",
+            "Overall: rejected (exit_code=0)",
+            f"Run summary: {summary_path}",
         ]
     )
 

--- a/orchestrators/dagster-floe/tests/test_events.py
+++ b/orchestrators/dagster-floe/tests/test_events.py
@@ -1,6 +1,11 @@
 from pathlib import Path
 
-from floe_dagster.events import last_run_finished, parse_ndjson_events, parse_run_finished
+from floe_dagster.events import (
+    last_run_finished,
+    parse_json_event_lines,
+    parse_ndjson_events,
+    parse_run_finished,
+)
 
 
 def test_ndjson_parsing_finds_run_finished():
@@ -22,6 +27,28 @@ def test_parse_run_finished_supports_custom_summary_field():
     }
     finished = parse_run_finished(event, summary_uri_field="custom_summary")
     assert finished.summary_uri == "local:///tmp/run.summary.json"
+
+
+def test_json_event_line_parsing_ignores_human_summary_lines():
+    stdout = "\n".join(
+        [
+            '{"event":"run_started","run_id":"run-1"}',
+            (
+                '{"event":"run_finished","run_id":"run-1","status":"success",'
+                '"exit_code":0,"summary_uri":"s3://bucket/report/run.summary.json"}'
+            ),
+            "run id: run-1",
+            "Totals: files=1 rows=3 accepted=3 rejected=0",
+            "Overall: success (exit_code=0)",
+        ]
+    )
+
+    events = parse_json_event_lines(stdout)
+    finished = parse_run_finished(last_run_finished(events))
+
+    assert len(events) == 2
+    assert finished.run_id == "run-1"
+    assert finished.summary_uri == "s3://bucket/report/run.summary.json"
 
 
 def test_parse_run_finished_extracts_new_fields():
@@ -52,4 +79,3 @@ def test_parse_run_finished_defaults_new_fields_when_absent():
     finished = parse_run_finished(event)
     assert finished.report_base is None
     assert finished.entity_report_uris == {}
-

--- a/orchestrators/dagster-floe/tests/test_events.py
+++ b/orchestrators/dagster-floe/tests/test_events.py
@@ -5,6 +5,7 @@ from floe_dagster.events import (
     parse_json_event_lines,
     parse_ndjson_events,
     parse_run_finished,
+    render_log_event,
 )
 
 
@@ -49,6 +50,45 @@ def test_json_event_line_parsing_ignores_human_summary_lines():
     assert len(events) == 2
     assert finished.run_id == "run-1"
     assert finished.summary_uri == "s3://bucket/report/run.summary.json"
+
+
+def test_render_log_event_formats_file_and_summary_details():
+    line = render_log_event(
+        {
+            "event": "file_finished",
+            "run_id": "run-1",
+            "entity": "customers",
+            "input": "s3://bucket/bronze/customers.csv",
+            "status": "success",
+            "rows": 3,
+            "accepted": 3,
+            "rejected": 0,
+            "elapsed_ms": 42,
+        }
+    )
+
+    assert line == (
+        "floe file finished run_id=run-1 entity=customers "
+        "input=s3://bucket/bronze/customers.csv status=success "
+        "rows=3 accepted=3 rejected=0 elapsed_ms=42"
+    )
+
+    line = render_log_event(
+        {
+            "event": "run_finished",
+            "run_id": "run-1",
+            "status": "success",
+            "exit_code": 0,
+            "files": 1,
+            "rows": 3,
+            "accepted": 3,
+            "rejected": 0,
+            "summary_uri": "s3://bucket/report/run.summary.json",
+        }
+    )
+
+    assert "floe run finished run_id=run-1 status=success exit_code=0" in line
+    assert "summary_uri=s3://bucket/report/run.summary.json" in line
 
 
 def test_parse_run_finished_extracts_new_fields():


### PR DESCRIPTION
## Summary
- tolerate Floe Kubernetes stdout that contains both JSON event lines and plain human-readable CLI lines
- render known Floe events into concise Dagster log messages for run, entity, file, and summary lifecycle events
- preserve non-JSON stdout/stderr as readable Dagster log lines instead of treating them as parse failures
- keep report/check parsing based on `run_finished.summary_uri` when Floe emits a remote report

## Root Cause
`dagster-floe` parsed Kubernetes backend stdout as strict NDJSON. In OpenLakeForge, Floe stdout can contain valid JSON lifecycle events followed by plain summary lines. A single non-JSON line made parsing fail, so dagster-floe fell back to a synthetic finished event with no `summary_uri`. Dagster then missed report stats and showed little useful detail in the run logs.

## Validation
- `PYTHONPATH=orchestrators/dagster-floe/src .venv-dagster-floe-pr/bin/python -m pytest -s -q orchestrators/dagster-floe/tests/test_events.py orchestrators/dagster-floe/tests/test_asset_checks.py` => 11 passed
- Built the PR wheel into `ghcr.io/openlakeforge/project-code:dagster-floe-pr-363-render`
- Deployed OpenLakeForge local stack with `make local-up`
- Launched `sales_bronze_to_silver_job` with empty run config, matching UI defaults
- OpenLakeForge Dagster run `f41d1e08-f182-455c-8cb6-47efda43d0f7` completed with `SUCCESS`
- Confirmed Dagster logs now include `floe run started`, `floe file started`, `floe file finished`, `floe entity finished`, `floe run finished ... summary_uri=...`, and plain text `floe stdout | ...` summary lines
- Confirmed the previous mixed-stdout parse warning did not appear in the validation run