### PR TITLE
feat(duckdb): lean + companion DuckDB distribution (v0.5.1)

### DIFF
--- a/.github/scripts/render_pep503_index.py
+++ b/.github/scripts/render_pep503_index.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+"""Render a PEP 503 "simple" index for the off-PyPI ``floe-duckdb`` wheels.
+
+The DuckDB companion wheel bundles a native C++ DuckDB build that is too large
+for PyPI (>100 MB) and does not cross-compile in the manylinux/musllinux wheel
+containers, so it is published OFF PyPI as GitHub Release assets. This script
+builds a self-hosted simple index (à la ``download.pytorch.org``) that ``pip``
+can consume::
+
+    pip install floe-duckdb --extra-index-url https://malon64.github.io/floe/simple/
+
+It enumerates every ``floe_duckdb-*.whl`` asset across ALL GitHub Releases via the
+GitHub REST API so the regenerated index always lists the full version history,
+then writes the two-level PEP 503 layout::
+
+    <out>/index.html                     # project list
+    <out>/floe-duckdb/index.html         # file list with download URLs + #sha256
+
+Each file link points at the Release asset download URL and carries the asset's
+SHA-256 as a ``#sha256=`` fragment (PEP 503 hash) when GitHub reports a digest.
+"""
+
+from __future__ import annotations
+
+import argparse
+import html
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+PROJECT = "floe-duckdb"
+# PEP 503 normalizes the project name to lowercase with runs of [-_.] collapsed
+# to a single dash; "floe-duckdb" is already normalized.
+NORMALIZED = "floe-duckdb"
+
+
+def _api(url: str, token: str | None) -> list | dict:
+    req = urllib.request.Request(url)
+    req.add_header("Accept", "application/vnd.github+json")
+    req.add_header("X-GitHub-Api-Version", "2022-11-28")
+    if token:
+        req.add_header("Authorization", f"Bearer {token}")
+    with urllib.request.urlopen(req) as resp:
+        return json.load(resp)
+
+
+def collect_wheels(repo: str, token: str | None) -> list[dict]:
+    """Return [{name, url, sha256}] for every floe-duckdb wheel across releases."""
+    wheels: list[dict] = []
+    page = 1
+    while True:
+        releases = _api(
+            f"https://api.github.com/repos/{repo}/releases?per_page=100&page={page}",
+            token,
+        )
+        if not releases:
+            break
+        for rel in releases:
+            for asset in rel.get("assets", []):
+                name = asset.get("name", "")
+                if not name.startswith("floe_duckdb-") or not name.endswith(".whl"):
+                    continue
+                digest = asset.get("digest") or ""
+                sha256 = digest.split(":", 1)[1] if digest.startswith("sha256:") else ""
+                wheels.append(
+                    {
+                        "name": name,
+                        "url": asset["browser_download_url"],
+                        "sha256": sha256,
+                    }
+                )
+        page += 1
+    # Stable, de-duplicated ordering (a wheel name is unique per release tag).
+    seen: dict[str, dict] = {}
+    for wheel in wheels:
+        seen[wheel["name"]] = wheel
+    return [seen[k] for k in sorted(seen)]
+
+
+def write_index(out: Path, wheels: list[dict]) -> None:
+    out.mkdir(parents=True, exist_ok=True)
+
+    root = (
+        "<!DOCTYPE html>\n<html><body>\n"
+        f'<a href="{NORMALIZED}/">{PROJECT}</a>\n'
+        "</body></html>\n"
+    )
+    (out / "index.html").write_text(root, encoding="utf-8")
+
+    project_dir = out / NORMALIZED
+    project_dir.mkdir(parents=True, exist_ok=True)
+    links = []
+    for wheel in wheels:
+        href = wheel["url"]
+        if wheel["sha256"]:
+            href = f"{href}#sha256={wheel['sha256']}"
+        links.append(f'<a href="{html.escape(href)}">{html.escape(wheel["name"])}</a>')
+    body = (
+        "<!DOCTYPE html>\n<html><body>\n"
+        + "<br>\n".join(links)
+        + ("\n" if links else "")
+        + "</body></html>\n"
+    )
+    (project_dir / "index.html").write_text(body, encoding="utf-8")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--repo",
+        default=os.environ.get("GITHUB_REPOSITORY", "malon64/floe"),
+        help="owner/name of the GitHub repository holding the release assets",
+    )
+    parser.add_argument(
+        "--out",
+        type=Path,
+        required=True,
+        help="output directory for the PEP 503 simple index",
+    )
+    args = parser.parse_args()
+
+    token = os.environ.get("GITHUB_TOKEN") or os.environ.get("GH_TOKEN")
+    try:
+        wheels = collect_wheels(args.repo, token)
+    except urllib.error.HTTPError as err:  # pragma: no cover - network failure path
+        print(f"ERROR: failed to list releases for {args.repo}: {err}", file=sys.stderr)
+        return 1
+
+    write_index(args.out, wheels)
+    print(f"Wrote PEP 503 index for {len(wheels)} {PROJECT} wheel(s) to {args.out}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/render_pep503_index.py
+++ b/.github/scripts/render_pep503_index.py
@@ -7,7 +7,8 @@ containers, so it is published OFF PyPI as GitHub Release assets. This script
 builds a self-hosted simple index (à la ``download.pytorch.org``) that ``pip``
 can consume::
 
-    pip install floe-duckdb --extra-index-url https://malon64.github.io/floe/simple/
+    pip install floe-python  # lean wheel from PyPI (provides the companion's dependency)
+    pip install floe-duckdb --index-url https://malon64.github.io/floe/simple/
 
 It enumerates every ``floe_duckdb-*.whl`` asset across ALL GitHub Releases via the
 GitHub REST API so the regenerated index always lists the full version history,

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -319,7 +319,10 @@ jobs:
 
   publish-duckdb-wheel:
     name: Publish floe-duckdb wheels (off-PyPI)
-    needs: [meta, build-duckdb-wheel, release]
+    # Wait for publish-python: the companion wheel pins `floe-python==<version>`,
+    # so advertising it in the PEP 503 index before the matching lean wheel is
+    # live on PyPI would leave pip unable to resolve the dependency.
+    needs: [meta, build-duckdb-wheel, release, publish-python]
     if: ${{ needs.meta.outputs.on_main == 'true' && github.ref_type == 'tag' && (github.event_name != 'workflow_dispatch' || inputs.dry_run == false) }}
     runs-on: ubuntu-latest
     env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,6 +76,7 @@ jobs:
               ("floe-cli (Cargo)",             "crates/floe-cli/Cargo.toml",       ["package", "version"]),
               ("floe-python (Cargo)",          "crates/floe-python/Cargo.toml",    ["package", "version"]),
               ("floe-python (pyproject.toml)", "crates/floe-python/pyproject.toml",["project",  "version"]),
+              ("floe-duckdb (pyproject.duckdb.toml)", "crates/floe-python/pyproject.duckdb.toml", ["project", "version"]),
           ]
           for label, path, keys in pkg_checks:
               with open(path, "rb") as f:
@@ -162,6 +163,183 @@ jobs:
             ghcr.io/${{ github.repository_owner }}/floe:latest
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+  docker-duckdb:
+    name: Build floe-duckdb image (${{ matrix.platform }})
+    runs-on: ${{ matrix.runner }}
+    needs: [meta, validate]
+    if: ${{ needs.meta.outputs.on_main == 'true' && github.ref_type == 'tag' && (github.event_name != 'workflow_dispatch' || inputs.dry_run == false) }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # Build each arch on a NATIVE runner. The duckdb image compiles a
+          # bundled native (C++) DuckDB build from source; under QEMU emulation
+          # that compile is prohibitively slow, so we build per-arch natively and
+          # combine the manifests in docker-duckdb-merge below.
+          - platform: linux/amd64
+            runner: ubuntu-latest
+            arch: amd64
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+            arch: arm64
+    env:
+      IMAGE: ghcr.io/${{ github.repository_owner }}/floe-duckdb
+    steps:
+      - uses: actions/checkout@v6
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+      - name: Login to GHCR
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and push by digest
+        id: build
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: ./Dockerfile.duckdb
+          platforms: ${{ matrix.platform }}
+          # Push by digest only; the named multi-arch tags are assembled in the
+          # docker-duckdb-merge job from the per-arch digests.
+          outputs: type=image,name=${{ env.IMAGE }},push-by-digest=true,name-canonical=true,push=true
+          cache-from: type=gha,scope=duckdb-${{ matrix.arch }}
+          cache-to: type=gha,mode=max,scope=duckdb-${{ matrix.arch }}
+      - name: Export digest
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
+      - uses: actions/upload-artifact@v6
+        with:
+          name: duckdb-digest-${{ matrix.arch }}
+          path: /tmp/digests/*
+          retention-days: 1
+          if-no-files-found: error
+
+  docker-duckdb-merge:
+    name: Publish floe-duckdb multi-arch image (GHCR)
+    runs-on: ubuntu-latest
+    needs: [meta, docker-duckdb]
+    if: ${{ needs.meta.outputs.on_main == 'true' && github.ref_type == 'tag' && (github.event_name != 'workflow_dispatch' || inputs.dry_run == false) }}
+    env:
+      VERSION: ${{ needs.meta.outputs.version }}
+      IMAGE: ghcr.io/${{ github.repository_owner }}/floe-duckdb
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@v7
+        with:
+          path: /tmp/digests
+          pattern: duckdb-digest-*
+          merge-multiple: true
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+      - name: Login to GHCR
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Create and push multi-arch manifest
+        working-directory: /tmp/digests
+        run: |
+          set -euo pipefail
+          docker buildx imagetools create \
+            -t "${IMAGE}:${VERSION}" \
+            -t "${IMAGE}:latest" \
+            $(for d in *; do printf '%s@sha256:%s ' "${IMAGE}" "$d"; done)
+      - name: Inspect
+        run: docker buildx imagetools inspect "${IMAGE}:${VERSION}"
+
+  build-duckdb-wheel:
+    name: Build floe-duckdb wheel (${{ matrix.target }} on ${{ matrix.os }})
+    needs: [meta, validate]
+    if: ${{ needs.meta.outputs.on_main == 'true' }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # Native runners only. The bundled native DuckDB (C++) build does not
+          # compile in the manylinux/musllinux containers and cannot be cross-
+          # compiled, so these wheels are platform-tagged and published OFF PyPI
+          # (GitHub Release assets + a PEP 503 index), not to PyPI.
+          - os: ubuntu-latest
+            target: x86_64
+            manylinux: auto
+            before_script: "dnf install -y perl-core 2>/dev/null || yum install -y perl-core 2>/dev/null || true"
+          - os: ubuntu-24.04-arm
+            target: aarch64
+            manylinux: auto
+            before_script: "dnf install -y perl-core 2>/dev/null || yum install -y perl-core 2>/dev/null || true"
+          - os: macos-15-intel
+            target: x86_64
+            manylinux: "off"
+            before_script: ""
+          - os: macos-latest
+            target: aarch64
+            manylinux: "off"
+            before_script: ""
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: PyO3/maturin-action@v1
+        with:
+          command: build
+          # Build the DuckDB companion: same crate +duckdb, distinct module
+          # (floe._floe_duckdb) and dist name (floe-duckdb) via pyproject.duckdb.toml.
+          args: >-
+            --release
+            --strip
+            --features duckdb
+            -m crates/floe-python/Cargo.toml
+            --pyproject crates/floe-python/pyproject.duckdb.toml
+            --out dist
+          target: ${{ matrix.target }}
+          manylinux: ${{ matrix.manylinux }}
+          before-script-linux: ${{ matrix.before_script }}
+      - uses: actions/upload-artifact@v6
+        with:
+          name: duckdb-wheel-${{ matrix.os }}-${{ matrix.target }}
+          path: dist
+          if-no-files-found: error
+
+  publish-duckdb-wheel:
+    name: Publish floe-duckdb wheels (off-PyPI)
+    needs: [meta, build-duckdb-wheel, release]
+    if: ${{ needs.meta.outputs.on_main == 'true' && github.ref_type == 'tag' && (github.event_name != 'workflow_dispatch' || inputs.dry_run == false) }}
+    runs-on: ubuntu-latest
+    env:
+      VERSION: ${{ needs.meta.outputs.version }}
+      TAG: ${{ needs.meta.outputs.tag }}
+    steps:
+      - uses: actions/checkout@v6
+      - name: Download duckdb wheels
+        uses: actions/download-artifact@v7
+        with:
+          path: duckdb-dist
+          pattern: duckdb-wheel-*
+          merge-multiple: true
+      - name: Attach wheels to the GitHub Release
+        uses: softprops/action-gh-release@v3
+        with:
+          tag_name: ${{ env.TAG }}
+          files: duckdb-dist/*.whl
+      - name: Render PEP 503 index from all release assets
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          python .github/scripts/render_pep503_index.py \
+            --repo "${{ github.repository }}" \
+            --out site/simple
+      - name: Publish index to gh-pages
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: site
+          # Keep any other gh-pages content (docs); only the simple/ tree is ours.
+          keep_files: true
 
   publish:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -284,17 +284,26 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v6
+      - name: Stage DuckDB build manifest
+        shell: bash
+        # maturin has no flag to select an alternate pyproject; it always reads
+        # `pyproject.toml` next to the manifest. Swap in the companion build
+        # manifest (dist name `floe-duckdb`, module `floe._floe_duckdb`, no
+        # python-source) so this job builds the heavy companion wheel. The
+        # workspace is shared with the maturin-action container, so this host
+        # copy is visible inside it.
+        run: cp crates/floe-python/pyproject.duckdb.toml crates/floe-python/pyproject.toml
       - uses: PyO3/maturin-action@v1
         with:
           command: build
           # Build the DuckDB companion: same crate +duckdb, distinct module
-          # (floe._floe_duckdb) and dist name (floe-duckdb) via pyproject.duckdb.toml.
+          # (floe._floe_duckdb) and dist name (floe-duckdb) from the staged
+          # pyproject.toml above.
           args: >-
             --release
             --strip
             --features duckdb
             -m crates/floe-python/Cargo.toml
-            --pyproject crates/floe-python/pyproject.duckdb.toml
             --out dist
           target: ${{ matrix.target }}
           manylinux: ${{ matrix.manylinux }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -261,18 +261,21 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # Native runners only. The bundled native DuckDB (C++) build does not
-          # compile in the manylinux/musllinux containers and cannot be cross-
-          # compiled, so these wheels are platform-tagged and published OFF PyPI
-          # (GitHub Release assets + a PEP 503 index), not to PyPI.
+          # Native runners with manylinux OFF. The manylinux containers ship a
+          # GCC pinned to the legacy pre-C++11 CXX ABI, and bundled DuckDB refuses
+          # to compile its extensions under that ABI (platform.hpp guard). Building
+          # directly on the runner host uses a modern toolchain (new C++11 ABI) so
+          # the bundle compiles. The bundle also cannot be cross-compiled, so these
+          # wheels are platform-tagged and published OFF PyPI (GitHub Release assets
+          # + a PEP 503 index), not to PyPI — manylinux compliance is not required.
           - os: ubuntu-latest
             target: x86_64
-            manylinux: auto
-            before_script: "dnf install -y perl-core 2>/dev/null || yum install -y perl-core 2>/dev/null || true"
+            manylinux: "off"
+            before_script: ""
           - os: ubuntu-24.04-arm
             target: aarch64
-            manylinux: auto
-            before_script: "dnf install -y perl-core 2>/dev/null || yum install -y perl-core 2>/dev/null || true"
+            manylinux: "off"
+            before_script: ""
           - os: macos-15-intel
             target: x86_64
             manylinux: "off"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,41 @@
 
 All notable changes to Floe are documented in this file.
 
+## v0.5.1
+
+- **DuckDB is now available to non-Rust users via a lean-primary + heavy-companion
+  distribution.** v0.5.0 made `duckdb` an opt-in Cargo feature, which left it reachable
+  only by building from source. v0.5.1 ships the existing DuckDB sink (local `.duckdb`
+  files and MotherDuck `md:` databases) as a separate companion that the lean,
+  default-distributed `floe` transparently delegates to — modeled on the
+  companion-on-PATH pattern used by `git`/`git-lfs` and cargo subcommands, and the
+  ONNX-Runtime / PyTorch split-package model for Python.
+  - **CLI:** the lean `floe` binary auto-detects a DuckDB sink in the resolved config
+    and re-execs a `floe-duckdb` companion (same `floe-cli` source built
+    `--features duckdb`) with identical arguments, propagating its exit status. The
+    companion is resolved **only** from `PATH` or the canonicalized directory of the
+    running executable — never the current working directory (avoids the git-lfs
+    CVE GHSA-6rw3-3whw-jvjj class of attack). If no companion is found, the run fails
+    with an actionable install hint instead of a cryptic missing-feature error.
+  - **Docker:** new `ghcr.io/malon64/floe-duckdb` image (built from `Dockerfile.duckdb`)
+    bundles the native DuckDB build with `ENTRYPOINT ["floe-duckdb"]`. The lean
+    `ghcr.io/malon64/floe` image is unchanged.
+  - **Python:** new off-PyPI `floe-duckdb` wheel installs a `floe._floe_duckdb`
+    companion extension into the same `floe` package; the lean `floe.run()`
+    transparently delegates a DuckDB-sink run to it. Because the bundled native build
+    exceeds PyPI's 100 MB per-file limit and does not build in the manylinux/musllinux
+    containers, the companion wheel is published off PyPI (GitHub Release assets + a
+    PEP 503 simple index), à la `download.pytorch.org`:
+    `pip install floe-duckdb --extra-index-url https://malon64.github.io/floe/simple/`.
+  - No engine changes: this release only changes *distribution*. The DuckDB sink
+    behavior, config surface, and supported targets (Local + MotherDuck) are identical
+    to v0.5.0. DuckLake and remote-DuckDB (Quack) sinks remain deferred (they require a
+    DuckDB ≥1.5.3 / Arrow 58 bump that is blocked upstream until the Iceberg crate
+    publishes an Arrow 58 release).
+  - See [DuckDB sink](docs/sinks/duckdb.md) and [installation](docs/installation.md).
+
+- **`floe` 0.5.1**: version bump for this release.
+
 ## v0.5.0
 
 - **Accepted sinks are now opt-in Cargo features** (PR #375):

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,10 @@ All notable changes to Floe are documented in this file.
     exceeds PyPI's 100 MB per-file limit and does not build in the manylinux/musllinux
     containers, the companion wheel is published off PyPI (GitHub Release assets + a
     PEP 503 simple index), à la `download.pytorch.org`:
-    `pip install floe-duckdb --extra-index-url https://malon64.github.io/floe/simple/`.
+    `pip install floe-python` then
+    `pip install floe-duckdb --index-url https://malon64.github.io/floe/simple/`
+    (`--index-url`, not `--extra-index-url`, so a squatted `floe-duckdb` on PyPI can't
+    shadow the off-PyPI companion).
   - No engine changes: this release only changes *distribution*. The DuckDB sink
     behavior, config surface, and supported targets (Local + MotherDuck) are identical
     to v0.5.0. DuckLake and remote-DuckDB (Quack) sinks remain deferred (they require a

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3508,7 +3508,7 @@ dependencies = [
 
 [[package]]
 name = "floe-cli"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "assert_cmd",
  "clap",
@@ -3521,7 +3521,7 @@ dependencies = [
 
 [[package]]
 name = "floe-core"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "apache-avro 0.16.0",
  "arrow",
@@ -3565,7 +3565,7 @@ dependencies = [
 
 [[package]]
 name = "floe-python"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "floe-core",
  "pyo3",

--- a/Dockerfile.duckdb
+++ b/Dockerfile.duckdb
@@ -1,0 +1,39 @@
+# Full Floe image with the DuckDB sink compiled in (bundled native DuckDB).
+# Published as ghcr.io/malon64/floe-duckdb. This is the heavy companion to the
+# lean ghcr.io/malon64/floe image: the bundled C++ DuckDB build is large and slow
+# to compile, so it ships as a separate opt-in image rather than in the default.
+FROM rust:1-bookworm AS builder
+
+WORKDIR /app
+
+# Cache dependencies first.
+COPY Cargo.toml Cargo.lock ./
+COPY crates/floe-core/Cargo.toml crates/floe-core/Cargo.toml
+COPY crates/floe-cli/Cargo.toml crates/floe-cli/Cargo.toml
+
+RUN cargo fetch --locked
+
+# Copy the full source and build with the duckdb feature on top of the default
+# delta/iceberg set. rust:1-bookworm provides the C/C++ toolchain the bundled
+# DuckDB build needs.
+COPY crates crates
+
+RUN cargo build -p floe-cli --release --locked --features duckdb \
+  && cp target/release/floe target/release/floe-duckdb
+
+FROM debian:bookworm-slim AS runtime
+
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends ca-certificates \
+  && rm -rf /var/lib/apt/lists/*
+
+RUN useradd --create-home --uid 10001 --shell /usr/sbin/nologin floe
+
+WORKDIR /work
+
+COPY --from=builder /app/target/release/floe-duckdb /usr/local/bin/floe-duckdb
+
+USER 10001
+
+ENTRYPOINT ["floe-duckdb"]
+CMD ["--help"]

--- a/Dockerfile.duckdb
+++ b/Dockerfile.duckdb
@@ -6,10 +6,13 @@ FROM rust:1-bookworm AS builder
 
 WORKDIR /app
 
-# Cache dependencies first.
+# Cache dependencies first. Every workspace member manifest must be present or
+# `cargo fetch` fails loading the workspace (the root Cargo.toml lists
+# crates/floe-python as a member too).
 COPY Cargo.toml Cargo.lock ./
 COPY crates/floe-core/Cargo.toml crates/floe-core/Cargo.toml
 COPY crates/floe-cli/Cargo.toml crates/floe-cli/Cargo.toml
+COPY crates/floe-python/Cargo.toml crates/floe-python/Cargo.toml
 
 RUN cargo fetch --locked
 

--- a/README.md
+++ b/README.md
@@ -50,6 +50,11 @@ docker run --rm -v "$PWD:/work" ghcr.io/malon64/floe:latest run -c /work/config.
 Or download a prebuilt binary from [GitHub Releases](https://github.com/malon64/floe/releases), or `cargo install floe-cli`.  
 → [Full installation guide](docs/installation.md)
 
+**DuckDB sink** is shipped as a companion (the default artifacts are lean): use the
+`ghcr.io/malon64/floe-duckdb` image, a `floe-duckdb` binary on your `PATH`, or the
+off-PyPI `floe-duckdb` wheel. The lean `floe` auto-delegates DuckDB-sink runs to it.
+→ [DuckDB support](docs/installation.md#duckdb-support-companion-distribution)
+
 ## Quick start
 
 ```bash

--- a/crates/floe-cli/Cargo.toml
+++ b/crates/floe-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "floe-cli"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2021"
 description = "CLI for Floe, a YAML-driven technical ingestion tool."
 license = "MIT"
@@ -17,7 +17,7 @@ path = "src/main.rs"
 
 [dependencies]
 clap = { version = "4", features = ["derive"] }
-floe-core = { path = "../floe-core", version = "0.5.0", default-features = false }
+floe-core = { path = "../floe-core", version = "0.5.1", default-features = false }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 

--- a/crates/floe-cli/src/delegate.rs
+++ b/crates/floe-cli/src/delegate.rs
@@ -22,17 +22,18 @@ use floe_core::FloeResult;
 #[cfg(not(feature = "duckdb"))]
 const COMPANION_STEM: &str = "floe-duckdb";
 
-/// True when any entity writes to a DuckDB sink (accepted or rejected target).
+/// True when any entity writes to a DuckDB *accepted* sink. Only the accepted
+/// sink can target DuckDB: rejected sinks accept `csv` only
+/// (`format::rejected_sink_adapter`), so a `rejected.format: duckdb` is always
+/// invalid. Keying delegation on the rejected format too would re-exec the
+/// companion for such a config and surface a misleading "install the companion"
+/// hint instead of the real unsupported-rejected-sink validation error.
 #[cfg_attr(feature = "duckdb", allow(dead_code))]
 pub fn config_targets_duckdb(config: &RootConfig) -> bool {
-    config.entities.iter().any(|entity| {
-        entity.sink.accepted.format == "duckdb"
-            || entity
-                .sink
-                .rejected
-                .as_ref()
-                .is_some_and(|rejected| rejected.format == "duckdb")
-    })
+    config
+        .entities
+        .iter()
+        .any(|entity| entity.sink.accepted.format == "duckdb")
 }
 
 /// In the full build DuckDB is compiled in, so there is nothing to delegate.

--- a/crates/floe-cli/src/delegate.rs
+++ b/crates/floe-cli/src/delegate.rs
@@ -88,7 +88,7 @@ fn find_companion() -> Option<PathBuf> {
         .and_then(|exe| exe.parent().map(Path::to_path_buf))
     {
         let candidate = dir.join(&name);
-        if candidate.is_file() {
+        if is_executable_file(&candidate) {
             return Some(candidate);
         }
     }
@@ -103,11 +103,33 @@ fn find_companion() -> Option<PathBuf> {
                 continue;
             }
             let candidate = dir.join(&name);
-            if candidate.is_file() {
+            if is_executable_file(&candidate) {
                 return Some(candidate);
             }
         }
     }
 
     None
+}
+
+/// True only for a regular file that is actually executable. A non-executable
+/// file named like the companion (e.g. a stray data file earlier in PATH) must
+/// be skipped so the search continues to a real executable, mirroring how a
+/// shell resolves a command on PATH.
+#[cfg(not(feature = "duckdb"))]
+fn is_executable_file(path: &Path) -> bool {
+    if !path.is_file() {
+        return false;
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::metadata(path)
+            .map(|meta| meta.permissions().mode() & 0o111 != 0)
+            .unwrap_or(false)
+    }
+    #[cfg(not(unix))]
+    {
+        true
+    }
 }

--- a/crates/floe-cli/src/delegate.rs
+++ b/crates/floe-cli/src/delegate.rs
@@ -93,10 +93,13 @@ fn find_companion() -> Option<PathBuf> {
         }
     }
 
-    // 2. PATH, skipping empty entries and `.` which both denote the CWD.
+    // 2. PATH, considering only absolute entries. Any non-absolute entry
+    //    (empty, ".", "bin", "./.venv/bin", "..") is resolved relative to the
+    //    CWD, which must never be trusted for companion lookup (git-lfs CVE
+    //    GHSA-6rw3-3whw-jvjj), so skip them all.
     if let Some(path) = std::env::var_os("PATH") {
         for dir in std::env::split_paths(&path) {
-            if dir.as_os_str().is_empty() || dir == Path::new(".") {
+            if !dir.is_absolute() {
                 continue;
             }
             let candidate = dir.join(&name);

--- a/crates/floe-cli/src/delegate.rs
+++ b/crates/floe-cli/src/delegate.rs
@@ -1,0 +1,110 @@
+//! Companion-binary delegation for DuckDB sinks.
+//!
+//! The published `floe` binary is built lean (no `duckdb` feature) because the
+//! bundled native DuckDB build does not cross-compile in the release pipeline and
+//! would bloat every artifact. DuckDB support ships as a separate `floe-duckdb`
+//! companion (same `floe-cli` source built `--features duckdb`), following the
+//! companion-on-PATH model used by git/git-lfs and cargo subcommands.
+//!
+//! When the lean build is asked to run a config that writes to a DuckDB sink, it
+//! locates the `floe-duckdb` companion and re-execs it with the identical argv.
+//! The full build (`cfg!(feature = "duckdb")`) handles DuckDB directly, so its
+//! delegation hook is a no-op.
+
+#[cfg(not(feature = "duckdb"))]
+use std::path::{Path, PathBuf};
+
+use floe_core::config::RootConfig;
+#[cfg(not(feature = "duckdb"))]
+use floe_core::ConfigError;
+use floe_core::FloeResult;
+
+#[cfg(not(feature = "duckdb"))]
+const COMPANION_STEM: &str = "floe-duckdb";
+
+/// True when any entity writes to a DuckDB sink (accepted or rejected target).
+#[cfg_attr(feature = "duckdb", allow(dead_code))]
+pub fn config_targets_duckdb(config: &RootConfig) -> bool {
+    config.entities.iter().any(|entity| {
+        entity.sink.accepted.format == "duckdb"
+            || entity
+                .sink
+                .rejected
+                .as_ref()
+                .is_some_and(|rejected| rejected.format == "duckdb")
+    })
+}
+
+/// In the full build DuckDB is compiled in, so there is nothing to delegate.
+#[cfg(feature = "duckdb")]
+pub fn maybe_delegate_duckdb(_config: &RootConfig) -> FloeResult<()> {
+    Ok(())
+}
+
+/// In the lean build, re-exec the `floe-duckdb` companion when the config targets
+/// a DuckDB sink. On success this never returns — it propagates the companion's
+/// exit status. Returns an actionable error when no companion can be located.
+#[cfg(not(feature = "duckdb"))]
+pub fn maybe_delegate_duckdb(config: &RootConfig) -> FloeResult<()> {
+    if !config_targets_duckdb(config) {
+        return Ok(());
+    }
+
+    let companion = find_companion().ok_or_else(|| {
+        Box::new(ConfigError(format!(
+            "this config writes to a DuckDB sink, but this is the lean `floe` build \
+             without DuckDB support and no `{COMPANION_STEM}` companion was found on \
+             PATH or alongside this executable. Install the DuckDB build via the \
+             `ghcr.io/malon64/floe-duckdb` image, the `floe-duckdb` release binary, \
+             or `cargo install floe-cli --features duckdb`."
+        ))) as Box<dyn std::error::Error + Send + Sync>
+    })?;
+
+    let status = std::process::Command::new(&companion)
+        .args(std::env::args_os().skip(1))
+        .status()
+        .map_err(|err| {
+            Box::new(ConfigError(format!(
+                "failed to launch DuckDB companion at {}: {err}",
+                companion.display()
+            ))) as Box<dyn std::error::Error + Send + Sync>
+        })?;
+
+    std::process::exit(status.code().unwrap_or(1));
+}
+
+/// Locate the `floe-duckdb` companion, resolving ONLY from the directory of the
+/// running executable or from `PATH`. The current working directory is never
+/// consulted (git-lfs CVE GHSA-6rw3-3whw-jvjj: a CWD-resolved companion lets an
+/// attacker who can drop a file next to untrusted data hijack execution).
+#[cfg(not(feature = "duckdb"))]
+fn find_companion() -> Option<PathBuf> {
+    let name = format!("{COMPANION_STEM}{}", std::env::consts::EXE_SUFFIX);
+
+    // 1. Alongside the running executable (canonicalized to defeat symlink tricks).
+    if let Some(dir) = std::env::current_exe()
+        .ok()
+        .and_then(|exe| exe.canonicalize().ok())
+        .and_then(|exe| exe.parent().map(Path::to_path_buf))
+    {
+        let candidate = dir.join(&name);
+        if candidate.is_file() {
+            return Some(candidate);
+        }
+    }
+
+    // 2. PATH, skipping empty entries and `.` which both denote the CWD.
+    if let Some(path) = std::env::var_os("PATH") {
+        for dir in std::env::split_paths(&path) {
+            if dir.as_os_str().is_empty() || dir == Path::new(".") {
+                continue;
+            }
+            let candidate = dir.join(&name);
+            if candidate.is_file() {
+                return Some(candidate);
+            }
+        }
+    }
+
+    None
+}

--- a/crates/floe-cli/src/main.rs
+++ b/crates/floe-cli/src/main.rs
@@ -503,12 +503,17 @@ fn main() -> FloeResult<()> {
 
                 // Re-exec the floe-duckdb companion before any work when this lean
                 // build is asked to run a DuckDB sink (no-op in the full build).
-                if let Some((cfg, _)) = floe_core::read_manifest_text(&manifest_path_str)
-                    .ok()
-                    .and_then(|json| floe_core::config_from_manifest_json(&json).ok())
-                {
-                    if let Err(err) = delegate::maybe_delegate_duckdb(&cfg) {
-                        exit_with_error(err);
+                // Dry runs never reach the DuckDB writer (run resolves inputs and
+                // returns previews before any sink write), so they run on the lean
+                // build without the companion.
+                if !dry_run {
+                    if let Some((cfg, _)) = floe_core::read_manifest_text(&manifest_path_str)
+                        .ok()
+                        .and_then(|json| floe_core::config_from_manifest_json(&json).ok())
+                    {
+                        if let Err(err) = delegate::maybe_delegate_duckdb(&cfg) {
+                            exit_with_error(err);
+                        }
                     }
                 }
 
@@ -698,9 +703,14 @@ fn main() -> FloeResult<()> {
             );
             // Re-exec the floe-duckdb companion before any work when this lean
             // build is asked to run a DuckDB sink (no-op in the full build).
-            if let Ok(ref cfg) = early_config {
-                if let Err(err) = delegate::maybe_delegate_duckdb(cfg) {
-                    exit_with_error(err);
+            // Dry runs never reach the DuckDB writer (run resolves inputs and
+            // returns previews before any sink write), so they run on the lean
+            // build without the companion.
+            if !dry_run {
+                if let Ok(ref cfg) = early_config {
+                    if let Err(err) = delegate::maybe_delegate_duckdb(cfg) {
+                        exit_with_error(err);
+                    }
                 }
             }
 

--- a/crates/floe-cli/src/main.rs
+++ b/crates/floe-cli/src/main.rs
@@ -95,6 +95,7 @@ const STATE_LONG_ABOUT: &str = concat!(
     "  floe state reset -c example/config.yml -p profiles/local.yml --entity customers --yes\n",
 );
 
+mod delegate;
 mod logging;
 mod manifest_output;
 mod output;
@@ -500,6 +501,17 @@ fn main() -> FloeResult<()> {
                 // --- Manifest mode: no config file, no profile ---
                 let manifest_path = std::path::PathBuf::from(&manifest_path_str);
 
+                // Re-exec the floe-duckdb companion before any work when this lean
+                // build is asked to run a DuckDB sink (no-op in the full build).
+                if let Some((cfg, _)) = floe_core::read_manifest_text(&manifest_path_str)
+                    .ok()
+                    .and_then(|json| floe_core::config_from_manifest_json(&json).ok())
+                {
+                    if let Err(err) = delegate::maybe_delegate_duckdb(&cfg) {
+                        exit_with_error(err);
+                    }
+                }
+
                 // Wire up lineage from manifest's embedded lineage block.
                 // Use read_manifest_text so remote URIs (s3://, gs://, abfs://) are
                 // downloaded before parsing; std::fs::read_to_string would fail silently.
@@ -684,6 +696,14 @@ fn main() -> FloeResult<()> {
                 options.profile.as_ref().and_then(|p| p.storages.as_ref()),
                 options.profile.as_ref().and_then(|p| p.lineage.as_ref()),
             );
+            // Re-exec the floe-duckdb companion before any work when this lean
+            // build is asked to run a DuckDB sink (no-op in the full build).
+            if let Ok(ref cfg) = early_config {
+                if let Err(err) = delegate::maybe_delegate_duckdb(cfg) {
+                    exit_with_error(err);
+                }
+            }
+
             let lineage_observer = early_config
                 .as_ref()
                 .ok()

--- a/crates/floe-cli/tests/delegate.rs
+++ b/crates/floe-cli/tests/delegate.rs
@@ -123,6 +123,43 @@ fn lean_run_does_not_resolve_companion_from_relative_path_entry() {
 
 #[cfg(unix)]
 #[test]
+fn lean_run_skips_non_executable_companion_and_continues_search() {
+    let dir = tempdir().expect("tempdir");
+    let config_path = write_duckdb_config(dir.path());
+
+    // A non-executable file named like the companion sits earlier in PATH. A
+    // correct resolver must skip it (it cannot be re-execed) and keep searching,
+    // mirroring how a shell resolves a command on PATH.
+    use std::os::unix::fs::PermissionsExt;
+    let first_dir = dir.path().join("first");
+    fs::create_dir_all(&first_dir).expect("mkdir");
+    let non_exec = first_dir.join("floe-duckdb");
+    fs::write(&non_exec, "not executable\n").expect("write non-exec");
+    let mut perms = fs::metadata(&non_exec).unwrap().permissions();
+    perms.set_mode(0o644);
+    fs::set_permissions(&non_exec, perms).unwrap();
+
+    let second_dir = dir.path().join("second");
+    fs::create_dir_all(&second_dir).expect("mkdir");
+    let stub = second_dir.join("floe-duckdb");
+    fs::write(&stub, "#!/bin/sh\necho DELEGATED_OK\nexit 0\n").expect("write stub");
+    let mut perms = fs::metadata(&stub).unwrap().permissions();
+    perms.set_mode(0o755);
+    fs::set_permissions(&stub, perms).unwrap();
+
+    let path = std::env::join_paths([&first_dir, &second_dir]).expect("join paths");
+
+    let mut cmd = Command::new(assert_cmd::cargo::cargo_bin!("floe"));
+    cmd.args(["run", "-c"])
+        .arg(&config_path)
+        .env("PATH", &path)
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("DELEGATED_OK"));
+}
+
+#[cfg(unix)]
+#[test]
 fn lean_run_delegates_to_companion_on_path() {
     let dir = tempdir().expect("tempdir");
     let config_path = write_duckdb_config(dir.path());

--- a/crates/floe-cli/tests/delegate.rs
+++ b/crates/floe-cli/tests/delegate.rs
@@ -1,0 +1,120 @@
+//! Delegation behavior of the lean `floe` binary toward the `floe-duckdb`
+//! companion. These tests build against default features (no `duckdb`), so the
+//! test binary is the lean variant that must delegate.
+
+use assert_cmd::Command;
+use predicates::prelude::*;
+use std::fs;
+use tempfile::tempdir;
+
+fn write_duckdb_config(dir: &std::path::Path) -> std::path::PathBuf {
+    let config_path = dir.join("config.yml");
+    let body = format!(
+        r#"version: "0.1"
+report:
+  path: "{report}"
+entities:
+  - name: customers
+    source:
+      format: csv
+      path: "{input}"
+    sink:
+      accepted:
+        format: duckdb
+        path: "{out}"
+        duckdb:
+          table: customers
+          schema: main
+    policy:
+      severity: warn
+    schema:
+      columns:
+        - name: id
+          type: string
+"#,
+        report = dir.join("report").display(),
+        input = dir.join("in.csv").display(),
+        out = dir.join("out.duckdb").display(),
+    );
+    fs::write(&config_path, body).expect("write config");
+    config_path
+}
+
+#[test]
+fn lean_run_with_duckdb_sink_and_no_companion_errors_clearly() {
+    let dir = tempdir().expect("tempdir");
+    let config_path = write_duckdb_config(dir.path());
+
+    // PATH points at an empty dir so no stray `floe-duckdb` is discovered.
+    let empty_path = dir.path().join("emptybin");
+    fs::create_dir_all(&empty_path).expect("mkdir");
+
+    let mut cmd = Command::new(assert_cmd::cargo::cargo_bin!("floe"));
+    cmd.args(["run", "-c"])
+        .arg(&config_path)
+        .env("PATH", &empty_path)
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("DuckDB sink"))
+        .stderr(predicate::str::contains("floe-duckdb"))
+        .stderr(predicate::str::contains("--features duckdb"));
+}
+
+#[test]
+fn lean_run_does_not_resolve_companion_from_cwd() {
+    let dir = tempdir().expect("tempdir");
+    let config_path = write_duckdb_config(dir.path());
+
+    // Drop an executable named like the companion into the CWD. A correct
+    // resolver must ignore it (git-lfs CVE GHSA-6rw3-3whw-jvjj) and still error.
+    let cwd_companion = dir.path().join("floe-duckdb");
+    fs::write(&cwd_companion, "#!/bin/sh\nexit 0\n").expect("write fake companion");
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mut perms = fs::metadata(&cwd_companion).unwrap().permissions();
+        perms.set_mode(0o755);
+        fs::set_permissions(&cwd_companion, perms).unwrap();
+    }
+
+    let empty_path = dir.path().join("emptybin");
+    fs::create_dir_all(&empty_path).expect("mkdir");
+
+    let mut cmd = Command::new(assert_cmd::cargo::cargo_bin!("floe"));
+    cmd.args(["run", "-c"])
+        .arg(&config_path)
+        .current_dir(dir.path())
+        .env("PATH", &empty_path)
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("floe-duckdb"));
+}
+
+#[cfg(unix)]
+#[test]
+fn lean_run_delegates_to_companion_on_path() {
+    let dir = tempdir().expect("tempdir");
+    let config_path = write_duckdb_config(dir.path());
+
+    // A stub companion on PATH that prints a marker and exits 0 stands in for the
+    // real floe-duckdb. Proves the lean binary locates and re-execs it.
+    let bin_dir = dir.path().join("bin");
+    fs::create_dir_all(&bin_dir).expect("mkdir");
+    let stub = bin_dir.join("floe-duckdb");
+    fs::write(&stub, "#!/bin/sh\necho DELEGATED_OK\nexit 0\n").expect("write stub");
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mut perms = fs::metadata(&stub).unwrap().permissions();
+        perms.set_mode(0o755);
+        fs::set_permissions(&stub, perms).unwrap();
+    }
+
+    let mut cmd = Command::new(assert_cmd::cargo::cargo_bin!("floe"));
+    cmd.args(["run", "-c"])
+        .arg(&config_path)
+        .env("PATH", &bin_dir)
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("DELEGATED_OK"));
+}

--- a/crates/floe-cli/tests/delegate.rs
+++ b/crates/floe-cli/tests/delegate.rs
@@ -92,6 +92,37 @@ fn lean_run_does_not_resolve_companion_from_cwd() {
 
 #[cfg(unix)]
 #[test]
+fn lean_run_does_not_resolve_companion_from_relative_path_entry() {
+    let dir = tempdir().expect("tempdir");
+    let config_path = write_duckdb_config(dir.path());
+
+    // A relative PATH entry ("bin") resolves against the CWD, so an executable
+    // dropped at ./bin/floe-duckdb must NOT be trusted (git-lfs CVE
+    // GHSA-6rw3-3whw-jvjj). The resolver must skip non-absolute PATH entries.
+    let bin_dir = dir.path().join("bin");
+    fs::create_dir_all(&bin_dir).expect("mkdir");
+    let stub = bin_dir.join("floe-duckdb");
+    fs::write(&stub, "#!/bin/sh\necho HIJACKED\nexit 0\n").expect("write stub");
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mut perms = fs::metadata(&stub).unwrap().permissions();
+        perms.set_mode(0o755);
+        fs::set_permissions(&stub, perms).unwrap();
+    }
+
+    let mut cmd = Command::new(assert_cmd::cargo::cargo_bin!("floe"));
+    cmd.args(["run", "-c"])
+        .arg(&config_path)
+        .current_dir(dir.path())
+        .env("PATH", "bin")
+        .assert()
+        .failure()
+        .stdout(predicate::str::contains("HIJACKED").not())
+        .stderr(predicate::str::contains("floe-duckdb"));
+}
+
+#[cfg(unix)]
+#[test]
 fn lean_run_delegates_to_companion_on_path() {
     let dir = tempdir().expect("tempdir");
     let config_path = write_duckdb_config(dir.path());

--- a/crates/floe-cli/tests/delegate.rs
+++ b/crates/floe-cli/tests/delegate.rs
@@ -158,6 +158,73 @@ fn lean_run_skips_non_executable_companion_and_continues_search() {
         .stdout(predicate::str::contains("DELEGATED_OK"));
 }
 
+/// A config whose ONLY DuckDB reference is the rejected sink. Rejected sinks
+/// accept `csv` only, so this is an invalid config — it must NOT trigger
+/// companion delegation.
+fn write_rejected_only_duckdb_config(dir: &std::path::Path) -> std::path::PathBuf {
+    let config_path = dir.join("rejected-config.yml");
+    let body = format!(
+        r#"version: "0.1"
+report:
+  path: "{report}"
+entities:
+  - name: customers
+    source:
+      format: csv
+      path: "{input}"
+    sink:
+      accepted:
+        format: parquet
+        path: "{accepted}"
+      rejected:
+        format: duckdb
+        path: "{rejected}"
+    policy:
+      severity: warn
+    schema:
+      columns:
+        - name: id
+          type: string
+"#,
+        report = dir.join("report").display(),
+        input = dir.join("in.csv").display(),
+        accepted = dir.join("accepted.parquet").display(),
+        rejected = dir.join("rejected.duckdb").display(),
+    );
+    fs::write(&config_path, body).expect("write config");
+    config_path
+}
+
+/// A `rejected.format: duckdb` config is invalid (rejected sinks accept `csv`
+/// only), so the lean binary must NOT delegate to the companion even when one is
+/// present on PATH. It must instead surface the real unsupported-rejected-sink
+/// validation error rather than a misleading companion-install hint.
+#[cfg(unix)]
+#[test]
+fn lean_run_with_only_rejected_duckdb_sink_does_not_delegate() {
+    let dir = tempdir().expect("tempdir");
+    let config_path = write_rejected_only_duckdb_config(dir.path());
+
+    // A stub companion on PATH that would print a marker if (wrongly) re-execed.
+    use std::os::unix::fs::PermissionsExt;
+    let bin_dir = dir.path().join("bin");
+    fs::create_dir_all(&bin_dir).expect("mkdir");
+    let stub = bin_dir.join("floe-duckdb");
+    fs::write(&stub, "#!/bin/sh\necho DELEGATED_OK\nexit 0\n").expect("write stub");
+    let mut perms = fs::metadata(&stub).unwrap().permissions();
+    perms.set_mode(0o755);
+    fs::set_permissions(&stub, perms).unwrap();
+
+    let mut cmd = Command::new(assert_cmd::cargo::cargo_bin!("floe"));
+    cmd.args(["run", "-c"])
+        .arg(&config_path)
+        .env("PATH", &bin_dir)
+        .assert()
+        .failure()
+        .stdout(predicate::str::contains("DELEGATED_OK").not())
+        .stderr(predicate::str::contains("sink.rejected.format=duckdb"));
+}
+
 #[cfg(unix)]
 #[test]
 fn lean_run_delegates_to_companion_on_path() {

--- a/crates/floe-core/Cargo.toml
+++ b/crates/floe-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "floe-core"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2021"
 description = "Core library for Floe, a YAML-driven technical ingestion tool."
 license = "MIT"

--- a/crates/floe-python/Cargo.toml
+++ b/crates/floe-python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "floe-python"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2021"
 description = "Python bindings for floe-core (PyO3-based)"
 license = "Apache-2.0"
@@ -13,7 +13,7 @@ name = "_floe"
 crate-type = ["cdylib"]
 
 [dependencies]
-floe-core = { path = "../floe-core", version = "0.5.0", default-features = false }
+floe-core = { path = "../floe-core", version = "0.5.1", default-features = false }
 pyo3 = { version = "0.22", features = ["extension-module", "abi3-py310"] }
 serde_json = "1"
 

--- a/crates/floe-python/pyproject.duckdb.toml
+++ b/crates/floe-python/pyproject.duckdb.toml
@@ -1,0 +1,62 @@
+# Build manifest for the heavy `floe-duckdb` companion wheel.
+#
+# This builds the SAME `floe-python` crate as `pyproject.toml`, but with the
+# `duckdb` feature on (bundled native DuckDB). The bundled C++ build fails to
+# cross-compile in the manylinux/musllinux wheel containers and exceeds PyPI's
+# 100 MB per-file limit, so this wheel is published OFF PyPI (GitHub Release
+# assets + a PEP 503 index, like PyTorch's own download index) rather than to
+# PyPI.
+#
+# It compiles to a distinct extension module — `floe._floe_duckdb` — and ships
+# ONLY that compiled `.so` (no python-source). That lets it install into the
+# same `floe` package directory as the lean PyPI `floe` wheel without file
+# collisions, so the two coexist and the lean `floe.run` delegates DuckDB sinks
+# to this companion at runtime.
+#
+# Build with: maturin build --release --features duckdb \
+#               --manifest-path crates/floe-python/Cargo.toml \
+#               -o dist crates/floe-python/pyproject.duckdb.toml
+[build-system]
+requires = ["maturin>=1.7,<2"]
+build-backend = "maturin"
+
+[project]
+name = "floe-duckdb"
+version = "0.5.1"
+description = "DuckDB companion extension for floe — adds the native DuckDB sink to the floe Python package"
+readme = "README.md"
+requires-python = ">=3.10"
+license = { text = "Apache-2.0" }
+authors = [{ name = "Floe contributors" }]
+keywords = ["ingestion", "data-quality", "yaml", "polars", "duckdb"]
+classifiers = [
+  "Development Status :: 4 - Beta",
+  "Intended Audience :: Developers",
+  "Intended Audience :: Science/Research",
+  "Programming Language :: Rust",
+  "Programming Language :: Python :: 3",
+  "Programming Language :: Python :: 3 :: Only",
+  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
+  "Topic :: Scientific/Engineering :: Information Analysis",
+]
+# The lean `floe` wheel provides the Python source and public API; this companion
+# only contributes the compiled DuckDB extension module into that package. Pin to
+# the exact lean version so the companion's `_floe_duckdb` ABI always matches the
+# `floe` package it plugs into.
+dependencies = ["floe-python==0.5.1"]
+
+[project.urls]
+Homepage = "https://github.com/malon64/floe"
+Repository = "https://github.com/malon64/floe"
+"Bug Tracker" = "https://github.com/malon64/floe/issues"
+
+[tool.maturin]
+# Compiled extension is installed as floe._floe_duckdb (matches the
+# `#[pymodule] fn _floe_duckdb` entry point gated behind the `duckdb` feature).
+# No python-source: ship only the .so so this coexists with the lean wheel.
+module-name = "floe._floe_duckdb"
+manifest-path = "Cargo.toml"
+features = ["duckdb"]

--- a/crates/floe-python/pyproject.toml
+++ b/crates/floe-python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "floe-python"
-version = "0.5.0"
+version = "0.5.1"
 description = "Python bindings for floe-core — run floe pipelines at Rust speed from Python and notebooks"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/crates/floe-python/python/floe/__init__.py
+++ b/crates/floe-python/python/floe/__init__.py
@@ -65,11 +65,18 @@ from floe import _floe as _lean
 # this same package. When a run targets a DuckDB sink and this is the lean build,
 # `run` transparently delegates to that companion, mirroring the lean `floe` CLI
 # re-execing the `floe-duckdb` binary. Install instructions for the companion:
+# `--index-url` (not `--extra-index-url`) so pip resolves the `floe-duckdb`
+# name ONLY from the off-PyPI index: `floe-duckdb` is intentionally absent from
+# PyPI, and `--extra-index-url` would leave PyPI in play, letting a squatted /
+# higher-version `floe-duckdb` there shadow the real companion (dependency
+# confusion). The companion's `floe-python` dependency is already satisfied
+# here — this hint only fires from an installed lean `floe` — so replacing PyPI
+# for this single install does not break dependency resolution.
 _DUCKDB_INSTALL_HINT = (
     "this config writes to a DuckDB sink, but the installed `floe` wheel is the "
     "lean build without DuckDB support and the `floe-duckdb` companion wheel is "
     "not installed. Install it from the off-PyPI index, e.g. "
-    "`pip install floe-duckdb --extra-index-url "
+    "`pip install floe-duckdb --index-url "
     "https://malon64.github.io/floe/simple/`, or use the "
     "`ghcr.io/malon64/floe-duckdb` image."
 )

--- a/crates/floe-python/python/floe/__init__.py
+++ b/crates/floe-python/python/floe/__init__.py
@@ -119,8 +119,14 @@ def run(config_path, *args, **kwargs):
     Transparently delegates to the `floe-duckdb` companion when the config
     targets a DuckDB sink and this lean build lacks native DuckDB support.
     """
-    if not getattr(_lean, "HAS_DUCKDB", False) and _lean.config_targets_duckdb(
-        config_path
+    # Dry runs resolve inputs and return previews before any sink write, so they
+    # never touch the DuckDB writer — run them on the lean build without the
+    # companion. `dry_run` is the 3rd positional arg (entities, dry_run, ...).
+    dry_run = kwargs.get("dry_run", args[1] if len(args) >= 2 else False)
+    if (
+        not dry_run
+        and not getattr(_lean, "HAS_DUCKDB", False)
+        and _lean.config_targets_duckdb(config_path)
     ):
         companion = _duckdb_module()
         if companion is None:

--- a/crates/floe-python/python/floe/__init__.py
+++ b/crates/floe-python/python/floe/__init__.py
@@ -46,7 +46,7 @@ from floe._floe import (
     EntityConfig,
     RunOutcome,
     validate,
-    run,
+    run as _run,
     load_config,
     extract_config_env_vars,
     inspect_entity_state,
@@ -54,6 +54,49 @@ from floe._floe import (
     set_observer,
     clear_observer,
 )
+from floe import _floe as _lean
+
+# DuckDB sinks compile a bundled native build that is too large for PyPI, so the
+# published `floe` wheel is lean. DuckDB support ships as a separate off-PyPI
+# `floe-duckdb` wheel that installs a `floe._floe_duckdb` companion extension into
+# this same package. When a run targets a DuckDB sink and this is the lean build,
+# `run` transparently delegates to that companion, mirroring the lean `floe` CLI
+# re-execing the `floe-duckdb` binary. Install instructions for the companion:
+_DUCKDB_INSTALL_HINT = (
+    "this config writes to a DuckDB sink, but the installed `floe` wheel is the "
+    "lean build without DuckDB support and the `floe-duckdb` companion wheel is "
+    "not installed. Install it from the off-PyPI index, e.g. "
+    "`pip install floe-duckdb --extra-index-url "
+    "https://malon64.github.io/floe/simple/`, or use the "
+    "`ghcr.io/malon64/floe-duckdb` image."
+)
+
+
+def _duckdb_module():
+    """Return the `floe._floe_duckdb` companion extension, or None if absent."""
+    try:
+        from floe import _floe_duckdb
+
+        return _floe_duckdb
+    except ImportError:
+        return None
+
+
+def run(config_path, *args, **kwargs):
+    """Execute a floe pipeline.
+
+    Transparently delegates to the `floe-duckdb` companion when the config
+    targets a DuckDB sink and this lean build lacks native DuckDB support.
+    """
+    if not getattr(_lean, "HAS_DUCKDB", False) and _lean.config_targets_duckdb(
+        config_path
+    ):
+        companion = _duckdb_module()
+        if companion is None:
+            raise FloeConfigError(_DUCKDB_INSTALL_HINT)
+        return companion.run(config_path, *args, **kwargs)
+    return _run(config_path, *args, **kwargs)
+
 
 __all__ = [
     "__version__",

--- a/crates/floe-python/python/floe/__init__.py
+++ b/crates/floe-python/python/floe/__init__.py
@@ -31,6 +31,7 @@ Run floe pipelines at Rust speed from Python notebooks::
 
 import importlib
 import importlib.util
+import sys
 from importlib.metadata import version as _pkg_version
 
 try:
@@ -84,12 +85,17 @@ _current_observer = None
 def set_observer(callback):
     """Register a callback for live run/validation events.
 
-    Mirrors into the DuckDB companion (if loaded) so delegated DuckDB runs
-    emit the same events as native runs.
+    Mirrors into the DuckDB companion only if it is *already* loaded, so
+    delegated DuckDB runs emit the same events as native runs. Registering an
+    observer must not trigger a companion import: if the companion is installed
+    but its native extension fails to load, that error should surface when a
+    DuckDB run is actually attempted, not as a side effect of setting an
+    observer. `run` re-installs the tracked observer into the companion right
+    before delegating, so a companion loaded later still gets the callback.
     """
     global _current_observer
     _current_observer = callback
-    companion = _duckdb_module()
+    companion = _loaded_duckdb_module()
     if companion is not None:
         companion.set_observer(callback)
     return _lean_set_observer(callback)
@@ -99,10 +105,20 @@ def clear_observer():
     """Remove the previously registered event callback."""
     global _current_observer
     _current_observer = None
-    companion = _duckdb_module()
+    companion = _loaded_duckdb_module()
     if companion is not None:
         companion.clear_observer()
     return _lean_clear_observer()
+
+
+def _loaded_duckdb_module():
+    """Return the companion module only if it is already imported, else None.
+
+    Unlike `_duckdb_module`, this never triggers an import, so it cannot raise a
+    companion load error. Used on paths (observer registration) where a broken
+    companion must not surface until a DuckDB run is actually attempted.
+    """
+    return sys.modules.get("floe._floe_duckdb")
 
 
 def _duckdb_module():
@@ -149,8 +165,33 @@ def run(config_path, *args, **kwargs):
             raise FloeConfigError(_DUCKDB_INSTALL_HINT)
         if _current_observer is not None:
             companion.set_observer(_current_observer)
-        return companion.run(config_path, *args, **kwargs)
+        try:
+            outcome = companion.run(config_path, *args, **kwargs)
+        except companion.FloeError as exc:
+            raise _translate_companion_error(exc) from exc
+        # The companion is a separate native library, so its RunOutcome is a
+        # distinct Python class. Round-trip through the dict form so callers get
+        # the lean `RunOutcome` type they imported from `floe`.
+        return RunOutcome.from_dict(outcome.to_dict())
     return _run(config_path, *args, **kwargs)
+
+
+# The companion's exception classes are distinct objects from the lean ones
+# (separate native libraries), so `except floe.FloeRunError` on a caller's side
+# would not catch a companion-raised error. Map each companion exception to the
+# matching lean class by name so delegated runs raise the types callers expect.
+_LEAN_EXCEPTIONS = {
+    "FloeConfigError": FloeConfigError,
+    "FloeRunError": FloeRunError,
+    "FloeStorageError": FloeStorageError,
+    "FloeIoError": FloeIoError,
+    "FloeError": FloeError,
+}
+
+
+def _translate_companion_error(exc):
+    lean_cls = _LEAN_EXCEPTIONS.get(type(exc).__name__, FloeError)
+    return lean_cls(str(exc))
 
 
 __all__ = [

--- a/crates/floe-python/python/floe/__init__.py
+++ b/crates/floe-python/python/floe/__init__.py
@@ -121,12 +121,20 @@ def run(config_path, *args, **kwargs):
     """
     # Dry runs resolve inputs and return previews before any sink write, so they
     # never touch the DuckDB writer — run them on the lean build without the
-    # companion. `dry_run` is the 3rd positional arg (entities, dry_run, ...).
+    # companion. Positional order mirrors the native `run`:
+    # (config_path, entities, dry_run, run_id, full_refresh, profile_vars, profile_path).
     dry_run = kwargs.get("dry_run", args[1] if len(args) >= 2 else False)
+    # The sink format can be selected through a profile variable (e.g.
+    # `format: "{{SINK_FORMAT}}"`), so the delegation check must apply the same
+    # profile inputs as the run or it would miss the DuckDB sink and run lean.
+    profile_vars = kwargs.get("profile_vars", args[4] if len(args) >= 5 else None)
+    profile_path = kwargs.get("profile_path", args[5] if len(args) >= 6 else None)
     if (
         not dry_run
         and not getattr(_lean, "HAS_DUCKDB", False)
-        and _lean.config_targets_duckdb(config_path)
+        and _lean.config_targets_duckdb(
+            config_path, profile_vars=profile_vars, profile_path=profile_path
+        )
     ):
         companion = _duckdb_module()
         if companion is None:

--- a/crates/floe-python/python/floe/__init__.py
+++ b/crates/floe-python/python/floe/__init__.py
@@ -51,8 +51,8 @@ from floe._floe import (
     extract_config_env_vars,
     inspect_entity_state,
     reset_entity_state,
-    set_observer,
-    clear_observer,
+    set_observer as _lean_set_observer,
+    clear_observer as _lean_clear_observer,
 )
 from floe import _floe as _lean
 
@@ -70,6 +70,37 @@ _DUCKDB_INSTALL_HINT = (
     "https://malon64.github.io/floe/simple/`, or use the "
     "`ghcr.io/malon64/floe-duckdb` image."
 )
+
+
+# The lean `_floe` and companion `_floe_duckdb` are separate native libraries
+# with independent observer state, so the registered callback must be mirrored
+# into the companion before a delegated run or its progress/log events are lost.
+# Track the active observer here so delegation can re-install it.
+_current_observer = None
+
+
+def set_observer(callback):
+    """Register a callback for live run/validation events.
+
+    Mirrors into the DuckDB companion (if loaded) so delegated DuckDB runs
+    emit the same events as native runs.
+    """
+    global _current_observer
+    _current_observer = callback
+    companion = _duckdb_module()
+    if companion is not None:
+        companion.set_observer(callback)
+    return _lean_set_observer(callback)
+
+
+def clear_observer():
+    """Remove the previously registered event callback."""
+    global _current_observer
+    _current_observer = None
+    companion = _duckdb_module()
+    if companion is not None:
+        companion.clear_observer()
+    return _lean_clear_observer()
 
 
 def _duckdb_module():
@@ -94,6 +125,8 @@ def run(config_path, *args, **kwargs):
         companion = _duckdb_module()
         if companion is None:
             raise FloeConfigError(_DUCKDB_INSTALL_HINT)
+        if _current_observer is not None:
+            companion.set_observer(_current_observer)
         return companion.run(config_path, *args, **kwargs)
     return _run(config_path, *args, **kwargs)
 

--- a/crates/floe-python/python/floe/__init__.py
+++ b/crates/floe-python/python/floe/__init__.py
@@ -104,13 +104,22 @@ def clear_observer():
 
 
 def _duckdb_module():
-    """Return the `floe._floe_duckdb` companion extension, or None if absent."""
+    """Return the `floe._floe_duckdb` companion extension, or None if not installed.
+
+    Only a genuinely absent companion maps to None. If the companion IS installed
+    but its native extension fails to load (incompatible libc, unresolved symbol),
+    the import raises a plain ImportError (not ModuleNotFoundError); that is allowed
+    to propagate so the real loader error surfaces instead of a misleading
+    "companion wheel is not installed" hint.
+    """
     try:
         from floe import _floe_duckdb
 
         return _floe_duckdb
-    except ImportError:
-        return None
+    except ModuleNotFoundError as exc:
+        if exc.name in ("floe._floe_duckdb", "_floe_duckdb"):
+            return None
+        raise
 
 
 def run(config_path, *args, **kwargs):

--- a/crates/floe-python/python/floe/__init__.py
+++ b/crates/floe-python/python/floe/__init__.py
@@ -29,6 +29,8 @@ Run floe pipelines at Rust speed from Python notebooks::
     floe.run("pipeline.yml", profile_vars={"output_bucket": "s3://my-bucket"})
 """
 
+import importlib
+import importlib.util
 from importlib.metadata import version as _pkg_version
 
 try:
@@ -106,20 +108,17 @@ def clear_observer():
 def _duckdb_module():
     """Return the `floe._floe_duckdb` companion extension, or None if not installed.
 
-    Only a genuinely absent companion maps to None. If the companion IS installed
-    but its native extension fails to load (incompatible libc, unresolved symbol),
-    the import raises a plain ImportError (not ModuleNotFoundError); that is allowed
-    to propagate so the real loader error surfaces instead of a misleading
-    "companion wheel is not installed" hint.
+    A genuinely absent companion maps to None. If the companion IS installed but
+    its native extension fails to load (incompatible libc, unresolved symbol), the
+    loader error is allowed to propagate so it surfaces instead of a misleading
+    "companion wheel is not installed" hint. `find_spec` distinguishes the two:
+    `from floe import _floe_duckdb` would raise a plain ImportError for the absent
+    case too (attribute fallback), so the exception type alone cannot tell them
+    apart — but `find_spec` returns None only when the module is truly not there.
     """
-    try:
-        from floe import _floe_duckdb
-
-        return _floe_duckdb
-    except ModuleNotFoundError as exc:
-        if exc.name in ("floe._floe_duckdb", "_floe_duckdb"):
-            return None
-        raise
+    if importlib.util.find_spec("floe._floe_duckdb") is None:
+        return None
+    return importlib.import_module("floe._floe_duckdb")
 
 
 def run(config_path, *args, **kwargs):

--- a/crates/floe-python/python/floe/_floe.pyi
+++ b/crates/floe-python/python/floe/_floe.pyi
@@ -144,8 +144,20 @@ class RunOutcome:
     def __repr__(self) -> str: ...
 
 # ---------------------------------------------------------------------------
+# Capability flags
+# ---------------------------------------------------------------------------
+
+HAS_DUCKDB: bool
+"""True only in the `+duckdb` build (the off-PyPI `floe-duckdb` companion)."""
+
+# ---------------------------------------------------------------------------
 # Core functions
 # ---------------------------------------------------------------------------
+
+def config_targets_duckdb(config_path: str) -> bool:
+    """True when the config writes to a DuckDB sink. Returns False if the config
+    cannot be loaded, so the normal run path surfaces the real error."""
+    ...
 
 def validate(
     config_path: str,

--- a/crates/floe-python/src/functions.rs
+++ b/crates/floe-python/src/functions.rs
@@ -105,6 +105,26 @@ pub fn load_config(config_path: &str) -> PyResult<PyRootConfig> {
         .map_err(to_py_err)
 }
 
+/// True when the config writes to a DuckDB sink (accepted or rejected target).
+/// The lean `floe` Python wrapper calls this to decide whether a run must be
+/// delegated to the `floe._floe_duckdb` companion module. A load failure returns
+/// `false` so the lean run path surfaces the real error rather than masking it.
+#[pyfunction]
+pub fn config_targets_duckdb(config_path: &str) -> bool {
+    let path = Path::new(config_path);
+    match floe_core::load_config(path) {
+        Ok(config) => config.entities.iter().any(|entity| {
+            entity.sink.accepted.format == "duckdb"
+                || entity
+                    .sink
+                    .rejected
+                    .as_ref()
+                    .is_some_and(|rejected| rejected.format == "duckdb")
+        }),
+        Err(_) => false,
+    }
+}
+
 #[pyfunction]
 pub fn extract_config_env_vars(config_path: &str) -> PyResult<HashMap<String, String>> {
     let path = Path::new(config_path);

--- a/crates/floe-python/src/functions.rs
+++ b/crates/floe-python/src/functions.rs
@@ -107,12 +107,25 @@ pub fn load_config(config_path: &str) -> PyResult<PyRootConfig> {
 
 /// True when the config writes to a DuckDB sink (accepted or rejected target).
 /// The lean `floe` Python wrapper calls this to decide whether a run must be
-/// delegated to the `floe._floe_duckdb` companion module. A load failure returns
+/// delegated to the `floe._floe_duckdb` companion module. The same `profile_vars`
+/// / `profile_path` the run will use are applied first, so a sink format selected
+/// through a profile variable (e.g. `format: "{{SINK_FORMAT}}"`) is detected and
+/// delegated rather than silently run on the lean build. A load failure returns
 /// `false` so the lean run path surfaces the real error rather than masking it.
 #[pyfunction]
-pub fn config_targets_duckdb(config_path: &str) -> bool {
+#[pyo3(signature = (config_path, profile_vars=None, profile_path=None))]
+pub fn config_targets_duckdb(
+    config_path: &str,
+    profile_vars: Option<HashMap<String, String>>,
+    profile_path: Option<String>,
+) -> bool {
     let path = Path::new(config_path);
-    match floe_core::load_config(path) {
+    let vars = match load_optional_profile(profile_path, profile_vars) {
+        Ok(Some(profile)) => profile.variables,
+        Ok(None) => HashMap::new(),
+        Err(_) => return false,
+    };
+    match floe_core::load_config_with_profile_vars(path, &vars) {
         Ok(config) => config.entities.iter().any(|entity| {
             entity.sink.accepted.format == "duckdb"
                 || entity

--- a/crates/floe-python/src/functions.rs
+++ b/crates/floe-python/src/functions.rs
@@ -105,13 +105,18 @@ pub fn load_config(config_path: &str) -> PyResult<PyRootConfig> {
         .map_err(to_py_err)
 }
 
-/// True when the config writes to a DuckDB sink (accepted or rejected target).
-/// The lean `floe` Python wrapper calls this to decide whether a run must be
-/// delegated to the `floe._floe_duckdb` companion module. The same `profile_vars`
-/// / `profile_path` the run will use are applied first, so a sink format selected
-/// through a profile variable (e.g. `format: "{{SINK_FORMAT}}"`) is detected and
-/// delegated rather than silently run on the lean build. A load failure returns
-/// `false` so the lean run path surfaces the real error rather than masking it.
+/// True when the config writes to a DuckDB *accepted* sink. The lean `floe`
+/// Python wrapper calls this to decide whether a run must be delegated to the
+/// `floe._floe_duckdb` companion module. Only the accepted sink can target
+/// DuckDB: rejected sinks accept `csv` only, so a `rejected.format: duckdb` is
+/// always invalid and must fall through to the lean run path so its real
+/// unsupported-rejected-sink validation error surfaces, rather than being
+/// delegated (which would yield a misleading companion-install hint). The same
+/// `profile_vars` / `profile_path` the run will use are applied first, so a sink
+/// format selected through a profile variable (e.g. `format: "{{SINK_FORMAT}}"`)
+/// is detected and delegated rather than silently run on the lean build. A load
+/// failure returns `false` so the lean run path surfaces the real error rather
+/// than masking it.
 #[pyfunction]
 #[pyo3(signature = (config_path, profile_vars=None, profile_path=None))]
 pub fn config_targets_duckdb(
@@ -126,14 +131,10 @@ pub fn config_targets_duckdb(
         Err(_) => return false,
     };
     match floe_core::load_config_with_profile_vars(path, &vars) {
-        Ok(config) => config.entities.iter().any(|entity| {
-            entity.sink.accepted.format == "duckdb"
-                || entity
-                    .sink
-                    .rejected
-                    .as_ref()
-                    .is_some_and(|rejected| rejected.format == "duckdb")
-        }),
+        Ok(config) => config
+            .entities
+            .iter()
+            .any(|entity| entity.sink.accepted.format == "duckdb"),
         Err(_) => false,
     }
 }

--- a/crates/floe-python/src/lib.rs
+++ b/crates/floe-python/src/lib.rs
@@ -11,8 +11,13 @@ use types::config::{PyEntityConfig, PyRootConfig};
 use types::errors::{FloeConfigError, FloeError, FloeIoError, FloeRunError, FloeStorageError};
 use types::outcome::PyRunOutcome;
 
-#[pymodule]
-fn _floe(m: &Bound<'_, PyModule>) -> PyResult<()> {
+// Shared registration for both the lean (`_floe`) and full (`_floe_duckdb`)
+// extension modules. The two entry points below differ only in name so the
+// compiled symbol (`PyInit__floe` vs `PyInit__floe_duckdb`) matches the dotted
+// module each wheel installs; everything they expose is identical save for the
+// `HAS_DUCKDB` capability flag the lean Python wrapper uses to decide whether to
+// delegate a DuckDB-sink run to the companion module.
+fn register(m: &Bound<'_, PyModule>) -> PyResult<()> {
     // Exception hierarchy
     m.add("FloeError", m.py().get_type_bound::<FloeError>())?;
     m.add(
@@ -26,6 +31,10 @@ fn _floe(m: &Bound<'_, PyModule>) -> PyResult<()> {
     )?;
     m.add("FloeIoError", m.py().get_type_bound::<FloeIoError>())?;
 
+    // Capability flag: true only in the `+duckdb` build. The lean Python wrapper
+    // reads this to know whether it must delegate DuckDB sinks to the companion.
+    m.add("HAS_DUCKDB", cfg!(feature = "duckdb"))?;
+
     // Types
     m.add_class::<PyRootConfig>()?;
     m.add_class::<PyEntityConfig>()?;
@@ -38,10 +47,27 @@ fn _floe(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(functions::extract_config_env_vars, m)?)?;
     m.add_function(wrap_pyfunction!(functions::inspect_entity_state, m)?)?;
     m.add_function(wrap_pyfunction!(functions::reset_entity_state, m)?)?;
+    m.add_function(wrap_pyfunction!(functions::config_targets_duckdb, m)?)?;
 
     // Observer
     m.add_function(wrap_pyfunction!(observer::set_observer, m)?)?;
     m.add_function(wrap_pyfunction!(observer::clear_observer, m)?)?;
 
     Ok(())
+}
+
+/// Lean extension module, installed as `floe._floe` by the PyPI `floe` wheel.
+#[cfg(not(feature = "duckdb"))]
+#[pymodule]
+fn _floe(m: &Bound<'_, PyModule>) -> PyResult<()> {
+    register(m)
+}
+
+/// Full extension module, installed as `floe._floe_duckdb` by the off-PyPI
+/// `floe-duckdb` companion wheel. Ships only the compiled `.so` into the shared
+/// `floe` package so it can coexist with the lean wheel.
+#[cfg(feature = "duckdb")]
+#[pymodule]
+fn _floe_duckdb(m: &Bound<'_, PyModule>) -> PyResult<()> {
+    register(m)
 }

--- a/crates/floe-python/src/types/outcome.rs
+++ b/crates/floe-python/src/types/outcome.rs
@@ -48,6 +48,24 @@ impl From<DryRunEntityPreview> for DryRunPreviewData {
     }
 }
 
+impl DryRunPreviewData {
+    fn from_dict(d: &Bound<'_, PyAny>) -> PyResult<Self> {
+        Ok(DryRunPreviewData {
+            name: d.get_item("name")?.extract()?,
+            input_path: d.get_item("input_path")?.extract()?,
+            input_format: d.get_item("input_format")?.extract()?,
+            accepted_path: d.get_item("accepted_path")?.extract()?,
+            accepted_format: d.get_item("accepted_format")?.extract()?,
+            rejected_path: d.get_item("rejected_path")?.extract()?,
+            rejected_format: d.get_item("rejected_format")?.extract()?,
+            archive_path: d.get_item("archive_path")?.extract()?,
+            archive_storage: d.get_item("archive_storage")?.extract()?,
+            report_file: d.get_item("report_file")?.extract()?,
+            scanned_files: d.get_item("scanned_files")?.extract()?,
+        })
+    }
+}
+
 impl TryFrom<RunOutcome> for PyRunOutcome {
     type Error = serde_json::Error;
 
@@ -79,6 +97,46 @@ fn json_loads<'py>(py: Python<'py>, s: &str) -> PyResult<Bound<'py, PyAny>> {
 
 #[pymethods]
 impl PyRunOutcome {
+    /// Rebuild a lean `RunOutcome` from the `to_dict()` payload of a companion's
+    /// `RunOutcome`. The lean `_floe` and companion `_floe_duckdb` are separate
+    /// native libraries, so a companion-returned outcome is a *different* Python
+    /// class. Delegated DuckDB runs round-trip through this so callers always get
+    /// the lean `RunOutcome` type they imported, not the companion's.
+    #[staticmethod]
+    fn from_dict(data: Bound<'_, PyAny>) -> PyResult<Self> {
+        let py = data.py();
+        let json = py.import_bound("json")?;
+        let dumps = |obj: Bound<'_, PyAny>| -> PyResult<String> {
+            json.call_method1("dumps", (obj,))?.extract()
+        };
+        let run_id: String = data.get_item("run_id")?.extract()?;
+        let report_base_path: Option<String> = data.get_item("report_base_path")?.extract()?;
+        let dry_run: bool = data.get_item("dry_run")?.extract()?;
+        let summary_json = dumps(data.get_item("summary")?)?;
+        let mut entity_reports_json = Vec::new();
+        for item in data.get_item("entity_reports")?.iter()? {
+            entity_reports_json.push(dumps(item?)?);
+        }
+        let previews = data.get_item("dry_run_previews")?;
+        let dry_run_previews_data = if previews.is_none() {
+            None
+        } else {
+            let mut v = Vec::new();
+            for item in previews.iter()? {
+                v.push(DryRunPreviewData::from_dict(&item?)?);
+            }
+            Some(v)
+        };
+        Ok(PyRunOutcome {
+            run_id,
+            report_base_path,
+            dry_run,
+            summary_json,
+            entity_reports_json,
+            dry_run_previews_data,
+        })
+    }
+
     #[getter]
     fn summary(&self, py: Python<'_>) -> PyResult<PyObject> {
         Ok(json_loads(py, &self.summary_json)?.into_py(py))

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -111,8 +111,15 @@ off-PyPI index (the companion is too large for PyPI):
 
 ```bash
 pip install floe-python
-pip install floe-duckdb --extra-index-url https://malon64.github.io/floe/simple/
+pip install floe-duckdb --index-url https://malon64.github.io/floe/simple/
 ```
+
+> Use `--index-url` (not `--extra-index-url`) for the companion: `floe-duckdb` is
+> intentionally **not** on PyPI, and `--extra-index-url` would keep PyPI in play,
+> letting a squatted or higher-version `floe-duckdb` there shadow the real
+> off-PyPI wheel (dependency confusion). The companion's `floe-python` dependency
+> is already satisfied by the previous step, so consulting only the off-PyPI index
+> for the companion install resolves cleanly.
 
 The companion installs a `floe._floe_duckdb` extension into the same `floe` package.
 `floe.run(...)` then transparently delegates a DuckDB-sink run to it; without the

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -69,6 +69,58 @@ docker run --rm -v "$PWD:/work" ghcr.io/malon64/floe:latest run -c /work/example
 
 Cloud credentials should be provided via environment variables or runtime identity — not baked into the image.
 
+## DuckDB support (companion distribution)
+
+The default `floe` CLI, Docker image, and PyPI wheel are **lean**: they include the
+Parquet, Delta, and Iceberg sinks but **not** the DuckDB sink. DuckDB bundles a large
+native (C++) build that does not cross-compile in the release pipeline and exceeds
+PyPI's per-file size limit, so it ships as a separate **companion** that the lean
+`floe` transparently delegates to. There are three ways to get it:
+
+### 1. Docker image (recommended)
+
+```bash
+docker pull ghcr.io/malon64/floe-duckdb:latest
+docker run --rm -v "$PWD:/work" ghcr.io/malon64/floe-duckdb:latest run -c /work/config.yml
+```
+
+This image is multi-arch (linux/amd64 + linux/arm64) and runs DuckDB sinks directly.
+
+### 2. Companion binary on `PATH`
+
+Install the lean `floe` as usual, then place a `floe-duckdb` binary alongside it (same
+directory) or anywhere on your `PATH`. When `floe run` resolves a config that writes to
+a DuckDB sink, the lean binary automatically re-execs `floe-duckdb` with the same
+arguments. If no companion is found, the run fails with an install hint rather than a
+missing-feature error.
+
+Build the companion from source:
+
+```bash
+cargo build -p floe-cli --release --features duckdb
+cp target/release/floe target/release/floe-duckdb   # place on PATH next to floe
+```
+
+> For security, the companion is resolved **only** from `PATH` or the directory of the
+> running `floe` executable — never the current working directory.
+
+### 3. Python — off-PyPI `floe-duckdb` wheel
+
+Install the lean `floe` package from PyPI, then add the DuckDB companion wheel from the
+off-PyPI index (the companion is too large for PyPI):
+
+```bash
+pip install floe-python
+pip install floe-duckdb --extra-index-url https://malon64.github.io/floe/simple/
+```
+
+The companion installs a `floe._floe_duckdb` extension into the same `floe` package.
+`floe.run(...)` then transparently delegates a DuckDB-sink run to it; without the
+companion installed, such a run raises a `FloeConfigError` with install instructions.
+
+> DuckLake and remote-DuckDB (Quack) sinks are not yet available — they require a
+> DuckDB / Arrow upgrade that is currently blocked upstream.
+
 ## Troubleshooting
 
 - **`brew` not found**: install Homebrew from [brew.sh](https://brew.sh), then retry.

--- a/docs/sinks/duckdb.md
+++ b/docs/sinks/duckdb.md
@@ -16,7 +16,7 @@ of:
 - a `floe-duckdb` companion binary on your `PATH` (lean `floe run` auto-re-execs it when
   a config targets a DuckDB sink), or
 - the off-PyPI `floe-duckdb` Python wheel
-  (`pip install floe-duckdb --extra-index-url https://malon64.github.io/floe/simple/`).
+  (`pip install floe-duckdb --index-url https://malon64.github.io/floe/simple/`).
 
 See [installation → DuckDB support](../installation.md#duckdb-support-companion-distribution)
 for details. A lean build still *validates* and round-trips a DuckDB-sink config; only the

--- a/docs/sinks/duckdb.md
+++ b/docs/sinks/duckdb.md
@@ -5,6 +5,23 @@ Floe can write accepted output into a [DuckDB](https://duckdb.org) database — 
 database. Writes use DuckDB's bundled engine (DuckDB 1.5.0, native `MERGE INTO`) and Arrow
 ingestion, so source `RecordBatch`es feed DuckDB directly with no intermediate file.
 
+## Availability (companion distribution)
+
+The DuckDB sink is **not** compiled into the default `floe` CLI, Docker image, or PyPI
+wheel — its bundled native build is too large for the standard release artifacts. It
+ships as a separate companion that the lean `floe` transparently delegates to. Use any
+of:
+
+- the `ghcr.io/malon64/floe-duckdb` Docker image, or
+- a `floe-duckdb` companion binary on your `PATH` (lean `floe run` auto-re-execs it when
+  a config targets a DuckDB sink), or
+- the off-PyPI `floe-duckdb` Python wheel
+  (`pip install floe-duckdb --extra-index-url https://malon64.github.io/floe/simple/`).
+
+See [installation → DuckDB support](../installation.md#duckdb-support-companion-distribution)
+for details. A lean build still *validates* and round-trips a DuckDB-sink config; only the
+write path requires the companion.
+
 ## Local file target
 
 ```yaml


### PR DESCRIPTION
## Summary

Makes the existing **Local + MotherDuck DuckDB sinks** reachable by non-Rust users without a from-source build, using a **lean-primary + heavy-companion** model grounded in real-world precedents (git→git-lfs companion-on-PATH, cargo subcommands, ONNX Runtime split packages, PyTorch off-PyPI index) — not a bespoke design.

This is **distribution-only**: no engine/config changes, no Arrow bump. DuckLake + Quack sinks remain deferred (blocked upstream on an unpublished iceberg arrow-58 release, est. ~July 2026). Per SemVer this is a **patch bump (0.5.0 → 0.5.1)**.

### CLI
- Lean `floe` auto-delegates DuckDB-sink runs to a `floe-duckdb` companion (re-exec with identical argv, propagating exit status).
- Companion resolved **only** from `PATH` or the canonicalized executable dir — **never cwd** (git-lfs CVE GHSA-6rw3-3whw-jvjj). Missing companion → clear, actionable error.
- New `crates/floe-cli/src/delegate.rs` + wiring in `main.rs`; the full build (`--features duckdb`) executes directly.

### Docker
- New `Dockerfile.duckdb` (multi-stage, non-root) builds the full `ghcr.io/malon64/floe-duckdb` image.
- `release.yml` builds it per-arch on native runners (amd64 + arm64) and merges manifests via `buildx imagetools` — avoids the slow QEMU C++ bundle compile.

### Python
- New `floe-duckdb` wheel ships **only** the compiled `_floe_duckdb` `.so` (no python-source) so it coexists in the same `floe/` package dir as the lean PyPI wheel.
- Lean `floe.run` imports the companion module at runtime for DuckDB sinks; absent → clear off-PyPI install hint.
- Distributed **off-PyPI** via a PEP 503 simple index on gh-pages + wheels as GitHub Release assets (bundled native DuckDB exceeds PyPI's 100 MB limit and won't cross-compile in manylinux/musllinux).

### Versioning / docs
- All manifests bumped to **0.5.1** (`floe-core`, `floe-cli`, `floe-python` Cargo.toml + `pyproject.toml` + new `pyproject.duckdb.toml`); release.yml validate job extended to cover the new manifest.
- CHANGELOG, `docs/installation.md`, `docs/sinks/duckdb.md`, README updated with the three DuckDB channels and the auto-delegation behavior.

## Test plan
- [x] `cargo check -p floe-cli` green at 0.5.1
- [x] `crates/floe-cli/tests/delegate.rs` (3 tests): no-companion error, never resolves from cwd, delegates to PATH companion — all pass
- [x] floe-cli clippy clean (lean + `--features duckdb`)
- [x] maturin lean wheel build + 22 existing pytest pass with the new `run()` wrapper
- [x] Python delegation smoke test: `HAS_DUCKDB=False`, `config_targets_duckdb=True`, `run()` raises with install hint
- [ ] CI: `docker-duckdb` per-arch build + manifest merge
- [ ] CI: `build-duckdb-wheel` native matrix + off-PyPI index render
- [ ] `release.yml workflow_dispatch dry_run=true` exercises new jobs without pushing