### PR TITLE
feat(write): stream Parquet writes via Polars sink_parquet (new_streaming)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to Floe are documented in this file.
 
 ## Unreleased
 
+- **Stream Parquet writes through the Polars `new_streaming` engine** (completes #332):
+  - The accepted Parquet writer in `io/write/parquet.rs::write_parquet_to_path` now calls `LazyFrame::sink_parquet(...).with_new_streaming(true).collect()` instead of the eager `ParquetWriter::new(file).finish(&mut df)`. The outer per-chunk loop in `ParquetSinkFormat::write` (which slices the input DataFrame to keep each call ≤ `sink.accepted.options.max_size_per_file`) is unchanged, so the existing `part-NNNNN.parquet` / `part-<uuid>.parquet` naming, the `PartNameAllocator`, `small_files_count`, and the run-report shape are all preserved.
+  - Within each chunk's write, the streaming engine emits one row group at a time and drops it before the next, replacing the previous "buffer the chunk plus full Arrow encoding state" footprint with "one row group + encoding buffer". Marginal versus the per-entity cap delivered earlier in this release, but real, especially on wide schemas or large `row_group_size` values.
+  - Polars' `new_streaming` cargo feature is enabled on `floe-core`'s existing `polars = "0.52.0"` dependency. No version bump, no `df-interchange` churn, no Cargo.lock noise. Reader paths (`io/read/parquet.rs::ParquetInputAdapter::read_inputs`, `io/write/parquet.rs::seed_from_parquet_path`) already use `LazyFrame::scan_parquet` plans and pick up the new engine implicitly through Polars' default-collect dispatch — no code change there.
+  - New integration test `streaming_parquet_writes_preserve_row_counts_and_size_bound` in `tests/integration/local_run.rs` forces ≥ 2 chunked writes through `sink_parquet` (5000 rows × `max_size_per_file: 4096`) and verifies the round-trip row count plus the per-part size bound.
+
 - **Soft-buffered accepted writes — cap per-entity memory at `max_size_per_file`** (addresses #332):
   - Floe previously held every accepted `DataFrame` from every input file in `accepted_accum: Vec<DataFrame>` until the entire entity was processed, then concatenated and wrote once. Peak RAM scaled as `O(n_files × rows_per_file)`, capping practical batch size.
   - A new `AcceptedBuffer` flushes to the configured sink whenever the running estimated in-memory size meets `sink.accepted.options.max_size_per_file` (default 256 MB) and once at the end of the entity. Peak accepted-side memory is bounded by one configured output-file budget regardless of input fanout.

--- a/crates/floe-core/Cargo.toml
+++ b/crates/floe-core/Cargo.toml
@@ -14,7 +14,7 @@ path = "src/lib.rs"
 
 [dependencies]
 yaml-rust2 = "0.11"
-polars = { version = "0.52.0", features = ["csv", "parquet", "lazy", "timezones", "dtype-date", "dtype-datetime", "dtype-time", "polars-ops", "is_unique", "is_first_distinct"] }
+polars = { version = "0.52.0", features = ["csv", "parquet", "lazy", "new_streaming", "timezones", "dtype-date", "dtype-datetime", "dtype-time", "polars-ops", "is_unique", "is_first_distinct"] }
 calamine = "0.24"
 rayon = "1"
 deltalake = { version = "0.30.1", features = ["datafusion", "s3", "azure", "gcs"] }

--- a/crates/floe-core/src/io/write/parquet.rs
+++ b/crates/floe-core/src/io/write/parquet.rs
@@ -1,6 +1,10 @@
 use std::path::Path;
 
-use polars::prelude::{DataFrame, ParquetCompression, ParquetWriter};
+use polars::polars_utils::plpath::PlPathRef;
+use polars::prelude::{
+    DataFrame, IntoLazy, ParquetCompression, ParquetWriteOptions, SinkOptions as PolarsSinkOptions,
+    SinkTarget,
+};
 
 use crate::checks::normalize::rename_output_columns;
 use crate::errors::{IoError, StorageError};
@@ -46,11 +50,32 @@ pub fn write_parquet_to_path(
     if let Some(parent) = output_path.parent() {
         std::fs::create_dir_all(parent)?;
     }
-    let file = std::fs::File::create(output_path)?;
-    let mut writer = ParquetWriter::new(file);
+    let write_options = build_parquet_write_options(options)?;
+    let sink_options = PolarsSinkOptions {
+        mkdir: false,
+        ..PolarsSinkOptions::default()
+    };
+    let target = SinkTarget::Path(PlPathRef::from_local_path(output_path).into_owned());
+    // The outer chunking loop in `ParquetSinkFormat::write` discards each
+    // chunk after the write, so taking the DataFrame here is safe. Using
+    // `std::mem::take` lets us hand ownership to `LazyFrame` without an
+    // extra clone of the Arrow buffers.
+    let frame = std::mem::take(df);
+    frame
+        .lazy()
+        .sink_parquet(target, write_options, None, sink_options)
+        .and_then(|lf| lf.with_new_streaming(true).collect())
+        .map_err(|err| Box::new(IoError(format!("parquet write failed: {err}"))))?;
+    Ok(())
+}
+
+fn build_parquet_write_options(
+    options: Option<&config::SinkOptions>,
+) -> FloeResult<ParquetWriteOptions> {
+    let mut write_options = ParquetWriteOptions::default();
     if let Some(options) = options {
         if let Some(compression) = &options.compression {
-            writer = writer.with_compression(parse_parquet_compression(compression)?);
+            write_options.compression = parse_parquet_compression(compression)?;
         }
         if let Some(row_group_size) = options.row_group_size {
             let row_group_size = usize::try_from(row_group_size).map_err(|_| {
@@ -58,13 +83,10 @@ pub fn write_parquet_to_path(
                     "parquet row_group_size is too large: {row_group_size}"
                 )))
             })?;
-            writer = writer.with_row_group_size(Some(row_group_size));
+            write_options.row_group_size = Some(row_group_size);
         }
     }
-    writer
-        .finish(df)
-        .map_err(|err| Box::new(IoError(format!("parquet write failed: {err}"))))?;
-    Ok(())
+    Ok(write_options)
 }
 
 impl SinkFormat for ParquetSinkFormat {

--- a/crates/floe-core/tests/integration/local_run.rs
+++ b/crates/floe-core/tests/integration/local_run.rs
@@ -2,6 +2,7 @@ use std::fs;
 use std::path::{Path, PathBuf};
 
 use floe_core::{run, RunOptions};
+use polars::prelude::{ParquetReader, SerReader};
 
 fn write_csv(dir: &Path, name: &str, contents: &str) -> PathBuf {
     let path = dir.join(name);
@@ -197,4 +198,100 @@ entities:
             > 0.0
     );
     assert!(report.accepted_output.small_files_count.is_some());
+}
+
+#[test]
+fn streaming_parquet_writes_preserve_row_counts_and_size_bound() {
+    // Forces multiple chunked writes through LazyFrame::sink_parquet (the
+    // new_streaming engine) within a single buffer flush, and verifies the
+    // round trip: sum of rows on disk == input rows, and each part stays
+    // within a generous multiple of `max_size_per_file`. Locks down the
+    // streaming-engine swap against the previous eager-writer baseline.
+    let temp_dir = tempfile::TempDir::new().expect("temp dir");
+    let root = temp_dir.path();
+    let input_dir = root.join("in");
+    let accepted_dir = root.join("out/accepted/customer");
+    let report_dir = root.join("report");
+
+    fs::create_dir_all(&input_dir).expect("create input dir");
+    let mut csv = String::from("id;name\n");
+    for i in 0..5000 {
+        csv.push_str(&format!("{i};user_{i}\n"));
+    }
+    write_csv(&input_dir, "data.csv", &csv);
+
+    let max_size_per_file: u64 = 4096;
+    let yaml = format!(
+        r#"version: "0.1"
+report:
+  path: "{report_dir}"
+entities:
+  - name: "customer"
+    source:
+      format: "csv"
+      path: "{input_dir}"
+    sink:
+      accepted:
+        format: "parquet"
+        path: "{accepted_dir}"
+        options:
+          max_size_per_file: {max_size_per_file}
+    policy:
+      severity: "warn"
+    schema:
+      columns:
+        - name: "id"
+          type: "string"
+        - name: "name"
+          type: "string"
+"#,
+        report_dir = report_dir.display(),
+        input_dir = input_dir.display(),
+        accepted_dir = accepted_dir.display(),
+        max_size_per_file = max_size_per_file,
+    );
+    let config_path = write_config(root, &yaml);
+
+    let outcome = run(
+        &config_path,
+        RunOptions {
+            profile: None,
+            run_id: Some("it-streaming-parquet".to_string()),
+            entities: Vec::new(),
+            dry_run: false,
+            full_refresh: false,
+        },
+    )
+    .expect("run config");
+
+    let report = &outcome.entity_outcomes[0].report;
+    assert_eq!(report.results.accepted_total, 5000);
+    assert!(
+        report.accepted_output.parts_written > 1,
+        "expected the streaming engine to emit multiple part files for a small max_size_per_file"
+    );
+
+    let mut part_paths: Vec<PathBuf> = fs::read_dir(&accepted_dir)
+        .expect("read accepted dir")
+        .filter_map(|entry| entry.ok())
+        .map(|entry| entry.path())
+        .filter(|path| path.extension().and_then(|ext| ext.to_str()) == Some("parquet"))
+        .collect();
+    part_paths.sort();
+
+    let mut total_rows = 0_usize;
+    for part_path in &part_paths {
+        let file = fs::File::open(part_path).expect("open part parquet");
+        let df = ParquetReader::new(file)
+            .finish()
+            .expect("read part parquet");
+        total_rows += df.height();
+        // Allow generous slack for Parquet metadata + footer overhead.
+        let size = fs::metadata(part_path).expect("part metadata").len();
+        assert!(
+            size <= max_size_per_file * 4,
+            "part {part_path:?} size {size} exceeds 4x max_size_per_file ({max_size_per_file})"
+        );
+    }
+    assert_eq!(total_rows, 5000);
 }


### PR DESCRIPTION
## Summary

Completes the migration to the Polars streaming engine described in #332. PR 1 (#366) capped per-entity memory at `sink.accepted.options.max_size_per_file` via the soft-buffered flush. PR 2 replaces the per-chunk Parquet write inside that buffer's flush loop with a streaming-engine write, so allocation during a single chunk becomes row-group-bounded instead of full-Arrow-buffer-bounded.

Two atomic commits:
- `2c3b18f` — Enable `new_streaming` cargo feature on the existing `polars = 0.52.0` dep. No version bump.
- `c470436` — Rewrite `write_parquet_to_path` to call `LazyFrame::sink_parquet(...).with_new_streaming(true).collect()`. Outer chunking loop, part naming, allocator, and `AcceptedWriteOutput` shape are unchanged.

## Why Polars 0.52 (not 0.53)

Polars 0.53.0 on crates.io is currently unusable: `polars-arrow 0.53.0` declares `chrono = { version = \"<=0.4.41\", features = [\"std\"] }`, but chrono 0.4.41 does not expose a `std` feature. Fixed on polars `main` in [pola-rs/polars#26075](https://github.com/pola-rs/polars/pull/26075) but no 0.53.x patch has been cut. Polars 0.52 already ships the new streaming engine behind the `new_streaming` feature flag; no version bump is needed to ship PR 2 today.

## What changed inside the writer

```rust
// before — eager
let file = std::fs::File::create(output_path)?;
ParquetWriter::new(file)
    .with_compression(...)
    .with_row_group_size(...)
    .finish(df)?;

// after — streaming
let target = SinkTarget::Path(PlPathRef::from_local_path(output_path).into_owned());
let frame = std::mem::take(df);
frame.lazy()
    .sink_parquet(target, options, None, sink_options)
    .and_then(|lf| lf.with_new_streaming(true).collect())?;
```

The outer chunking loop in `ParquetSinkFormat::write` (lines 105–192 in the diff) is untouched. Part naming (`part-NNNNN.parquet` for Overwrite, `part-<uuid>.parquet` for Append) goes through the existing `PartNameAllocator`. The `small_files_count`, `total_bytes_written`, `avg_file_size_mb`, and `parts_written` derivation in `metrics::summarize_written_file_sizes` is unchanged.

Reader paths (`io/read/parquet.rs::ParquetInputAdapter::read_inputs`, `io/write/parquet.rs::seed_from_parquet_path`) already use `LazyFrame::scan_parquet` plans, so they pick up the new engine implicitly through Polars' default-collect dispatch — no code change there.

## What this PR does NOT do

- **No cloud-side streaming sinks.** The existing write-to-local-temp-then-upload-via-`StorageClient` pattern is preserved. Direct `s3://` / `gs://` / `abfss://` sinks via `polars[cloud]` would require reworking the storage layer; out of scope.
- **No reader-path audit.** Lazy reads already inherit the streaming engine post-feature-enable; auditing every `scan_parquet().collect()` pair for streaming eligibility is a separate exercise.
- **No validation-pipeline streaming.** `run_expr_checks`, `apply_mismatch_plan`, and `UniqueTracker` still require a materialised DataFrame. Documented in #332 as a future iteration.
- **No `polars = 0.53` upgrade.** Blocked on upstream; revisit when 0.53.1 (or later) ships on crates.io.

## Test plan

- [x] `cargo fmt --all`
- [x] `cargo clippy -p floe-core -p floe-cli -p floe-python -- -D warnings` — clean
- [x] `cargo test -p floe-core` — **543 unit + 52 integration tests pass** (was 543 + 51 on main; +1 from the new streaming test below)
- [x] New `streaming_parquet_writes_preserve_row_counts_and_size_bound` in `tests/integration/local_run.rs`: 5000 rows × `max_size_per_file: 4096` forces multiple chunked `sink_parquet` writes; asserts (a) total row round-trip via `ParquetReader`, (b) per-part on-disk size ≤ `max_size_per_file * 4` (slack for Parquet metadata + footer overhead).
- [x] The existing chunking tests (`accepted_output_splits_into_multiple_parts`, `accepted_output_overwrite_clears_previous_parts`, `accepted_output_append_adds_new_parts_across_runs`, the Delta and Iceberg multi-flush tests, the archive ordering test from PR 1) all stay green against the new writer — strongest evidence the swap is observably equivalent.

## Rollback story

If the streaming engine surfaces a regression specific to a corner case the tests don't cover, both commits can be reverted independently: the writer swap (`c470436`) is the only behavioural change, and the feature-flag commit (`2c3b18f`) is inert without it.

Closes #332 (in combination with #366).