### PR TITLE
[codex] fix REST Iceberg env credentials

### DIFF
--- a/crates/floe-core/src/io/write/iceberg/rest.rs
+++ b/crates/floe-core/src/io/write/iceberg/rest.rs
@@ -146,32 +146,32 @@ fn expand_env_refs(value: &str, catalog_name: &str) -> FloeResult<String> {
         return Ok(value.to_string());
     }
 
-    let mut expanded = String::with_capacity(value.len());
-    let mut rest = value;
-    while let Some(start) = rest.find("${") {
-        expanded.push_str(&rest[..start]);
-        let after_start = &rest[start + 2..];
-        let Some(end) = after_start.find('}') else {
-            return Err(Box::new(RunError(format!(
-                "rest iceberg catalog {catalog_name} credential has unclosed env placeholder"
-            ))));
-        };
-        let name = &after_start[..end];
-        if name.is_empty() || name.contains('{') || name.contains('}') {
-            return Err(Box::new(RunError(format!(
-                "rest iceberg catalog {catalog_name} credential has invalid env placeholder"
-            ))));
-        }
-        let env_value = std::env::var(name).map_err(|_| {
-            Box::new(RunError(format!(
-                "rest iceberg catalog {catalog_name} credential references env var {name} which is not set"
-            ))) as Box<dyn std::error::Error + Send + Sync>
-        })?;
-        expanded.push_str(&env_value);
-        rest = &after_start[end + 1..];
+    let mut parts = Vec::new();
+    for part in value.split(':') {
+        parts.push(expand_env_ref_part(part, catalog_name)?);
     }
-    expanded.push_str(rest);
-    Ok(expanded)
+    Ok(parts.join(":"))
+}
+
+fn expand_env_ref_part(part: &str, catalog_name: &str) -> FloeResult<String> {
+    let Some(inner) = part.strip_prefix("${") else {
+        return Ok(part.to_string());
+    };
+    let Some(name) = inner.strip_suffix('}') else {
+        return Err(Box::new(RunError(format!(
+            "rest iceberg catalog {catalog_name} credential has unclosed env placeholder"
+        ))));
+    };
+    if name.is_empty() || name.contains('{') || name.contains('}') {
+        return Err(Box::new(RunError(format!(
+            "rest iceberg catalog {catalog_name} credential has invalid env placeholder"
+        ))));
+    }
+    std::env::var(name).map_err(|_| {
+        Box::new(RunError(format!(
+            "rest iceberg catalog {catalog_name} credential references env var {name} which is not set"
+        ))) as Box<dyn std::error::Error + Send + Sync>
+    })
 }
 
 pub(crate) async fn write_via_rest_catalog(
@@ -406,6 +406,14 @@ mod tests {
 
         assert_eq!(expanded, "token:pat-token");
         std::env::remove_var("FLOE_TEST_REST_TOKEN");
+    }
+
+    #[test]
+    fn preserves_literal_credential_text_that_contains_env_ref_syntax() {
+        let expanded =
+            expand_env_refs("token:abc${def}ghi", "nessie").expect("preserve literal credential");
+
+        assert_eq!(expanded, "token:abc${def}ghi");
     }
 
     #[test]

--- a/crates/floe-core/src/io/write/iceberg/rest.rs
+++ b/crates/floe-core/src/io/write/iceberg/rest.rs
@@ -174,64 +174,6 @@ fn expand_env_refs(value: &str, catalog_name: &str) -> FloeResult<String> {
     Ok(expanded)
 }
 
-#[cfg(test)]
-mod tests {
-    use super::expand_env_refs;
-
-    #[test]
-    fn expands_partial_env_refs_in_client_credentials() {
-        std::env::set_var("FLOE_TEST_REST_CLIENT_ID", "client-id");
-        std::env::set_var("FLOE_TEST_REST_CLIENT_SECRET", "client-secret");
-
-        let expanded = expand_env_refs(
-            "client_credentials:${FLOE_TEST_REST_CLIENT_ID}:${FLOE_TEST_REST_CLIENT_SECRET}",
-            "polaris",
-        )
-        .expect("expand credential");
-
-        assert_eq!(expanded, "client_credentials:client-id:client-secret");
-        std::env::remove_var("FLOE_TEST_REST_CLIENT_ID");
-        std::env::remove_var("FLOE_TEST_REST_CLIENT_SECRET");
-    }
-
-    #[test]
-    fn expands_exact_env_ref_in_token_credential() {
-        std::env::set_var("FLOE_TEST_REST_TOKEN", "pat-token");
-
-        let expanded =
-            expand_env_refs("token:${FLOE_TEST_REST_TOKEN}", "nessie").expect("expand token");
-
-        assert_eq!(expanded, "token:pat-token");
-        std::env::remove_var("FLOE_TEST_REST_TOKEN");
-    }
-
-    #[test]
-    fn errors_when_env_ref_is_missing() {
-        std::env::remove_var("FLOE_TEST_REST_MISSING");
-
-        let err = expand_env_refs(
-            "client_credentials:${FLOE_TEST_REST_MISSING}:secret",
-            "polaris",
-        )
-        .unwrap_err();
-
-        assert_eq!(
-            err.to_string(),
-            "rest iceberg catalog polaris credential references env var FLOE_TEST_REST_MISSING which is not set"
-        );
-    }
-
-    #[test]
-    fn errors_on_malformed_env_ref() {
-        let err = expand_env_refs("client_credentials:${UNCLOSED", "polaris").unwrap_err();
-
-        assert_eq!(
-            err.to_string(),
-            "rest iceberg catalog polaris credential has unclosed env placeholder: \"client_credentials:${UNCLOSED\""
-        );
-    }
-}
-
 pub(crate) async fn write_via_rest_catalog(
     rest_cfg: &RestIcebergCatalogConfig,
     table_root_uri: String,
@@ -433,4 +375,62 @@ async fn create_rest_table(
         .create_table(namespace, creation)
         .await
         .map_err(map_iceberg_err("rest catalog create_table failed"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::expand_env_refs;
+
+    #[test]
+    fn expands_partial_env_refs_in_client_credentials() {
+        std::env::set_var("FLOE_TEST_REST_CLIENT_ID", "client-id");
+        std::env::set_var("FLOE_TEST_REST_CLIENT_SECRET", "client-secret");
+
+        let expanded = expand_env_refs(
+            "client_credentials:${FLOE_TEST_REST_CLIENT_ID}:${FLOE_TEST_REST_CLIENT_SECRET}",
+            "polaris",
+        )
+        .expect("expand credential");
+
+        assert_eq!(expanded, "client_credentials:client-id:client-secret");
+        std::env::remove_var("FLOE_TEST_REST_CLIENT_ID");
+        std::env::remove_var("FLOE_TEST_REST_CLIENT_SECRET");
+    }
+
+    #[test]
+    fn expands_exact_env_ref_in_token_credential() {
+        std::env::set_var("FLOE_TEST_REST_TOKEN", "pat-token");
+
+        let expanded =
+            expand_env_refs("token:${FLOE_TEST_REST_TOKEN}", "nessie").expect("expand token");
+
+        assert_eq!(expanded, "token:pat-token");
+        std::env::remove_var("FLOE_TEST_REST_TOKEN");
+    }
+
+    #[test]
+    fn errors_when_env_ref_is_missing() {
+        std::env::remove_var("FLOE_TEST_REST_MISSING");
+
+        let err = expand_env_refs(
+            "client_credentials:${FLOE_TEST_REST_MISSING}:secret",
+            "polaris",
+        )
+        .unwrap_err();
+
+        assert_eq!(
+            err.to_string(),
+            "rest iceberg catalog polaris credential references env var FLOE_TEST_REST_MISSING which is not set"
+        );
+    }
+
+    #[test]
+    fn errors_on_malformed_env_ref() {
+        let err = expand_env_refs("client_credentials:${UNCLOSED", "polaris").unwrap_err();
+
+        assert_eq!(
+            err.to_string(),
+            "rest iceberg catalog polaris credential has unclosed env placeholder: \"client_credentials:${UNCLOSED\""
+        );
+    }
 }

--- a/crates/floe-core/src/io/write/iceberg/rest.rs
+++ b/crates/floe-core/src/io/write/iceberg/rest.rs
@@ -45,6 +45,7 @@ pub(crate) async fn build_rest_catalog(
     }
 
     if let Some(credential) = rest_cfg.credential.as_deref() {
+        let credential = expand_env_refs(credential, &rest_cfg.catalog_name)?;
         if let Some(token_value) = credential.strip_prefix("token:") {
             // Bearer PAT (Unity Catalog / Nessie)
             props.insert("token".to_string(), token_value.to_string());
@@ -137,6 +138,97 @@ impl RestIcebergCatalogConfig {
                 "RestIcebergCatalogConfig::from_type_config called on non-REST catalog".to_string(),
             ))),
         }
+    }
+}
+
+fn expand_env_refs(value: &str, catalog_name: &str) -> FloeResult<String> {
+    if !value.contains("${") {
+        return Ok(value.to_string());
+    }
+
+    let mut expanded = String::with_capacity(value.len());
+    let mut rest = value;
+    while let Some(start) = rest.find("${") {
+        expanded.push_str(&rest[..start]);
+        let after_start = &rest[start + 2..];
+        let Some(end) = after_start.find('}') else {
+            return Err(Box::new(RunError(format!(
+                "rest iceberg catalog {catalog_name} credential has unclosed env placeholder: {value:?}"
+            ))));
+        };
+        let name = &after_start[..end];
+        if name.is_empty() || name.contains('{') || name.contains('}') {
+            return Err(Box::new(RunError(format!(
+                "rest iceberg catalog {catalog_name} credential has invalid env placeholder: {value:?}"
+            ))));
+        }
+        let env_value = std::env::var(name).map_err(|_| {
+            Box::new(RunError(format!(
+                "rest iceberg catalog {catalog_name} credential references env var {name} which is not set"
+            ))) as Box<dyn std::error::Error + Send + Sync>
+        })?;
+        expanded.push_str(&env_value);
+        rest = &after_start[end + 1..];
+    }
+    expanded.push_str(rest);
+    Ok(expanded)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::expand_env_refs;
+
+    #[test]
+    fn expands_partial_env_refs_in_client_credentials() {
+        std::env::set_var("FLOE_TEST_REST_CLIENT_ID", "client-id");
+        std::env::set_var("FLOE_TEST_REST_CLIENT_SECRET", "client-secret");
+
+        let expanded = expand_env_refs(
+            "client_credentials:${FLOE_TEST_REST_CLIENT_ID}:${FLOE_TEST_REST_CLIENT_SECRET}",
+            "polaris",
+        )
+        .expect("expand credential");
+
+        assert_eq!(expanded, "client_credentials:client-id:client-secret");
+        std::env::remove_var("FLOE_TEST_REST_CLIENT_ID");
+        std::env::remove_var("FLOE_TEST_REST_CLIENT_SECRET");
+    }
+
+    #[test]
+    fn expands_exact_env_ref_in_token_credential() {
+        std::env::set_var("FLOE_TEST_REST_TOKEN", "pat-token");
+
+        let expanded =
+            expand_env_refs("token:${FLOE_TEST_REST_TOKEN}", "nessie").expect("expand token");
+
+        assert_eq!(expanded, "token:pat-token");
+        std::env::remove_var("FLOE_TEST_REST_TOKEN");
+    }
+
+    #[test]
+    fn errors_when_env_ref_is_missing() {
+        std::env::remove_var("FLOE_TEST_REST_MISSING");
+
+        let err = expand_env_refs(
+            "client_credentials:${FLOE_TEST_REST_MISSING}:secret",
+            "polaris",
+        )
+        .unwrap_err();
+
+        assert_eq!(
+            err.to_string(),
+            "rest iceberg catalog polaris credential references env var FLOE_TEST_REST_MISSING which is not set"
+        );
+    }
+
+    #[test]
+    fn errors_on_malformed_env_ref() {
+        let err = expand_env_refs("client_credentials:${UNCLOSED", "polaris").unwrap_err();
+
+        assert_eq!(
+            err.to_string(),
+            "rest iceberg catalog polaris credential has unclosed env placeholder: \"client_credentials:${UNCLOSED\""
+        );
     }
 }
 

--- a/crates/floe-core/src/io/write/iceberg/rest.rs
+++ b/crates/floe-core/src/io/write/iceberg/rest.rs
@@ -153,13 +153,13 @@ fn expand_env_refs(value: &str, catalog_name: &str) -> FloeResult<String> {
         let after_start = &rest[start + 2..];
         let Some(end) = after_start.find('}') else {
             return Err(Box::new(RunError(format!(
-                "rest iceberg catalog {catalog_name} credential has unclosed env placeholder: {value:?}"
+                "rest iceberg catalog {catalog_name} credential has unclosed env placeholder"
             ))));
         };
         let name = &after_start[..end];
         if name.is_empty() || name.contains('{') || name.contains('}') {
             return Err(Box::new(RunError(format!(
-                "rest iceberg catalog {catalog_name} credential has invalid env placeholder: {value:?}"
+                "rest iceberg catalog {catalog_name} credential has invalid env placeholder"
             ))));
         }
         let env_value = std::env::var(name).map_err(|_| {
@@ -426,11 +426,19 @@ mod tests {
 
     #[test]
     fn errors_on_malformed_env_ref() {
-        let err = expand_env_refs("client_credentials:${UNCLOSED", "polaris").unwrap_err();
+        std::env::set_var("ID", "client-id");
+
+        let err = expand_env_refs(
+            "client_credentials:${ID}:literal-secret:${UNCLOSED",
+            "polaris",
+        )
+        .unwrap_err();
 
         assert_eq!(
             err.to_string(),
-            "rest iceberg catalog polaris credential has unclosed env placeholder: \"client_credentials:${UNCLOSED\""
+            "rest iceberg catalog polaris credential has unclosed env placeholder"
         );
+        assert!(!err.to_string().contains("literal-secret"));
+        std::env::remove_var("ID");
     }
 }

--- a/docs/config.md
+++ b/docs/config.md
@@ -100,7 +100,7 @@ entities:
         - `warehouse_prefix` (optional): prefix for deterministic table locations
       - **`rest`** — Iceberg REST catalog (Unity Catalog Iceberg endpoint, Polaris, Nessie, Snowflake Open Catalog, etc.):
         - `uri` (required): REST catalog base URI
-        - `credential` (optional): `token:<pat>` or `client_credentials:<id>:<secret>`
+        - `credential` (optional): `token:<pat>` or `client_credentials:<id>:<secret>`; `${ENV_VAR}` placeholders are resolved from the OS environment at run time, so manifest runs can keep REST catalog secrets out of the manifest artifact
         - `warehouse` (optional): warehouse/prefix hint forwarded to the REST catalog
         - `oauth2_server_uri` (optional): override OAuth2 server URL for client-credentials flow
         - `scope` (optional): OAuth2 scope

--- a/docs/manifest.md
+++ b/docs/manifest.md
@@ -22,11 +22,17 @@ Pipe to stdout for use in CI scripts:
 floe manifest generate -c orders.yml -o - | jq '.entities[].name'
 ```
 
-If your config uses profile variables (cloud paths, credentials), pass the profile at generation time to bake them in:
+If your config uses profile variables for non-secret deployment values such as cloud paths, pass the profile at generation time to bake them in:
 
 ```bash
 floe manifest generate -c orders.yml -p prod.yml --output manifests/orders.json
 ```
+
+For REST Iceberg catalog secrets, prefer env-backed credentials such as
+`client_credentials:${POLARIS_CLIENT_ID}:${POLARIS_CLIENT_SECRET}`. Manifest
+runs resolve those `${...}` references from the runner process environment at
+catalog initialization, so Kubernetes or another orchestrator can inject secrets
+without storing raw credentials in the manifest.
 
 Only need a subset of entities? Use `--entities`:
 

--- a/docs/sinks/iceberg.md
+++ b/docs/sinks/iceberg.md
@@ -2,8 +2,8 @@
 
 Floe writes Iceberg tables for `sink.accepted.format: iceberg` using filesystem
 catalog layout semantics (table root with `metadata/` and `data/`) on local
-storage, S3, and GCS. Floe also supports AWS Glue catalog registration for
-S3-backed Iceberg tables.
+storage, S3, and GCS. Floe also supports AWS Glue and Iceberg REST catalog
+registration.
 
 ## Storage catalog model
 
@@ -79,6 +79,28 @@ entities:
         - name: "customer_id"
           type: "string"
 ```
+
+## REST catalog credentials
+
+REST catalog definitions accept bearer tokens and OAuth2 client credentials:
+
+```yaml
+catalogs:
+  default: "polaris"
+  definitions:
+    - name: "polaris"
+      type: "rest"
+      uri: "http://polaris:8181/api/catalog"
+      credential: "client_credentials:${POLARIS_CLIENT_ID}:${POLARIS_CLIENT_SECRET}"
+      warehouse: "lakehouse"
+      oauth2_server_uri: "http://polaris:8181/api/catalog/v1/oauth/tokens"
+      scope: "PRINCIPAL_ROLE:ALL"
+```
+
+`${ENV_VAR}` placeholders in `credential` are resolved from the OS environment at
+run time, including during `floe run --manifest`. This lets runner environments
+inject REST catalog secrets without baking raw client IDs or secrets into the
+manifest.
 
 ## Partition spec config
 


### PR DESCRIPTION
## Summary
- Resolve `${ENV_VAR}` placeholders in REST Iceberg catalog credentials at catalog initialization.
- Support mixed client credentials such as `client_credentials:${POLARIS_CLIENT_ID}:${POLARIS_CLIENT_SECRET}` for manifest-mode runs.
- Document the runtime env-backed credential contract for config, manifests, and Iceberg sinks.

## Root cause
Manifest reconstruction preserved REST catalog credentials as literal strings, and `build_rest_catalog` stripped `client_credentials:` before forwarding the unchanged placeholder text to the Iceberg REST client. OAuth providers then received `${...}` instead of runtime-injected secrets.

## Validation
- `cargo test -p floe-core io::write::iceberg::rest::tests::expands_partial_env_refs_in_client_credentials -- --nocapture`
- `git diff --check -- crates/floe-core/src/io/write/iceberg/rest.rs docs/config.md docs/manifest.md docs/sinks/iceberg.md`

Fixes #368