### PR TITLE
chore: bump floe to v0.4.6 and dagster-floe to v0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ All notable changes to Floe are documented in this file.
   - Previously all accepted rows for an entity were accumulated in memory across every input file and written in a single pass at the end. Peak RAM scaled with input fanout.
   - Accepted rows are now flushed to the sink incrementally whenever the in-memory accumulation reaches `sink.accepted.options.max_size_per_file` (default 256 MB). Peak memory is bounded regardless of how many input files the entity processes.
   - `merge_scd1` / `merge_scd2` modes are unaffected — they still accumulate the full dataset before writing.
-  - See [Parquet sink limitations](docs/sinks/parquet.md#limitations) for durability caveats specific to Parquet output.
+  - **Durability note**: flushes commit while the batch is still running — if a later input file fails, rows from earlier files are already committed and will be re-written on the next run. In `append` mode this produces duplicate output rows; use `schema.unique_keys`, `merge_scd1`, or `merge_scd2` to guard against this. See [Parquet sink limitations](docs/sinks/parquet.md#limitations) for details (the same partial-commit exposure applies to Delta and Iceberg accepted sinks, though their individual flushes are transactional).
 
 - **Stream Parquet writes via the Polars `new_streaming` engine** (PR #369):
   - Accepted Parquet writes now emit one row group at a time rather than buffering the full chunk plus Arrow encoding state. This reduces per-write peak memory, most noticeably on wide schemas or large `row_group_size` values.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to Floe are documented in this file.
 
 ## Unreleased
 
+## v0.4.6
+
 - **Stream Parquet writes through the Polars `new_streaming` engine** (completes #332):
   - The accepted Parquet writer in `io/write/parquet.rs::write_parquet_to_path` now calls `LazyFrame::sink_parquet(...).with_new_streaming(true).collect()` instead of the eager `ParquetWriter::new(file).finish(&mut df)`. The outer per-chunk loop in `ParquetSinkFormat::write` (which slices the input DataFrame to keep each call ≤ `sink.accepted.options.max_size_per_file`) is unchanged, so the existing `part-NNNNN.parquet` / `part-<uuid>.parquet` naming, the `PartNameAllocator`, `small_files_count`, and the run-report shape are all preserved.
   - Within each chunk's write, the streaming engine emits one row group at a time and drops it before the next, replacing the previous "buffer the chunk plus full Arrow encoding state" footprint with "one row group + encoding buffer". Marginal versus the per-entity cap delivered earlier in this release, but real, especially on wide schemas or large `row_group_size` values.
@@ -17,6 +19,17 @@ All notable changes to Floe are documented in this file.
   - Catalog registration, schema evolution, and table-root reporting come from the first flush; Delta `table_version` and Iceberg `snapshot_id` track the latest commit; counters (`parts_written`, `total_bytes_written`, `small_files_count`) sum across flushes via a new `AcceptedWriteOutput::merge_in` reducer.
   - Merge modes (`merge_scd1`, `merge_scd2`) keep the previous accumulate-then-write path unchanged — they require the full per-entity dataset to compute upsert/close decisions.
   - **Behavioural note (applies to all non-merge sinks)**: because flushes commit synchronously while the file loop is still iterating, a failure on a *later* file in the same batch (read / validation / rejected-write / archive) can leave *earlier* files' accepted rows already committed — and in `overwrite` mode the first flush may already have replaced the previous dataset. The run report and incremental state are not committed in that case, so the same inputs are re-processed on the next run. For Parquet that committed prefix is non-transactional part files in the accepted directory. For Delta and Iceberg each individual flush is transactional, but a later-file failure does not roll back an earlier flush's commit, so readers can still observe a committed prefix between the failure and the next run; cross-run protection comes from `unique_keys` or merge modes, not from the sink's per-commit atomicity. Each file's archive call always runs before its rows enter the buffer. Documented under `sink.accepted.options.max_size_per_file` in `docs/config.md`.
+
+- **Profile `execution.orchestration` → manifest → Dagster job concurrency** (PR #367):
+  - New `orchestration` block in the profile's `execution` section (`strategy`, `max_concurrent_entities`). The manifest builder emits it as `execution.orchestration`; `dagster-floe` wires `max_concurrent` into the Dagster `multiprocess` executor config, driving entity-level parallelism end-to-end without per-job boilerplate.
+  - `max_concurrent_entities: 0` is rejected at parse time with an immediate config error.
+  - JSON Schema for the profile updated to declare the new block (`additionalProperties: false` was previously rejecting it).
+
+- **REST Iceberg: resolve environment-variable credentials** (PR #370):
+  - REST catalog configs that use `${ENV_VAR}` placeholders for credentials are now resolved against the process environment before the HTTP client is constructed, fixing authentication failures when credentials are injected via environment variables rather than baked into the config file.
+  - Malformed credential placeholder errors are redacted in log output to avoid leaking partial secrets.
+
+- **`floe` 0.4.6, `dagster-floe` 0.2.1**: version bumps for this release.
 
 ## v0.4.5
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,32 +2,35 @@
 
 All notable changes to Floe are documented in this file.
 
-## Unreleased
-
 ## v0.4.6
 
-- **Stream Parquet writes through the Polars `new_streaming` engine** (completes #332):
-  - The accepted Parquet writer in `io/write/parquet.rs::write_parquet_to_path` now calls `LazyFrame::sink_parquet(...).with_new_streaming(true).collect()` instead of the eager `ParquetWriter::new(file).finish(&mut df)`. The outer per-chunk loop in `ParquetSinkFormat::write` (which slices the input DataFrame to keep each call ≤ `sink.accepted.options.max_size_per_file`) is unchanged, so the existing `part-NNNNN.parquet` / `part-<uuid>.parquet` naming, the `PartNameAllocator`, `small_files_count`, and the run-report shape are all preserved.
-  - Within each chunk's write, the streaming engine emits one row group at a time and drops it before the next, replacing the previous "buffer the chunk plus full Arrow encoding state" footprint with "one row group + encoding buffer". Marginal versus the per-entity cap delivered earlier in this release, but real, especially on wide schemas or large `row_group_size` values.
-  - Polars' `new_streaming` cargo feature is enabled on `floe-core`'s existing `polars = "0.52.0"` dependency. No version bump, no `df-interchange` churn, no Cargo.lock noise. Reader paths (`io/read/parquet.rs::ParquetInputAdapter::read_inputs`, `io/write/parquet.rs::seed_from_parquet_path`) already use `LazyFrame::scan_parquet` plans and pick up the new engine implicitly through Polars' default-collect dispatch — no code change there.
-  - New integration test `streaming_parquet_writes_preserve_row_counts_and_size_bound` in `tests/integration/local_run.rs` forces ≥ 2 chunked writes through `sink_parquet` (5000 rows × `max_size_per_file: 4096`) and verifies the round-trip row count plus the per-part size bound.
+- **`dagster-floe`: load remote report URIs via fsspec** (fixes #361, PR #362):
+  - `summary_uri` and `entity_report_uri` values pointing at `s3://`, `gs://`, or `abfs://` were raising a `ValueError` that was silently swallowed, causing asset checks to fall back to summary-only mode. They are now fetched correctly via `fsspec`.
+  - New `remote` optional extra (`dagster-floe[remote]`) installs `s3fs`, `gcsfs`, and `adlfs` so all three cloud providers are covered out of the box.
 
-- **Soft-buffered accepted writes — cap per-entity memory at `max_size_per_file`** (addresses #332):
-  - Floe previously held every accepted `DataFrame` from every input file in `accepted_accum: Vec<DataFrame>` until the entire entity was processed, then concatenated and wrote once. Peak RAM scaled as `O(n_files × rows_per_file)`, capping practical batch size.
-  - A new `AcceptedBuffer` flushes to the configured sink whenever the running estimated in-memory size meets `sink.accepted.options.max_size_per_file` (default 256 MB) and once at the end of the entity. Peak accepted-side memory is bounded by one configured output-file budget regardless of input fanout.
-  - The first flush uses the entity's configured `write_mode` (`overwrite` or `append`); subsequent flushes within the same run are forced to `append`, mirroring the existing `rejected_overwrite_used` pattern. This preserves the existing first-flush-clears-then-appends behaviour for `overwrite` mode.
-  - Catalog registration, schema evolution, and table-root reporting come from the first flush; Delta `table_version` and Iceberg `snapshot_id` track the latest commit; counters (`parts_written`, `total_bytes_written`, `small_files_count`) sum across flushes via a new `AcceptedWriteOutput::merge_in` reducer.
-  - Merge modes (`merge_scd1`, `merge_scd2`) keep the previous accumulate-then-write path unchanged — they require the full per-entity dataset to compute upsert/close decisions.
-  - **Behavioural note (applies to all non-merge sinks)**: because flushes commit synchronously while the file loop is still iterating, a failure on a *later* file in the same batch (read / validation / rejected-write / archive) can leave *earlier* files' accepted rows already committed — and in `overwrite` mode the first flush may already have replaced the previous dataset. The run report and incremental state are not committed in that case, so the same inputs are re-processed on the next run. For Parquet that committed prefix is non-transactional part files in the accepted directory. For Delta and Iceberg each individual flush is transactional, but a later-file failure does not roll back an earlier flush's commit, so readers can still observe a committed prefix between the failure and the next run; cross-run protection comes from `unique_keys` or merge modes, not from the sink's per-commit atomicity. Each file's archive call always runs before its rows enter the buffer. Documented under `sink.accepted.options.max_size_per_file` in `docs/config.md`.
+- **`dagster-floe`: tolerate mixed stdout and surface floe events in Dagster logs** (PR #363):
+  - The log parser now handles non-JSON lines interleaved with NDJSON floe events, so plain-text output from wrappers or logging middleware no longer breaks event parsing.
+  - Floe run events (`run_started`, `entity_finished`, `run_finished`) are surfaced as structured Dagster log entries with appropriate log levels.
+
+- **Soft-buffered accepted writes — cap per-entity memory at `max_size_per_file`** (PR #366):
+  - Previously all accepted rows for an entity were accumulated in memory across every input file and written in a single pass at the end. Peak RAM scaled with input fanout.
+  - Accepted rows are now flushed to the sink incrementally whenever the in-memory accumulation reaches `sink.accepted.options.max_size_per_file` (default 256 MB). Peak memory is bounded regardless of how many input files the entity processes.
+  - `merge_scd1` / `merge_scd2` modes are unaffected — they still accumulate the full dataset before writing.
+  - **⚠️ Parquet durability**: Parquet is not transactional. If a failure occurs during or after a flush, partially-written part files are left on disk. There is no rollback mechanism — incomplete files must be cleaned up manually. Delta and Iceberg flushes are individually atomic, but a failure on a later input file does not roll back commits from earlier flushes in the same run. Re-runs are safe because the run report and incremental state are only committed once the full entity succeeds.
+
+- **Stream Parquet writes via the Polars `new_streaming` engine** (PR #369):
+  - Accepted Parquet writes now emit one row group at a time rather than buffering the full chunk plus Arrow encoding state. This reduces per-write peak memory, most noticeably on wide schemas or large `row_group_size` values.
+  - No config changes required. Output file naming, part counts, and the run report shape are unchanged.
+  - **⚠️ Parquet durability**: consistent with the point above — Parquet files are not written atomically. A failure mid-stream leaves an incomplete file on disk with no rollback.
 
 - **Profile `execution.orchestration` → manifest → Dagster job concurrency** (PR #367):
   - New `orchestration` block in the profile's `execution` section (`strategy`, `max_concurrent_entities`). The manifest builder emits it as `execution.orchestration`; `dagster-floe` wires `max_concurrent` into the Dagster `multiprocess` executor config, driving entity-level parallelism end-to-end without per-job boilerplate.
   - `max_concurrent_entities: 0` is rejected at parse time with an immediate config error.
-  - JSON Schema for the profile updated to declare the new block (`additionalProperties: false` was previously rejecting it).
+  - Profile JSON Schema updated to declare the new block (previously rejected by `additionalProperties: false`).
 
 - **REST Iceberg: resolve environment-variable credentials** (PR #370):
-  - REST catalog configs that use `${ENV_VAR}` placeholders for credentials are now resolved against the process environment before the HTTP client is constructed, fixing authentication failures when credentials are injected via environment variables rather than baked into the config file.
-  - Malformed credential placeholder errors are redacted in log output to avoid leaking partial secrets.
+  - REST catalog configs that use `${ENV_VAR}` placeholders for credentials are now resolved against the process environment before the HTTP client is constructed, fixing authentication failures when credentials are injected at runtime rather than baked into the config file.
+  - Malformed placeholder errors are redacted in log output to avoid leaking partial secrets.
 
 - **`floe` 0.4.6, `dagster-floe` 0.2.1**: version bumps for this release.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,12 +16,11 @@ All notable changes to Floe are documented in this file.
   - Previously all accepted rows for an entity were accumulated in memory across every input file and written in a single pass at the end. Peak RAM scaled with input fanout.
   - Accepted rows are now flushed to the sink incrementally whenever the in-memory accumulation reaches `sink.accepted.options.max_size_per_file` (default 256 MB). Peak memory is bounded regardless of how many input files the entity processes.
   - `merge_scd1` / `merge_scd2` modes are unaffected — they still accumulate the full dataset before writing.
-  - **⚠️ Parquet durability**: Parquet is not transactional. If a failure occurs during or after a flush, partially-written part files are left on disk. There is no rollback mechanism — incomplete files must be cleaned up manually. Delta and Iceberg flushes are individually atomic, but a failure on a later input file does not roll back commits from earlier flushes in the same run. Re-runs are safe because the run report and incremental state are only committed once the full entity succeeds.
+  - See [Parquet sink limitations](docs/sinks/parquet.md#limitations) for durability caveats specific to Parquet output.
 
 - **Stream Parquet writes via the Polars `new_streaming` engine** (PR #369):
   - Accepted Parquet writes now emit one row group at a time rather than buffering the full chunk plus Arrow encoding state. This reduces per-write peak memory, most noticeably on wide schemas or large `row_group_size` values.
   - No config changes required. Output file naming, part counts, and the run report shape are unchanged.
-  - **⚠️ Parquet durability**: consistent with the point above — Parquet files are not written atomically. A failure mid-stream leaves an incomplete file on disk with no rollback.
 
 - **Profile `execution.orchestration` → manifest → Dagster job concurrency** (PR #367):
   - New `orchestration` block in the profile's `execution` section (`strategy`, `max_concurrent_entities`). The manifest builder emits it as `execution.orchestration`; `dagster-floe` wires `max_concurrent` into the Dagster `multiprocess` executor config, driving entity-level parallelism end-to-end without per-job boilerplate.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3399,7 +3399,7 @@ dependencies = [
 
 [[package]]
 name = "floe-cli"
-version = "0.4.5"
+version = "0.4.6"
 dependencies = [
  "assert_cmd",
  "clap",
@@ -3412,7 +3412,7 @@ dependencies = [
 
 [[package]]
 name = "floe-core"
-version = "0.4.5"
+version = "0.4.6"
 dependencies = [
  "apache-avro 0.16.0",
  "arrow",
@@ -3455,7 +3455,7 @@ dependencies = [
 
 [[package]]
 name = "floe-python"
-version = "0.4.5"
+version = "0.4.6"
 dependencies = [
  "floe-core",
  "pyo3",

--- a/crates/floe-cli/Cargo.toml
+++ b/crates/floe-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "floe-cli"
-version = "0.4.5"
+version = "0.4.6"
 edition = "2021"
 description = "CLI for Floe, a YAML-driven technical ingestion tool."
 license = "MIT"
@@ -17,7 +17,7 @@ path = "src/main.rs"
 
 [dependencies]
 clap = { version = "4", features = ["derive"] }
-floe-core = { path = "../floe-core", version = "0.4.5" }
+floe-core = { path = "../floe-core", version = "0.4.6" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 

--- a/crates/floe-core/Cargo.toml
+++ b/crates/floe-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "floe-core"
-version = "0.4.5"
+version = "0.4.6"
 edition = "2021"
 description = "Core library for Floe, a YAML-driven technical ingestion tool."
 license = "MIT"

--- a/crates/floe-python/Cargo.toml
+++ b/crates/floe-python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "floe-python"
-version = "0.4.5"
+version = "0.4.6"
 edition = "2021"
 description = "Python bindings for floe-core (PyO3-based)"
 license = "Apache-2.0"
@@ -13,7 +13,7 @@ name = "_floe"
 crate-type = ["cdylib"]
 
 [dependencies]
-floe-core = { path = "../floe-core", version = "0.4.5" }
+floe-core = { path = "../floe-core", version = "0.4.6" }
 pyo3 = { version = "0.22", features = ["extension-module", "abi3-py310"] }
 serde_json = "1"
 

--- a/crates/floe-python/pyproject.toml
+++ b/crates/floe-python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "floe-python"
-version = "0.4.5"
+version = "0.4.6"
 description = "Python bindings for floe-core — run floe pipelines at Rust speed from Python and notebooks"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/docs/sinks/parquet.md
+++ b/docs/sinks/parquet.md
@@ -1,0 +1,84 @@
+# Parquet Sink (Accepted Output)
+
+Floe can write accepted output as Parquet files on local, S3, ADLS, or GCS storage.
+
+Example:
+```yaml
+entities:
+  - name: customers
+    source:
+      format: csv
+      path: /data/in/customers.csv
+    sink:
+      accepted:
+        format: parquet
+        path: /data/out/customers
+```
+
+Semantics:
+- `sink.accepted.format: parquet` writes one or more part files under `sink.accepted.path`.
+- Write mode comes from `sink.write_mode`:
+  - `overwrite`: clear the output directory, then write. The first flush of a run removes existing files; subsequent flushes append.
+  - `append`: add new part files alongside existing ones.
+  - `merge_scd1` / `merge_scd2`: not supported for Parquet — use Delta or Iceberg for merge modes.
+
+## File splitting
+
+Large accepted datasets are split into multiple part files. The split threshold is controlled by
+`sink.accepted.options.max_size_per_file` (default 256 MB). Floe flushes rows to disk
+incrementally as memory reaches this threshold, so peak accepted-side RAM is bounded regardless
+of how many input files the entity processes.
+
+```yaml
+sink:
+  accepted:
+    format: parquet
+    path: /data/out/orders
+    options:
+      compression: zstd
+      row_group_size: 50000
+      max_size_per_file: 268435456   # 256 MB
+```
+
+Available options:
+- `compression`: `snappy` (default), `gzip`, `zstd`, `uncompressed`
+- `row_group_size`: rows per row group (positive integer)
+- `max_size_per_file`: flush threshold in bytes (default: 268435456 / 256 MB)
+
+## Limitations
+
+### Parquet is not transactional
+
+Parquet has no built-in transaction or atomic-commit semantics. Floe does not implement a
+write-ahead log or two-phase commit for Parquet output. This has two practical consequences:
+
+**Incomplete files on write failure**
+
+If a failure occurs during a Parquet write (process crash, out-of-disk, network error on remote
+storage), the in-progress part file is left on disk in an incomplete or corrupt state. There is no
+rollback — incomplete files must be cleaned up manually before the next run or they will coexist
+with valid output files in the accepted directory.
+
+**Partial commits with soft-buffered writes**
+
+Because Floe flushes accepted rows incrementally (see [File splitting](#file-splitting) above),
+earlier flushes are already committed to the accepted path before the entity finishes processing.
+If a failure occurs on a *later* input file in the same run:
+
+- Rows from *earlier* input files that were already flushed remain on disk — there is no mechanism
+  to roll them back.
+- The run report and incremental state are **not** committed, so Floe will re-process the same
+  inputs on the next run. This means the already-committed rows will be written again.
+- In `overwrite` mode the first flush already cleared the previous dataset, so the directory will
+  contain only the partial output from the failed run until it is re-processed.
+
+For `append` mode, re-processing will produce duplicate part files in the accepted directory.
+Use `unique_keys` deduplication or a downstream dedup step if idempotency is required.
+
+Merge modes (`merge_scd1`, `merge_scd2`) are not affected because they accumulate the full
+dataset before writing and never perform intermediate flushes.
+
+**If you need transactional accepted writes, use the [Delta](delta.md) or [Iceberg](iceberg.md)
+sink instead.** Each Delta/Iceberg flush is an individually atomic commit; earlier commits are
+still not rolled back on a later-file failure within the same run, but readers never observe
+a corrupt or partial file.

--- a/orchestrators/dagster-floe/pyproject.toml
+++ b/orchestrators/dagster-floe/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "dagster-floe"
-version = "0.2.0"
+version = "0.2.1"
 description = "Dagster connector for Floe CLI (config-driven ingestion)"
 requires-python = ">=3.10"
 readme = "README.md"


### PR DESCRIPTION
## Summary

- `floe-core` / `floe-cli` / `floe-python`: **0.4.5 → 0.4.6**
- `dagster-floe`: **0.2.0 → 0.2.1** (orchestration concurrency config landed after the v0.2.0 tag)
- `airflow-floe`: unchanged at **0.1.5** (no changes since last release)

## Changes in this release

| PR | What |
|---|---|
| #366 | `feat(run)`: soft-buffered accepted writes — cap per-entity memory at `max_size_per_file` |
| #367 | `feat(orchestration)`: profile `execution.orchestration` → manifest → Dagster job concurrency |
| #369 | `feat(write)`: stream Parquet writes via `LazyFrame::sink_parquet` (Polars `new_streaming`) |
| #370 | `fix`: resolve REST Iceberg environment-variable credentials |

## Test plan

- [ ] CI passes (no logic changes — version bump only)