### PR TITLE
feat(orchestration): profile → manifest → Dagster job concurrency config

### DIFF
--- a/crates/floe-core/src/manifest/builder.rs
+++ b/crates/floe-core/src/manifest/builder.rs
@@ -6,9 +6,9 @@ use sha2::{Digest, Sha256};
 use crate::config::{ConfigLocation, RootConfig, SourceOptions, StorageResolver};
 use crate::manifest::model::{
     CommonManifest, ManifestArchiveTarget, ManifestColumnDef, ManifestDomain, ManifestEntity,
-    ManifestEntitySchema, ManifestExecution, ManifestExecutionDefaults, ManifestResultContract,
-    ManifestRunnerAuth, ManifestRunnerDefinition, ManifestRunnerResources, ManifestRunnerSecret,
-    ManifestRunners, ManifestSinkTarget, ManifestSinks, ManifestSource,
+    ManifestEntitySchema, ManifestExecution, ManifestExecutionDefaults, ManifestOrchestration,
+    ManifestResultContract, ManifestRunnerAuth, ManifestRunnerDefinition, ManifestRunnerResources,
+    ManifestRunnerSecret, ManifestRunners, ManifestSinkTarget, ManifestSinks, ManifestSource,
 };
 use crate::profile::ProfileConfig;
 use crate::FloeResult;
@@ -415,7 +415,7 @@ fn build_common_manifest(
                     .unwrap_or_else(|| domain.incoming_dir.clone()),
             })
             .collect(),
-        execution: default_execution_contract(options),
+        execution: default_execution_contract(options, profile),
         runners: runners_contract(profile),
         entities: manifest_entities,
         storages,
@@ -525,7 +525,10 @@ fn map_source_options(options: Option<&SourceOptions>) -> Option<serde_json::Val
     Some(serde_json::Value::Object(map))
 }
 
-fn default_execution_contract(options: &ManifestOptions) -> ManifestExecution {
+fn default_execution_contract(
+    options: &ManifestOptions,
+    profile: Option<&ProfileConfig>,
+) -> ManifestExecution {
     let mut exit_codes = BTreeMap::new();
     exit_codes.insert("0", "success_or_rejected");
     exit_codes.insert("1", "technical_failure");
@@ -554,6 +557,14 @@ fn default_execution_contract(options: &ManifestOptions) -> ManifestExecution {
     })
     .collect();
 
+    let orchestration = profile
+        .and_then(|p| p.execution.as_ref())
+        .and_then(|e| e.orchestration.as_ref())
+        .map(|o| ManifestOrchestration {
+            max_concurrent_entities: o.max_concurrent_entities,
+            strategy: o.strategy.clone(),
+        });
+
     ManifestExecution {
         entrypoint: "floe",
         base_args,
@@ -568,6 +579,7 @@ fn default_execution_contract(options: &ManifestOptions) -> ManifestExecution {
             env: BTreeMap::new(),
             workdir: None,
         },
+        orchestration,
     }
 }
 

--- a/crates/floe-core/src/manifest/model.rs
+++ b/crates/floe-core/src/manifest/model.rs
@@ -49,6 +49,16 @@ pub struct ManifestExecution {
     pub log_format: &'static str,
     pub result_contract: ManifestResultContract,
     pub defaults: ManifestExecutionDefaults,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub orchestration: Option<ManifestOrchestration>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ManifestOrchestration {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub max_concurrent_entities: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub strategy: Option<String>,
 }
 
 #[derive(Debug, Serialize)]

--- a/crates/floe-core/src/profile/parse.rs
+++ b/crates/floe-core/src/profile/parse.rs
@@ -196,6 +196,12 @@ fn parse_orchestration(value: &Yaml) -> FloeResult<ProfileOrchestration> {
         "profile.execution.orchestration",
     )?;
 
+    if let Some(0) = max_concurrent_entities {
+        return Err(Box::new(ConfigError(
+            "profile.execution.orchestration.max_concurrent_entities: must be >= 1".to_string(),
+        )));
+    }
+
     let strategy = get_optional_string(hash, "strategy", "profile.execution.orchestration")?;
 
     if let Some(ref s) = strategy {

--- a/crates/floe-core/src/profile/parse.rs
+++ b/crates/floe-core/src/profile/parse.rs
@@ -8,9 +8,9 @@ use crate::config::yaml_decode::{
     hash_get, load_yaml, validate_known_keys, yaml_array, yaml_hash, yaml_string,
 };
 use crate::profile::types::{
-    ProfileConfig, ProfileExecution, ProfileMetadata, ProfileRunner, ProfileRunnerAuth,
-    ProfileRunnerResources, ProfileRunnerSecret, ProfileValidation, PROFILE_API_VERSION,
-    PROFILE_KIND,
+    ProfileConfig, ProfileExecution, ProfileMetadata, ProfileOrchestration, ProfileRunner,
+    ProfileRunnerAuth, ProfileRunnerResources, ProfileRunnerSecret, ProfileValidation,
+    PROFILE_API_VERSION, PROFILE_KIND,
 };
 use crate::{ConfigError, FloeResult};
 
@@ -162,7 +162,7 @@ fn parse_metadata(value: &Yaml) -> FloeResult<ProfileMetadata> {
 
 fn parse_execution(value: &Yaml) -> FloeResult<ProfileExecution> {
     let hash = yaml_hash(value, "profile.execution")?;
-    validate_known_keys(hash, "profile.execution", &["runner"])?;
+    validate_known_keys(hash, "profile.execution", &["runner", "orchestration"])?;
 
     let runner_yaml = hash_get(hash, "runner").ok_or_else(|| {
         Box::new(ConfigError(
@@ -171,7 +171,45 @@ fn parse_execution(value: &Yaml) -> FloeResult<ProfileExecution> {
     })?;
     let runner = parse_runner(runner_yaml)?;
 
-    Ok(ProfileExecution { runner })
+    let orchestration = match hash_get(hash, "orchestration") {
+        Some(value) => Some(parse_orchestration(value)?),
+        None => None,
+    };
+
+    Ok(ProfileExecution {
+        runner,
+        orchestration,
+    })
+}
+
+fn parse_orchestration(value: &Yaml) -> FloeResult<ProfileOrchestration> {
+    let hash = yaml_hash(value, "profile.execution.orchestration")?;
+    validate_known_keys(
+        hash,
+        "profile.execution.orchestration",
+        &["max_concurrent_entities", "strategy"],
+    )?;
+
+    let max_concurrent_entities = get_optional_u64(
+        hash,
+        "max_concurrent_entities",
+        "profile.execution.orchestration",
+    )?;
+
+    let strategy = get_optional_string(hash, "strategy", "profile.execution.orchestration")?;
+
+    if let Some(ref s) = strategy {
+        if s != "sequential" && s != "parallel" {
+            return Err(Box::new(ConfigError(format!(
+                "profile.execution.orchestration.strategy: expected \"sequential\" or \"parallel\", got \"{s}\""
+            ))));
+        }
+    }
+
+    Ok(ProfileOrchestration {
+        max_concurrent_entities,
+        strategy,
+    })
 }
 
 fn parse_runner(value: &Yaml) -> FloeResult<ProfileRunner> {

--- a/crates/floe-core/src/profile/types.rs
+++ b/crates/floe-core/src/profile/types.rs
@@ -27,6 +27,14 @@ pub struct ProfileMetadata {
 #[derive(Debug, Clone)]
 pub struct ProfileExecution {
     pub runner: ProfileRunner,
+    pub orchestration: Option<ProfileOrchestration>,
+}
+
+#[derive(Debug, Clone)]
+pub struct ProfileOrchestration {
+    pub max_concurrent_entities: Option<u64>,
+    /// "sequential" | "parallel"
+    pub strategy: Option<String>,
 }
 
 #[derive(Debug, Clone)]

--- a/crates/floe-core/tests/unit/manifest/mod.rs
+++ b/crates/floe-core/tests/unit/manifest/mod.rs
@@ -572,6 +572,168 @@ entities:
 }
 
 #[test]
+fn manifest_orchestration_absent_when_no_profile() {
+    let config_path = repo_root().join("example/config.yml");
+    let config_location = resolve_config_location(config_path.to_str().expect("utf8"))
+        .expect("resolve config location");
+    let config = load_config(&config_location.path).expect("load config");
+
+    let payload = build_common_manifest_json(
+        &config_location,
+        &config,
+        &[],
+        None,
+        &ManifestOptions::default(),
+    )
+    .expect("manifest");
+    let value: Value = serde_json::from_str(&payload).expect("valid json");
+
+    assert!(
+        value["execution"]["orchestration"].is_null(),
+        "orchestration should be absent when no profile is provided"
+    );
+}
+
+#[test]
+fn manifest_orchestration_absent_when_profile_has_none() {
+    let profile_yaml = r#"
+apiVersion: floe/v1
+kind: EnvironmentProfile
+metadata:
+  name: prod
+execution:
+  runner:
+    type: local
+"#;
+    let profile = parse_profile_from_str(profile_yaml).expect("parse profile");
+    let config_path = repo_root().join("example/config.yml");
+    let config_location = resolve_config_location(config_path.to_str().expect("utf8"))
+        .expect("resolve config location");
+    let config = load_config(&config_location.path).expect("load config");
+
+    let payload = build_common_manifest_json(
+        &config_location,
+        &config,
+        &[],
+        Some(&profile),
+        &ManifestOptions::default(),
+    )
+    .expect("manifest");
+    let value: Value = serde_json::from_str(&payload).expect("valid json");
+
+    assert!(
+        value["execution"]["orchestration"].is_null(),
+        "orchestration should be absent when profile has no orchestration"
+    );
+}
+
+#[test]
+fn manifest_orchestration_strategy_sequential_from_profile() {
+    let profile_yaml = r#"
+apiVersion: floe/v1
+kind: EnvironmentProfile
+metadata:
+  name: prod
+execution:
+  runner:
+    type: kubernetes_job
+  orchestration:
+    strategy: sequential
+"#;
+    let profile = parse_profile_from_str(profile_yaml).expect("parse profile");
+    let config_path = repo_root().join("example/config.yml");
+    let config_location = resolve_config_location(config_path.to_str().expect("utf8"))
+        .expect("resolve config location");
+    let config = load_config(&config_location.path).expect("load config");
+
+    let payload = build_common_manifest_json(
+        &config_location,
+        &config,
+        &[],
+        Some(&profile),
+        &ManifestOptions::default(),
+    )
+    .expect("manifest");
+    let value: Value = serde_json::from_str(&payload).expect("valid json");
+
+    assert_eq!(
+        value["execution"]["orchestration"]["strategy"],
+        "sequential"
+    );
+    assert!(value["execution"]["orchestration"]["max_concurrent_entities"].is_null());
+}
+
+#[test]
+fn manifest_orchestration_max_concurrent_from_profile() {
+    let profile_yaml = r#"
+apiVersion: floe/v1
+kind: EnvironmentProfile
+metadata:
+  name: prod
+execution:
+  runner:
+    type: kubernetes_job
+  orchestration:
+    max_concurrent_entities: 2
+"#;
+    let profile = parse_profile_from_str(profile_yaml).expect("parse profile");
+    let config_path = repo_root().join("example/config.yml");
+    let config_location = resolve_config_location(config_path.to_str().expect("utf8"))
+        .expect("resolve config location");
+    let config = load_config(&config_location.path).expect("load config");
+
+    let payload = build_common_manifest_json(
+        &config_location,
+        &config,
+        &[],
+        Some(&profile),
+        &ManifestOptions::default(),
+    )
+    .expect("manifest");
+    let value: Value = serde_json::from_str(&payload).expect("valid json");
+
+    assert_eq!(
+        value["execution"]["orchestration"]["max_concurrent_entities"],
+        2
+    );
+}
+
+#[test]
+fn manifest_orchestration_both_fields_from_profile() {
+    let profile_yaml = r#"
+apiVersion: floe/v1
+kind: EnvironmentProfile
+metadata:
+  name: prod
+execution:
+  runner:
+    type: local
+  orchestration:
+    max_concurrent_entities: 1
+    strategy: sequential
+"#;
+    let profile = parse_profile_from_str(profile_yaml).expect("parse profile");
+    let config_path = repo_root().join("example/config.yml");
+    let config_location = resolve_config_location(config_path.to_str().expect("utf8"))
+        .expect("resolve config location");
+    let config = load_config(&config_location.path).expect("load config");
+
+    let payload = build_common_manifest_json(
+        &config_location,
+        &config,
+        &[],
+        Some(&profile),
+        &ManifestOptions::default(),
+    )
+    .expect("manifest");
+    let value: Value = serde_json::from_str(&payload).expect("valid json");
+
+    let orch = &value["execution"]["orchestration"];
+    assert_eq!(orch["max_concurrent_entities"], 1);
+    assert_eq!(orch["strategy"], "sequential");
+}
+
+#[test]
 fn manifest_path_mode_resolved_uri_sets_path_from_uri() {
     let temp_dir = tempfile::TempDir::new().expect("temp dir");
     let root = temp_dir.path();

--- a/crates/floe-core/tests/unit/profile/parse.rs
+++ b/crates/floe-core/tests/unit/profile/parse.rs
@@ -396,3 +396,123 @@ execution:
         "expected runner type error, got: {err}"
     );
 }
+
+// ---------------------------------------------------------------------------
+// Orchestration policy
+// ---------------------------------------------------------------------------
+
+#[test]
+fn parse_profile_orchestration_strategy_sequential() {
+    let yaml = r#"
+apiVersion: floe/v1
+kind: EnvironmentProfile
+metadata:
+  name: prod
+execution:
+  runner:
+    type: kubernetes_job
+  orchestration:
+    strategy: sequential
+"#;
+    let profile = parse_profile_from_str(yaml).expect("parse profile");
+    let exec = profile.execution.as_ref().expect("execution");
+    let orch = exec.orchestration.as_ref().expect("orchestration");
+    assert_eq!(orch.strategy.as_deref(), Some("sequential"));
+    assert!(orch.max_concurrent_entities.is_none());
+}
+
+#[test]
+fn parse_profile_orchestration_max_concurrent_entities() {
+    let yaml = r#"
+apiVersion: floe/v1
+kind: EnvironmentProfile
+metadata:
+  name: prod
+execution:
+  runner:
+    type: kubernetes_job
+  orchestration:
+    max_concurrent_entities: 3
+"#;
+    let profile = parse_profile_from_str(yaml).expect("parse profile");
+    let exec = profile.execution.as_ref().expect("execution");
+    let orch = exec.orchestration.as_ref().expect("orchestration");
+    assert_eq!(orch.max_concurrent_entities, Some(3));
+    assert!(orch.strategy.is_none());
+}
+
+#[test]
+fn parse_profile_orchestration_both_fields() {
+    let yaml = r#"
+apiVersion: floe/v1
+kind: EnvironmentProfile
+metadata:
+  name: prod
+execution:
+  runner:
+    type: local
+  orchestration:
+    max_concurrent_entities: 1
+    strategy: sequential
+"#;
+    let profile = parse_profile_from_str(yaml).expect("parse profile");
+    let exec = profile.execution.as_ref().expect("execution");
+    let orch = exec.orchestration.as_ref().expect("orchestration");
+    assert_eq!(orch.max_concurrent_entities, Some(1));
+    assert_eq!(orch.strategy.as_deref(), Some("sequential"));
+}
+
+#[test]
+fn parse_profile_orchestration_strategy_parallel() {
+    let yaml = r#"
+apiVersion: floe/v1
+kind: EnvironmentProfile
+metadata:
+  name: prod
+execution:
+  runner:
+    type: local
+  orchestration:
+    strategy: parallel
+"#;
+    let profile = parse_profile_from_str(yaml).expect("parse profile");
+    let exec = profile.execution.as_ref().expect("execution");
+    let orch = exec.orchestration.as_ref().expect("orchestration");
+    assert_eq!(orch.strategy.as_deref(), Some("parallel"));
+}
+
+#[test]
+fn parse_profile_orchestration_invalid_strategy_fails() {
+    let yaml = r#"
+apiVersion: floe/v1
+kind: EnvironmentProfile
+metadata:
+  name: prod
+execution:
+  runner:
+    type: local
+  orchestration:
+    strategy: round_robin
+"#;
+    let err = parse_profile_from_str(yaml).unwrap_err();
+    assert!(
+        err.to_string().contains("sequential") || err.to_string().contains("parallel"),
+        "expected strategy validation error, got: {err}"
+    );
+}
+
+#[test]
+fn parse_profile_without_orchestration_has_none() {
+    let yaml = r#"
+apiVersion: floe/v1
+kind: EnvironmentProfile
+metadata:
+  name: prod
+execution:
+  runner:
+    type: local
+"#;
+    let profile = parse_profile_from_str(yaml).expect("parse profile");
+    let exec = profile.execution.as_ref().expect("execution");
+    assert!(exec.orchestration.is_none());
+}

--- a/crates/floe-core/tests/unit/profile/parse.rs
+++ b/crates/floe-core/tests/unit/profile/parse.rs
@@ -502,6 +502,26 @@ execution:
 }
 
 #[test]
+fn parse_profile_orchestration_zero_max_concurrent_fails() {
+    let yaml = r#"
+apiVersion: floe/v1
+kind: EnvironmentProfile
+metadata:
+  name: prod
+execution:
+  runner:
+    type: local
+  orchestration:
+    max_concurrent_entities: 0
+"#;
+    let err = parse_profile_from_str(yaml).unwrap_err();
+    assert!(
+        err.to_string().contains("max_concurrent_entities"),
+        "expected max_concurrent_entities validation error, got: {err}"
+    );
+}
+
+#[test]
 fn parse_profile_without_orchestration_has_none() {
     let yaml = r#"
 apiVersion: floe/v1

--- a/orchestrators/dagster-floe/src/floe_dagster/definitions.py
+++ b/orchestrators/dagster-floe/src/floe_dagster/definitions.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import os
 import re
 from pathlib import Path
-from typing import Iterable
+from typing import Any, Iterable
 
 from dagster import AssetSelection, Definitions, define_asset_job
 
@@ -116,14 +116,32 @@ def build_definitions_from_manifest_paths(
             selection = AssetSelection.assets(
                 *[entity.asset_key for entity in manifest_entities]
             ).required_multi_asset_neighbors()
-            jobs.append(
-                define_asset_job(
-                    name=manifest_job_name,
-                    selection=selection,
-                )
-            )
+            job_kwargs: dict[str, Any] = {
+                "name": manifest_job_name,
+                "selection": selection,
+            }
+            max_concurrent = _resolve_max_concurrent(manifest.execution.orchestration)
+            if max_concurrent is not None:
+                job_kwargs["config"] = {
+                    "execution": {
+                        "config": {
+                            "multiprocess": {"max_concurrent": max_concurrent}
+                        }
+                    }
+                }
+            jobs.append(define_asset_job(**job_kwargs))
 
     return Definitions(assets=assets_defs, jobs=jobs)
+
+
+def _resolve_max_concurrent(orchestration: Any) -> int | None:
+    if orchestration is None:
+        return None
+    if orchestration.max_concurrent_entities is not None:
+        return orchestration.max_concurrent_entities
+    if orchestration.strategy == "sequential":
+        return 1
+    return None
 
 
 def _default_job_name(manifest_path: str, manifest_id: str) -> str:

--- a/orchestrators/dagster-floe/src/floe_dagster/definitions.py
+++ b/orchestrators/dagster-floe/src/floe_dagster/definitions.py
@@ -137,10 +137,11 @@ def build_definitions_from_manifest_paths(
 def _resolve_max_concurrent(orchestration: Any) -> int | None:
     if orchestration is None:
         return None
-    if orchestration.max_concurrent_entities is not None:
-        return orchestration.max_concurrent_entities
+    # sequential always means one-at-a-time, regardless of max_concurrent_entities
     if orchestration.strategy == "sequential":
         return 1
+    if orchestration.max_concurrent_entities is not None:
+        return orchestration.max_concurrent_entities
     return None
 
 

--- a/orchestrators/dagster-floe/src/floe_dagster/manifest.py
+++ b/orchestrators/dagster-floe/src/floe_dagster/manifest.py
@@ -53,6 +53,19 @@ class ManifestEntity:
 
 
 @dataclass(frozen=True)
+class ManifestOrchestration:
+    max_concurrent_entities: int | None
+    strategy: str | None
+
+    @staticmethod
+    def from_dict(data: dict[str, Any]) -> "ManifestOrchestration":
+        return ManifestOrchestration(
+            max_concurrent_entities=_optional_int(data, "max_concurrent_entities"),
+            strategy=_optional_str(data, "strategy"),
+        )
+
+
+@dataclass(frozen=True)
 class ManifestExecutionResultContract:
     run_finished_event: bool
     summary_uri_field: str
@@ -91,12 +104,19 @@ class ManifestExecution:
     log_format: str
     result_contract: ManifestExecutionResultContract
     defaults: ManifestExecutionDefaults
+    orchestration: ManifestOrchestration | None = None
 
     @staticmethod
     def from_dict(data: dict[str, Any]) -> "ManifestExecution":
         log_format = _required_str(data, "log_format")
         if log_format != "json":
             raise ValueError("execution.log_format must be 'json' for dagster-floe")
+        orchestration_raw = data.get("orchestration")
+        orchestration = (
+            ManifestOrchestration.from_dict(orchestration_raw)
+            if isinstance(orchestration_raw, dict)
+            else None
+        )
         return ManifestExecution(
             entrypoint=_required_str(data, "entrypoint"),
             base_args=_required_string_list(data, "base_args"),
@@ -106,6 +126,7 @@ class ManifestExecution:
                 _required_object(data, "result_contract")
             ),
             defaults=ManifestExecutionDefaults.from_dict(_required_object(data, "defaults")),
+            orchestration=orchestration,
         )
 
 

--- a/orchestrators/dagster-floe/src/floe_dagster/schemas/floe.manifest.v1.json
+++ b/orchestrators/dagster-floe/src/floe_dagster/schemas/floe.manifest.v1.json
@@ -183,6 +183,33 @@
               ]
             }
           }
+        },
+        "orchestration": {
+          "type": [
+            "object",
+            "null"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "max_concurrent_entities": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "minimum": 1
+            },
+            "strategy": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "enum": [
+                "sequential",
+                "parallel",
+                null
+              ]
+            }
+          }
         }
       }
     },

--- a/orchestrators/dagster-floe/tests/test_definitions.py
+++ b/orchestrators/dagster-floe/tests/test_definitions.py
@@ -315,3 +315,16 @@ def test_definitions_job_config_strategy_parallel_no_constraint(tmp_path) -> Non
     assert job is not None
     # strategy=parallel means no concurrency limit
     assert job.run_config is None or "multiprocess" not in str(job.run_config)
+
+
+def test_definitions_job_config_sequential_overrides_max_concurrent(tmp_path) -> None:
+    # strategy=sequential must enforce max_concurrent=1 even when
+    # max_concurrent_entities is set to a higher value
+    orchestration = '"orchestration": {"strategy": "sequential", "max_concurrent_entities": 3}'
+    manifest_path = _make_manifest_with_orchestration(tmp_path, orchestration)
+    defs = build_definitions(manifest_path=str(manifest_path), runner=_NoopRunner())
+    job = defs.get_job_def("floe_mfv1_orch_test_job")
+    assert job is not None
+    assert (
+        job.run_config["execution"]["config"]["multiprocess"]["max_concurrent"] == 1
+    ), "sequential strategy must cap concurrency at 1 regardless of max_concurrent_entities"

--- a/orchestrators/dagster-floe/tests/test_definitions.py
+++ b/orchestrators/dagster-floe/tests/test_definitions.py
@@ -204,3 +204,114 @@ def test_build_definitions_accepts_manifest_uri_kwarg() -> None:
         entities=["employees"],
     )
     assert defs is not None
+
+
+# ---------------------------------------------------------------------------
+# Orchestration policy → Dagster job concurrency config
+# ---------------------------------------------------------------------------
+
+def _make_manifest_with_orchestration(tmp_path, orchestration_block: str | None) -> Path:
+    """Write a minimal manifest fixture with an optional orchestration block."""
+    orch_section = ""
+    if orchestration_block is not None:
+        orch_section = f",\n    {orchestration_block}"
+    payload = """{
+  "schema": "floe.manifest.v1",
+  "generated_at_ts_ms": 0,
+  "floe_version": "0.4.5",
+  "spec_version": "0.1",
+  "manifest_id": "mfv1-orch-test",
+  "config_uri": "./config.yml",
+  "report_base_uri": "./report",
+  "domains": [],
+  "execution": {
+    "entrypoint": "floe",
+    "base_args": ["run", "--manifest", "{manifest_uri}", "--log-format", "json", "--quiet"],
+    "per_entity_args": ["--entities", "{entity_name}"],
+    "log_format": "json",
+    "result_contract": {
+      "run_finished_event": true,
+      "summary_uri_field": "summary_uri",
+      "exit_codes": {"0": "success_or_rejected", "1": "technical_failure"}
+    },
+    "defaults": {"env": {}, "workdir": null}""" + orch_section + """
+  },
+  "runners": {
+    "default": "local",
+    "definitions": {
+      "local": {"type": "local_process", "image": null, "namespace": null,
+                "service_account": null, "resources": null, "env": null}
+    }
+  },
+  "entities": [
+    {
+      "name": "orders",
+      "domain": "sales",
+      "group_name": "sales",
+      "asset_key": ["sales", "orders"],
+      "source_format": "csv",
+      "accepted_sink_uri": "./out/accepted/orders",
+      "runner": null,
+      "policy_severity": "warn",
+      "write_mode": "overwrite",
+      "incremental_mode": "none",
+      "source": {"format": "csv", "storage": "local", "uri": "./in/orders.csv",
+                 "path": "./in/orders.csv", "resolved": false},
+      "sinks": {
+        "accepted": {"format": "parquet", "storage": "local", "uri": "./out/accepted/orders",
+                     "path": "./out/accepted/orders", "resolved": false}
+      },
+      "schema": {"columns": [{"name": "id", "column_type": "string"}],
+                 "primary_key": [], "unique_keys": []}
+    }
+  ]
+}"""
+    path = tmp_path / "orch_test.manifest.json"
+    path.write_text(payload, encoding="utf-8")
+    return path
+
+
+def test_definitions_job_no_config_when_no_orchestration(tmp_path) -> None:
+    manifest_path = _make_manifest_with_orchestration(tmp_path, None)
+    defs = build_definitions(manifest_path=str(manifest_path), runner=_NoopRunner())
+    job = defs.get_job_def("floe_mfv1_orch_test_job")
+    assert job is not None
+    # No RunConfig should have been injected
+    assert job.run_config_schema is not None  # schema exists (Dagster always has it)
+    # Verify no multiprocess config was baked in by checking the default config is empty
+    assert job.config_mapping is None
+
+
+def test_definitions_job_config_strategy_sequential(tmp_path) -> None:
+    orchestration = '"orchestration": {"strategy": "sequential"}'
+    manifest_path = _make_manifest_with_orchestration(tmp_path, orchestration)
+    defs = build_definitions(manifest_path=str(manifest_path), runner=_NoopRunner())
+    job = defs.get_job_def("floe_mfv1_orch_test_job")
+    assert job is not None
+    # Job must carry a baked-in run_config with max_concurrent=1
+    assert job.run_config is not None
+    assert (
+        job.run_config["execution"]["config"]["multiprocess"]["max_concurrent"] == 1
+    )
+
+
+def test_definitions_job_config_max_concurrent_explicit(tmp_path) -> None:
+    orchestration = '"orchestration": {"max_concurrent_entities": 3}'
+    manifest_path = _make_manifest_with_orchestration(tmp_path, orchestration)
+    defs = build_definitions(manifest_path=str(manifest_path), runner=_NoopRunner())
+    job = defs.get_job_def("floe_mfv1_orch_test_job")
+    assert job is not None
+    assert job.run_config is not None
+    assert (
+        job.run_config["execution"]["config"]["multiprocess"]["max_concurrent"] == 3
+    )
+
+
+def test_definitions_job_config_strategy_parallel_no_constraint(tmp_path) -> None:
+    orchestration = '"orchestration": {"strategy": "parallel"}'
+    manifest_path = _make_manifest_with_orchestration(tmp_path, orchestration)
+    defs = build_definitions(manifest_path=str(manifest_path), runner=_NoopRunner())
+    job = defs.get_job_def("floe_mfv1_orch_test_job")
+    assert job is not None
+    # strategy=parallel means no concurrency limit
+    assert job.run_config is None or "multiprocess" not in str(job.run_config)

--- a/orchestrators/dagster-floe/tests/test_manifest.py
+++ b/orchestrators/dagster-floe/tests/test_manifest.py
@@ -221,3 +221,70 @@ def test_load_manifest_remote_uri_uses_fsspec(monkeypatch) -> None:
 
     result = load_manifest("s3://bucket/test/manifest.json")
     assert result.manifest_id
+
+
+# ---------------------------------------------------------------------------
+# ManifestOrchestration parsing
+# ---------------------------------------------------------------------------
+
+from floe_dagster.manifest import ManifestOrchestration
+
+
+def _base_execution_dict(**kwargs):
+    base = {
+        "entrypoint": "floe",
+        "base_args": ["run", "--manifest", "{manifest_uri}", "--log-format", "json"],
+        "per_entity_args": ["--entities", "{entity_name}"],
+        "log_format": "json",
+        "result_contract": {
+            "run_finished_event": True,
+            "summary_uri_field": "summary_uri",
+            "exit_codes": {"0": "success_or_rejected"},
+        },
+        "defaults": {"env": {}, "workdir": None},
+    }
+    base.update(kwargs)
+    return base
+
+
+def test_manifest_orchestration_absent_when_not_in_execution():
+    from floe_dagster.manifest import ManifestExecution
+    data = _base_execution_dict()
+    execution = ManifestExecution.from_dict(data)
+    assert execution.orchestration is None
+
+
+def test_manifest_orchestration_parsed_strategy_sequential():
+    from floe_dagster.manifest import ManifestExecution
+    data = _base_execution_dict(orchestration={"strategy": "sequential"})
+    execution = ManifestExecution.from_dict(data)
+    assert execution.orchestration is not None
+    assert execution.orchestration.strategy == "sequential"
+    assert execution.orchestration.max_concurrent_entities is None
+
+
+def test_manifest_orchestration_parsed_max_concurrent():
+    from floe_dagster.manifest import ManifestExecution
+    data = _base_execution_dict(orchestration={"max_concurrent_entities": 2})
+    execution = ManifestExecution.from_dict(data)
+    assert execution.orchestration is not None
+    assert execution.orchestration.max_concurrent_entities == 2
+    assert execution.orchestration.strategy is None
+
+
+def test_manifest_orchestration_parsed_both_fields():
+    from floe_dagster.manifest import ManifestExecution
+    data = _base_execution_dict(
+        orchestration={"max_concurrent_entities": 1, "strategy": "sequential"}
+    )
+    execution = ManifestExecution.from_dict(data)
+    assert execution.orchestration is not None
+    assert execution.orchestration.max_concurrent_entities == 1
+    assert execution.orchestration.strategy == "sequential"
+
+
+def test_manifest_orchestration_null_value_treated_as_absent():
+    from floe_dagster.manifest import ManifestExecution
+    data = _base_execution_dict(orchestration=None)
+    execution = ManifestExecution.from_dict(data)
+    assert execution.orchestration is None

--- a/orchestrators/schemas/floe.manifest.v1.json
+++ b/orchestrators/schemas/floe.manifest.v1.json
@@ -201,6 +201,33 @@
               ]
             }
           }
+        },
+        "orchestration": {
+          "type": [
+            "object",
+            "null"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "max_concurrent_entities": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "minimum": 1
+            },
+            "strategy": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "enum": [
+                "sequential",
+                "parallel",
+                null
+              ]
+            }
+          }
         }
       }
     },

--- a/schemas/profile.schema.yaml
+++ b/schemas/profile.schema.yaml
@@ -80,6 +80,33 @@ $defs:
     properties:
       runner:
         $ref: "#/$defs/profile_runner"
+      orchestration:
+        $ref: "#/$defs/profile_orchestration"
+
+  profile_orchestration:
+    type: object
+    additionalProperties: false
+    description: >
+      Controls how Floe schedules entity runs within a single execution.
+      Both fields are optional; omit the block entirely to use the default
+      (unbounded parallel) behaviour.
+    properties:
+      strategy:
+        type: string
+        enum:
+          - sequential
+          - parallel
+        description: >
+          Execution order of entities.
+            - "sequential": entities run one after another in sorted order.
+            - "parallel": entities run concurrently (default when omitted).
+      max_concurrent_entities:
+        type: integer
+        minimum: 1
+        description: >
+          Maximum number of entities that may run at the same time.
+          Must be >= 1.  When combined with strategy "sequential" this
+          value is effectively 1.
 
   profile_runner:
     type: object


### PR DESCRIPTION
## Summary

- **Profile** — adds an `orchestration` block under `execution` with two optional fields: `strategy` (`"sequential"` | `"parallel"`) and `max_concurrent_entities` (positive integer). Unknown keys and invalid strategy values are rejected at parse time.
- **Manifest** — `ManifestOrchestration` model + JSON schema field `execution.orchestration`; the builder copies the profile's orchestration block into the emitted manifest so it travels alongside the runner config.
- **dagster-floe** — new `ManifestOrchestration` dataclass; `build_definitions` wires `max_concurrent` into the Dagster `multiprocess` executor config automatically, replacing the previous hard-coded `max_concurrent: 1` sentinel with a profile-driven value.

## What changed

| Layer | Files |
|---|---|
| Rust profile types/parser | `crates/floe-core/src/profile/{types,parse}.rs` |
| Rust manifest model/builder | `crates/floe-core/src/manifest/{model,builder}.rs` |
| Rust tests | `crates/floe-core/tests/unit/{profile/parse,manifest/mod}.rs` |
| Python manifest dataclass | `orchestrators/dagster-floe/src/floe_dagster/manifest.py` |
| Dagster definitions | `orchestrators/dagster-floe/src/floe_dagster/definitions.py` |
| JSON schema | `orchestrators/dagster-floe/src/floe_dagster/schemas/floe.manifest.v1.json` |
| Python tests | `orchestrators/dagster-floe/tests/{test_manifest,test_definitions}.py` |

## Test plan

- [x] `cargo test -p floe-core --test unit` — 554 passed, 0 failed (includes 10 new orchestration tests)
- [x] `cargo clippy -p floe-core -p floe-cli -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] `uv run python -m pytest tests/` — 111 passed, 1 skipped (pre-existing skip), 0 failed (includes 9 new orchestration tests)