### PR TITLE
chore(dagster-floe): bump to v0.2.0

### DIFF
--- a/orchestrators/dagster-floe/pyproject.toml
+++ b/orchestrators/dagster-floe/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "dagster-floe"
-version = "0.1.9"
+version = "0.2.0"
 description = "Dagster connector for Floe CLI (config-driven ingestion)"
 requires-python = ">=3.10"
 readme = "README.md"


### PR DESCRIPTION
Bumps dagster-floe from 0.1.9 to 0.2.0.

Covers commits since the last release tag ():
- fix(dagster-floe): load remote report URIs via fsspec (#362)
- [codex] Improve dagster-floe stdout parsing and log rendering (#363)

🤖 Generated with [Claude Code](https://claude.com/claude-code)