### PR TITLE
chore(dagster-floe): bump to v0.2.2 + changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to Floe are documented in this file.
 
+## dagster-floe v0.2.2
+
+- **Expose public job run-config helpers for mixed asset jobs** (closes #376, PR #378):
+  - `resolve_execution_config(execution)` — derives the Dagster multiprocess run-config dict from a parsed `ManifestExecution` object; returns `None` when no concurrency constraint is set.
+  - `build_job_run_config_from_manifest(manifest_path)` — convenience wrapper that loads the manifest and delegates to `resolve_execution_config`.
+  - Both are exported from the top-level `floe_dagster` package.
+  - Users composing mixed Dagster asset jobs (Floe + dlt + dbt + other assets) can now pass the manifest-derived run config directly to `define_asset_job(config=...)` without duplicating internal logic.
+
 ## v0.5.0
 
 - **Accepted sinks are now opt-in Cargo features** (PR #375):

--- a/orchestrators/dagster-floe/pyproject.toml
+++ b/orchestrators/dagster-floe/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "dagster-floe"
-version = "0.2.1"
+version = "0.2.2"
 description = "Dagster connector for Floe CLI (config-driven ingestion)"
 requires-python = ">=3.10"
 readme = "README.md"


### PR DESCRIPTION
## Summary

- Bumps `dagster-floe` from `0.2.1` → `0.2.2` in `pyproject.toml`
- Adds `dagster-floe v0.2.2` entry to `CHANGELOG.md` documenting the `resolve_execution_config` / `build_job_run_config_from_manifest` additions from #378

🤖 Generated with [Claude Code](https://claude.com/claude-code)