### PR TITLE
feat(dagster-floe): expose resolve_execution_config and build_job_run_config_from_manifest

### DIFF
--- a/orchestrators/dagster-floe/src/floe_dagster/__init__.py
+++ b/orchestrators/dagster-floe/src/floe_dagster/__init__.py
@@ -3,7 +3,9 @@ from .definitions import (
     build_definitions,
     build_definitions_from_manifest_dir,
     build_definitions_from_manifest_paths,
+    build_job_run_config_from_manifest,
     build_runner_from_env,
+    resolve_execution_config,
 )
 from .runner import LocalRunner
 
@@ -12,6 +14,8 @@ __all__ = [
     "build_definitions",
     "build_definitions_from_manifest_dir",
     "build_definitions_from_manifest_paths",
+    "build_job_run_config_from_manifest",
     "build_runner_from_env",
     "load_floe_assets",
+    "resolve_execution_config",
 ]

--- a/orchestrators/dagster-floe/src/floe_dagster/definitions.py
+++ b/orchestrators/dagster-floe/src/floe_dagster/definitions.py
@@ -8,7 +8,7 @@ from typing import Any, Iterable
 from dagster import AssetSelection, Definitions, define_asset_job
 
 from .assets import build_floe_asset_defs
-from .manifest import load_manifest
+from .manifest import ManifestExecution, load_manifest
 from .runner import LocalRunner, Runner
 
 
@@ -120,15 +120,9 @@ def build_definitions_from_manifest_paths(
                 "name": manifest_job_name,
                 "selection": selection,
             }
-            max_concurrent = _resolve_max_concurrent(manifest.execution.orchestration)
-            if max_concurrent is not None:
-                job_kwargs["config"] = {
-                    "execution": {
-                        "config": {
-                            "multiprocess": {"max_concurrent": max_concurrent}
-                        }
-                    }
-                }
+            run_config = resolve_execution_config(manifest.execution)
+            if run_config is not None:
+                job_kwargs["config"] = run_config
             jobs.append(define_asset_job(**job_kwargs))
 
     return Definitions(assets=assets_defs, jobs=jobs)
@@ -143,6 +137,32 @@ def _resolve_max_concurrent(orchestration: Any) -> int | None:
     if orchestration.max_concurrent_entities is not None:
         return orchestration.max_concurrent_entities
     return None
+
+
+def resolve_execution_config(
+    execution: ManifestExecution | None,
+) -> dict[str, Any] | None:
+    """Return a Dagster job run-config dict derived from a manifest execution block.
+
+    Returns ``None`` when the manifest carries no concurrency constraint.
+    """
+    if execution is None:
+        return None
+    max_concurrent = _resolve_max_concurrent(execution.orchestration)
+    if max_concurrent is None:
+        return None
+    return {"execution": {"config": {"multiprocess": {"max_concurrent": max_concurrent}}}}
+
+
+def build_job_run_config_from_manifest(
+    manifest_path: str,
+) -> dict[str, Any] | None:
+    """Load a Floe manifest and return its Dagster job run-config dict.
+
+    Returns ``None`` when the manifest carries no concurrency constraint.
+    """
+    manifest = load_manifest(manifest_path)
+    return resolve_execution_config(manifest.execution)
 
 
 def _default_job_name(manifest_path: str, manifest_id: str) -> str:

--- a/orchestrators/dagster-floe/tests/test_definitions.py
+++ b/orchestrators/dagster-floe/tests/test_definitions.py
@@ -7,6 +7,8 @@ from floe_dagster.definitions import (
     build_definitions,
     build_definitions_from_manifest_dir,
     build_definitions_from_manifest_paths,
+    build_job_run_config_from_manifest,
+    resolve_execution_config,
 )
 from floe_dagster.runner import RunResult, Runner
 
@@ -328,3 +330,104 @@ def test_definitions_job_config_sequential_overrides_max_concurrent(tmp_path) ->
     assert (
         job.run_config["execution"]["config"]["multiprocess"]["max_concurrent"] == 1
     ), "sequential strategy must cap concurrency at 1 regardless of max_concurrent_entities"
+
+
+# ---------------------------------------------------------------------------
+# resolve_execution_config – unit tests (no manifest file needed)
+# ---------------------------------------------------------------------------
+
+def _make_execution(orchestration):
+    from floe_dagster.manifest import (
+        ManifestExecution,
+        ManifestExecutionDefaults,
+        ManifestExecutionResultContract,
+    )
+    return ManifestExecution(
+        entrypoint="floe",
+        base_args=[],
+        per_entity_args=[],
+        log_format="json",
+        result_contract=ManifestExecutionResultContract(
+            run_finished_event=True,
+            summary_uri_field="summary_uri",
+            exit_codes={},
+        ),
+        defaults=ManifestExecutionDefaults(env={}, workdir=None),
+        orchestration=orchestration,
+    )
+
+
+def test_resolve_execution_config_returns_none_when_execution_is_none() -> None:
+    assert resolve_execution_config(None) is None
+
+
+def test_resolve_execution_config_returns_none_when_no_orchestration() -> None:
+    assert resolve_execution_config(_make_execution(None)) is None
+
+
+def test_resolve_execution_config_sequential_returns_max_concurrent_1() -> None:
+    from floe_dagster.manifest import ManifestOrchestration
+    execution = _make_execution(ManifestOrchestration(strategy="sequential", max_concurrent_entities=None))
+    assert resolve_execution_config(execution) == {
+        "execution": {"config": {"multiprocess": {"max_concurrent": 1}}}
+    }
+
+
+def test_resolve_execution_config_explicit_max_concurrent() -> None:
+    from floe_dagster.manifest import ManifestOrchestration
+    execution = _make_execution(ManifestOrchestration(strategy=None, max_concurrent_entities=4))
+    assert resolve_execution_config(execution) == {
+        "execution": {"config": {"multiprocess": {"max_concurrent": 4}}}
+    }
+
+
+def test_resolve_execution_config_parallel_no_constraint_returns_none() -> None:
+    from floe_dagster.manifest import ManifestOrchestration
+    execution = _make_execution(ManifestOrchestration(strategy="parallel", max_concurrent_entities=None))
+    assert resolve_execution_config(execution) is None
+
+
+def test_resolve_execution_config_sequential_overrides_explicit_max_concurrent() -> None:
+    from floe_dagster.manifest import ManifestOrchestration
+    execution = _make_execution(ManifestOrchestration(strategy="sequential", max_concurrent_entities=5))
+    assert resolve_execution_config(execution) == {
+        "execution": {"config": {"multiprocess": {"max_concurrent": 1}}}
+    }
+
+
+# ---------------------------------------------------------------------------
+# build_job_run_config_from_manifest – integration tests (reads manifest file)
+# ---------------------------------------------------------------------------
+
+def test_build_job_run_config_from_manifest_no_orchestration(tmp_path) -> None:
+    path = _make_manifest_with_orchestration(tmp_path, None)
+    assert build_job_run_config_from_manifest(str(path)) is None
+
+
+def test_build_job_run_config_from_manifest_sequential(tmp_path) -> None:
+    path = _make_manifest_with_orchestration(tmp_path, '"orchestration": {"strategy": "sequential"}')
+    assert build_job_run_config_from_manifest(str(path)) == {
+        "execution": {"config": {"multiprocess": {"max_concurrent": 1}}}
+    }
+
+
+def test_build_job_run_config_from_manifest_explicit_max_concurrent(tmp_path) -> None:
+    path = _make_manifest_with_orchestration(tmp_path, '"orchestration": {"max_concurrent_entities": 2}')
+    assert build_job_run_config_from_manifest(str(path)) == {
+        "execution": {"config": {"multiprocess": {"max_concurrent": 2}}}
+    }
+
+
+def test_build_job_run_config_from_manifest_parallel_no_constraint(tmp_path) -> None:
+    path = _make_manifest_with_orchestration(tmp_path, '"orchestration": {"strategy": "parallel"}')
+    assert build_job_run_config_from_manifest(str(path)) is None
+
+
+# ---------------------------------------------------------------------------
+# Public API export smoke test
+# ---------------------------------------------------------------------------
+
+def test_public_api_exports_new_helpers() -> None:
+    import floe_dagster
+    assert hasattr(floe_dagster, "build_job_run_config_from_manifest")
+    assert hasattr(floe_dagster, "resolve_execution_config")


### PR DESCRIPTION
## Summary

Closes #376.

- Adds `resolve_execution_config(execution: ManifestExecution | None) -> dict | None` — derives the Dagster multiprocess run-config dict from a parsed manifest execution block
- Adds `build_job_run_config_from_manifest(manifest_path: str) -> dict | None` — convenience wrapper that loads the manifest and delegates to `resolve_execution_config`
- Both are exported from `floe_dagster.__all__`
- Refactors the inline config-building block inside `build_definitions_from_manifest_paths` to call `resolve_execution_config` (DRY)

Users composing mixed Dagster asset jobs (Floe + dlt + dbt + other assets) can now do:

```python
from floe_dagster import build_job_run_config_from_manifest

config = build_job_run_config_from_manifest("sales.manifest.json")
job = define_asset_job("my_mixed_job", selection=my_selection, config=config)
```

or, with an already-loaded manifest:

```python
from floe_dagster import resolve_execution_config

config = resolve_execution_config(manifest.execution)
```

## Test plan

- [x] 11 new tests added to `tests/test_definitions.py` (26 total, all green)
  - 6 unit tests for `resolve_execution_config` covering: `None` execution, no orchestration, `strategy=sequential`, explicit `max_concurrent_entities`, `strategy=parallel`, sequential-overrides-explicit
  - 4 integration tests for `build_job_run_config_from_manifest` covering the same cases via manifest file
  - 1 public API smoke test verifying both names importable from `floe_dagster`
- [x] All pre-existing orchestration tests still pass unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)