### PR TITLE
fix(io): normalize raw headers before projection in parquet and orc readers

### DIFF
--- a/crates/floe-core/src/io/read/orc.rs
+++ b/crates/floe-core/src/io/read/orc.rs
@@ -8,6 +8,7 @@ use orc_rust::arrow_reader::ArrowReaderBuilder;
 use orc_rust::projection::ProjectionMask;
 use polars::prelude::DataFrame;
 
+use crate::checks::normalize::normalize_name;
 use crate::errors::IoError;
 use crate::io::format::{self, FileReadError, InputAdapter, LocalInputFile, ReadInput};
 use crate::{config, FloeResult};
@@ -128,7 +129,7 @@ impl InputAdapter for OrcInputAdapter {
         for input_file in files {
             let path = &input_file.local_path;
             let input_columns = read_orc_schema_names(path)?;
-            let projection = projected_columns(&input_columns, columns);
+            let projection = projected_columns(&input_columns, columns, normalize_strategy);
             let df = read_orc_df(path, projection.as_deref())?;
             let typed_schema = format::build_typed_schema(
                 projection.as_deref().unwrap_or(input_columns.as_slice()),
@@ -152,6 +153,7 @@ impl InputAdapter for OrcInputAdapter {
 fn projected_columns(
     input_columns: &[String],
     declared_columns: &[config::ColumnConfig],
+    normalize_strategy: Option<&str>,
 ) -> Option<Vec<String>> {
     let declared = declared_columns
         .iter()
@@ -159,7 +161,13 @@ fn projected_columns(
         .collect::<std::collections::HashSet<_>>();
     let projected = input_columns
         .iter()
-        .filter(|name| declared.contains(name.as_str()))
+        .filter(|name| {
+            let normalized = match normalize_strategy {
+                Some(strategy) => normalize_name(name, strategy),
+                None => name.to_string(),
+            };
+            declared.contains(normalized.as_str())
+        })
         .cloned()
         .collect::<Vec<_>>();
     if projected.is_empty() || projected.len() == input_columns.len() {

--- a/crates/floe-core/src/io/read/parquet.rs
+++ b/crates/floe-core/src/io/read/parquet.rs
@@ -2,6 +2,7 @@ use std::path::Path;
 
 use polars::prelude::{col, DataFrame, LazyFrame, ParquetReader, PlPath, SerReader};
 
+use crate::checks::normalize::normalize_name;
 use crate::errors::IoError;
 use crate::io::format::{self, FileReadError, InputAdapter, LocalInputFile, ReadInput};
 use crate::{config, FloeResult};
@@ -82,7 +83,7 @@ impl InputAdapter for ParquetInputAdapter {
         for input_file in files {
             let path = &input_file.local_path;
             let input_columns = read_parquet_schema_names(path)?;
-            let projection = projected_columns(&input_columns, columns);
+            let projection = projected_columns(&input_columns, columns, normalize_strategy);
             let df = read_parquet_lazy(path, projection.as_deref())?;
             let typed_schema = format::build_typed_schema(
                 projection.as_deref().unwrap_or(input_columns.as_slice()),
@@ -106,6 +107,7 @@ impl InputAdapter for ParquetInputAdapter {
 fn projected_columns(
     input_columns: &[String],
     declared_columns: &[config::ColumnConfig],
+    normalize_strategy: Option<&str>,
 ) -> Option<Vec<String>> {
     let declared = declared_columns
         .iter()
@@ -113,7 +115,13 @@ fn projected_columns(
         .collect::<std::collections::HashSet<_>>();
     let projected = input_columns
         .iter()
-        .filter(|name| declared.contains(name.as_str()))
+        .filter(|name| {
+            let normalized = match normalize_strategy {
+                Some(strategy) => normalize_name(name, strategy),
+                None => name.to_string(),
+            };
+            declared.contains(normalized.as_str())
+        })
         .cloned()
         .collect::<Vec<_>>();
     if projected.is_empty() || projected.len() == input_columns.len() {

--- a/crates/floe-core/tests/unit/io/read/orc_input.rs
+++ b/crates/floe-core/tests/unit/io/read/orc_input.rs
@@ -32,6 +32,16 @@ fn make_batch(ids: &[&str], names: &[&str]) -> RecordBatch {
     RecordBatch::try_new(schema, vec![ids, names]).expect("record batch")
 }
 
+fn make_customer_id_with_extra(customer_ids: &[&str], extras: &[&str]) -> RecordBatch {
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("Customer ID", DataType::Utf8, false),
+        Field::new("extra_col", DataType::Utf8, false),
+    ]));
+    let ids = Arc::new(StringArray::from(customer_ids.to_vec()));
+    let extras = Arc::new(StringArray::from(extras.to_vec()));
+    RecordBatch::try_new(schema, vec![ids, extras]).expect("record batch")
+}
+
 fn make_payments_batch(ids: &[&str], amounts: &[&str]) -> RecordBatch {
     let schema = Arc::new(Schema::new(vec![
         Field::new("id", DataType::Utf8, false),
@@ -175,4 +185,69 @@ entities:
     assert_eq!(file.status, FileStatus::Rejected);
     assert_eq!(file.accepted_count, 1);
     assert_eq!(file.rejected_count, 1);
+}
+
+#[test]
+fn orc_normalize_columns_survives_projection() {
+    // Regression: projected_columns used to compare raw headers ("Customer ID")
+    // against already-normalised declared names ("customer_id"), so the column
+    // was silently dropped before it could reach the schema/sink.
+    let root = temp_dir("floe-orc-normalize");
+    let input_dir = root.join("in");
+    let accepted_dir = root.join("out/accepted");
+    let report_dir = root.join("report");
+    fs::create_dir_all(&input_dir).expect("create input dir");
+
+    // Two columns: one declared (raw "Customer ID"), one undeclared – the extra
+    // column is what causes projection to fire in the first place.
+    let batch = make_customer_id_with_extra(&["alice", "bob"], &["x", "y"]);
+    write_orc(&input_dir, "input.orc", batch);
+
+    let yaml = format!(
+        r#"version: "0.1"
+report:
+  path: "{report_dir}"
+entities:
+  - name: "customer"
+    source:
+      format: "orc"
+      path: "{input_dir}"
+    sink:
+      accepted:
+        format: "parquet"
+        path: "{accepted_dir}"
+    policy:
+      severity: "warn"
+    schema:
+      normalize_columns:
+        enabled: true
+        strategy: snake_case
+      mismatch:
+        extra_columns: "ignore"
+      columns:
+        - name: "Customer ID"
+          type: "string"
+"#,
+        report_dir = report_dir.display(),
+        input_dir = input_dir.display(),
+        accepted_dir = accepted_dir.display(),
+    );
+    let config_path = write_config(&root, &yaml);
+
+    let outcome = run_config(&config_path);
+    let file = &outcome.entity_outcomes[0].report.files[0];
+    assert_eq!(file.status, FileStatus::Success);
+
+    let output_path = accepted_dir.join("part-00000.parquet");
+    let fh = std::fs::File::open(&output_path).expect("open accepted parquet");
+    let df = ParquetReader::new(fh)
+        .finish()
+        .expect("read accepted parquet");
+    assert_eq!(df.height(), 2);
+    // After snake_case normalisation "Customer ID" → "customer_id"
+    assert!(
+        df.column("customer_id").is_ok(),
+        "expected customer_id column in output, got: {:?}",
+        df.get_column_names()
+    );
 }

--- a/crates/floe-core/tests/unit/io/read/parquet_input.rs
+++ b/crates/floe-core/tests/unit/io/read/parquet_input.rs
@@ -270,3 +270,72 @@ entities:
     assert_eq!(file.accepted_count, 1);
     assert_eq!(file.rejected_count, 1);
 }
+
+#[test]
+fn parquet_normalize_columns_survives_projection() {
+    // Regression: projected_columns used to compare raw headers ("Customer ID")
+    // against already-normalised declared names ("customer_id"), so the column
+    // was silently dropped before it could reach the schema/sink.
+    let root = temp_dir("floe-parquet-normalize");
+    let input_dir = root.join("in");
+    let accepted_dir = root.join("out/accepted");
+    let report_dir = root.join("report");
+    fs::create_dir_all(&input_dir).expect("create input dir");
+
+    // Two columns: one declared (raw "Customer ID"), one undeclared – the extra
+    // column is what causes projection to fire in the first place.
+    let df = DataFrame::new(vec![
+        Series::new("Customer ID".into(), vec!["alice", "bob"]).into(),
+        Series::new("extra_col".into(), vec!["x", "y"]).into(),
+    ])
+    .expect("df");
+    write_parquet(&input_dir, "input.parquet", df);
+
+    let yaml = format!(
+        r#"version: "0.1"
+report:
+  path: "{report_dir}"
+entities:
+  - name: "customer"
+    source:
+      format: "parquet"
+      path: "{input_dir}"
+    sink:
+      accepted:
+        format: "parquet"
+        path: "{accepted_dir}"
+    policy:
+      severity: "warn"
+    schema:
+      normalize_columns:
+        enabled: true
+        strategy: snake_case
+      mismatch:
+        extra_columns: "ignore"
+      columns:
+        - name: "Customer ID"
+          type: "string"
+"#,
+        report_dir = report_dir.display(),
+        input_dir = input_dir.display(),
+        accepted_dir = accepted_dir.display(),
+    );
+    let config_path = write_config(&root, &yaml);
+
+    let outcome = run_config(&config_path);
+    let file = &outcome.entity_outcomes[0].report.files[0];
+    assert_eq!(file.status, FileStatus::Success);
+
+    let output_path = accepted_dir.join("part-00000.parquet");
+    let fh = std::fs::File::open(&output_path).expect("open accepted parquet");
+    let df = ParquetReader::new(fh)
+        .finish()
+        .expect("read accepted parquet");
+    assert_eq!(df.height(), 2);
+    // After snake_case normalisation "Customer ID" → "customer_id"
+    assert!(
+        df.column("customer_id").is_ok(),
+        "expected customer_id column in output, got: {:?}",
+        df.get_column_names()
+    );
+}


### PR DESCRIPTION
## What changed

`projected_columns` in both `parquet.rs` and `orc.rs` compared raw file
headers (e.g. `"Customer ID"`) directly against already-normalised declared
column names (e.g. `"customer_id"`). Any column renamed by
`schema.normalize_columns` therefore failed the membership test and was
silently projected out before reaching checks or the sink — data loss with no
error.

## Fix

Thread `normalize_strategy: Option<&str>` into `projected_columns` and call
`crate::checks::normalize::normalize_name(raw_header, strategy)` before the
set-membership check, keeping the raw name in the returned projection list (the
file still uses the raw name for I/O).

This matches the pattern already used in `avro.rs`.

## Regression tests added

| Test | Format | Scenario |
|------|--------|----------|
| `parquet_normalize_columns_survives_projection` | Parquet | File has `"Customer ID"` + undeclared `"extra_col"`; schema declares `"Customer ID"` with `snake_case`; asserts `customer_id` column present in accepted output |
| `orc_normalize_columns_survives_projection` | ORC | Same scenario for ORC |

The extra/undeclared column is required to make projection fire at all
(`projected_columns` returns `None` when all columns are kept).

## CI

- `cargo fmt --all` ✅
- `cargo clippy -p floe-core --tests -- -D warnings` ✅
- `cargo test -p floe-core --test unit parquet_input` → 5/5 ok ✅
- `cargo test -p floe-core --test unit orc_input` → 3/3 ok ✅
- `cargo test -p floe-core` → 557/557 ok ✅