### PR TITLE
chore: bump floe to v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 All notable changes to Floe are documented in this file.
 
+## v0.5.0
+
+- **Accepted sinks are now opt-in Cargo features** (PR #375):
+  - `delta`, `iceberg`, and `duckdb` are each gated behind their own Cargo feature in `floe-core`.
+    Parquet (via Polars) is always compiled; the heavy sink dependencies are pulled in only when
+    requested. `floe-core`'s default features are `["delta", "iceberg"]`, and `floe-cli` /
+    `floe-python` forward the same defaults — so the shipped CLI and published wheels keep
+    Delta + Iceberg support and stay lean.
+  - **`duckdb` is opt-in everywhere.** The bundled native DuckDB build inflated compile times and
+    broke the manylinux/musllinux wheel cross-compile (and pushed wheels past PyPI's per-file size
+    limit), so it is excluded from default builds. Enable it from source with `--features duckdb`.
+  - **Breaking for library consumers:** code depending on `floe-core` with `default-features = false`
+    no longer compiles any sink; add the features you need (`delta`, `iceberg`, `duckdb`).
+  - Config validation and manifest generation accept any *known* sink format — including one whose
+    feature is not compiled into the current build — so a lean build still validates and round-trips
+    a config it cannot execute. Only the runtime write path enforces the feature, failing with a
+    clear `rebuild with --features <sink>` hint.
+  - CI now compiles and tests each sink selectively (path-filtered jobs with isolated caches), so the
+    expensive DuckDB bundle is built only when DuckDB code changes.
+
+- **`floe` 0.5.0**: version bump for this release.
+
 ## v0.4.7
 
 - **DuckDB accepted sink** (closes #248, PR #372):

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3508,7 +3508,7 @@ dependencies = [
 
 [[package]]
 name = "floe-cli"
-version = "0.4.7"
+version = "0.5.0"
 dependencies = [
  "assert_cmd",
  "clap",
@@ -3521,7 +3521,7 @@ dependencies = [
 
 [[package]]
 name = "floe-core"
-version = "0.4.7"
+version = "0.5.0"
 dependencies = [
  "apache-avro 0.16.0",
  "arrow",
@@ -3565,7 +3565,7 @@ dependencies = [
 
 [[package]]
 name = "floe-python"
-version = "0.4.7"
+version = "0.5.0"
 dependencies = [
  "floe-core",
  "pyo3",

--- a/crates/floe-cli/Cargo.toml
+++ b/crates/floe-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "floe-cli"
-version = "0.4.7"
+version = "0.5.0"
 edition = "2021"
 description = "CLI for Floe, a YAML-driven technical ingestion tool."
 license = "MIT"
@@ -17,7 +17,7 @@ path = "src/main.rs"
 
 [dependencies]
 clap = { version = "4", features = ["derive"] }
-floe-core = { path = "../floe-core", version = "0.4.7", default-features = false }
+floe-core = { path = "../floe-core", version = "0.5.0", default-features = false }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 

--- a/crates/floe-core/Cargo.toml
+++ b/crates/floe-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "floe-core"
-version = "0.4.7"
+version = "0.5.0"
 edition = "2021"
 description = "Core library for Floe, a YAML-driven technical ingestion tool."
 license = "MIT"

--- a/crates/floe-python/Cargo.toml
+++ b/crates/floe-python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "floe-python"
-version = "0.4.7"
+version = "0.5.0"
 edition = "2021"
 description = "Python bindings for floe-core (PyO3-based)"
 license = "Apache-2.0"
@@ -13,7 +13,7 @@ name = "_floe"
 crate-type = ["cdylib"]
 
 [dependencies]
-floe-core = { path = "../floe-core", version = "0.4.7", default-features = false }
+floe-core = { path = "../floe-core", version = "0.5.0", default-features = false }
 pyo3 = { version = "0.22", features = ["extension-module", "abi3-py310"] }
 serde_json = "1"
 

--- a/crates/floe-python/pyproject.toml
+++ b/crates/floe-python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "floe-python"
-version = "0.4.7"
+version = "0.5.0"
 description = "Python bindings for floe-core — run floe pipelines at Rust speed from Python and notebooks"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary

- Bumps `floe-core`, `floe-cli`, and `floe-python` from 0.4.7 → **0.5.0**.
- A **minor** bump because the merged sink feature-gating (#375) changed `floe-core`'s default features — breaking for library consumers building with `default-features = false` (no sink is compiled unless its feature is enabled).
- Adds a `v0.5.0` CHANGELOG entry documenting the opt-in `delta` / `iceberg` / `duckdb` features, the `duckdb`-is-opt-in-everywhere policy, the lean default (`delta` + `iceberg`), and the lenient validate/manifest behavior for known-but-uncompiled sinks.

## Test plan

- [x] `cargo build -p floe-cli` compiles with the bumped versions
- [x] `Cargo.lock` regenerated for the new versions
- [ ] CI green (fmt, clippy, test, build)