### PR TITLE
fix(release): ship floe-duckdb companion + bump to v0.5.2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -253,6 +253,31 @@ jobs:
       - name: Inspect
         run: docker buildx imagetools inspect "${IMAGE}:${VERSION}"
 
+  docker-duckdb-dryrun:
+    name: Validate floe-duckdb image build (dry-run)
+    runs-on: ubuntu-latest
+    needs: [meta, validate]
+    # The real publish path (docker-duckdb / docker-duckdb-merge) is gated to tag
+    # pushes, so a manual workflow_dispatch never exercises Dockerfile.duckdb —
+    # the blind spot that let a broken dependency-cache layer ship in v0.5.1.
+    # On a dry-run dispatch, build the image (linux/amd64, NO push) so the
+    # Dockerfile is validated end-to-end on a runner before a release tag is cut.
+    # Reuses the amd64 gha cache scope, so a green dry-run warms the real build.
+    if: ${{ needs.meta.outputs.on_main == 'true' && github.event_name == 'workflow_dispatch' && inputs.dry_run == true }}
+    steps:
+      - uses: actions/checkout@v6
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+      - name: Build floe-duckdb image (no push)
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: ./Dockerfile.duckdb
+          platforms: linux/amd64
+          push: false
+          cache-from: type=gha,scope=duckdb-amd64
+          cache-to: type=gha,mode=max,scope=duckdb-amd64
+
   build-duckdb-wheel:
     name: Build floe-duckdb wheel (${{ matrix.target }} on ${{ matrix.os }})
     needs: [meta, validate]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 All notable changes to Floe are documented in this file.
 
+## v0.5.2
+
+- **Fixes the v0.5.1 release pipeline so the DuckDB companion actually ships.** v0.5.1
+  published the lean `floe` (PyPI wheel + `ghcr.io/malon64/floe` image) correctly, but
+  the `floe-duckdb` companion image and off-PyPI wheel never published because the
+  companion image build failed. `Dockerfile.duckdb`'s dependency-cache layer copied
+  `crates/floe-python/Cargo.toml` (which declares an explicit `[lib] name = "_floe"`)
+  without its source, so `cargo fetch` failed parsing the workspace manifest
+  (*"can't find library `_floe`"*). The fetch layer now stubs
+  `crates/floe-python/src/lib.rs` before fetching; the real source replaces it in the
+  subsequent `COPY`. This path was invisible to release dry-runs because the Docker
+  jobs are gated off on dry-runs.
+- No engine or API changes: distribution-only patch. The DuckDB sink behavior, config
+  surface, and supported targets (Local + MotherDuck) are identical to v0.5.0/v0.5.1.
+
 ## v0.5.1
 
 - **DuckDB is now available to non-Rust users via a lean-primary + heavy-companion

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3508,7 +3508,7 @@ dependencies = [
 
 [[package]]
 name = "floe-cli"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "assert_cmd",
  "clap",
@@ -3521,7 +3521,7 @@ dependencies = [
 
 [[package]]
 name = "floe-core"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "apache-avro 0.16.0",
  "arrow",
@@ -3565,7 +3565,7 @@ dependencies = [
 
 [[package]]
 name = "floe-python"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "floe-core",
  "pyo3",

--- a/Dockerfile.duckdb
+++ b/Dockerfile.duckdb
@@ -14,6 +14,12 @@ COPY crates/floe-core/Cargo.toml crates/floe-core/Cargo.toml
 COPY crates/floe-cli/Cargo.toml crates/floe-cli/Cargo.toml
 COPY crates/floe-python/Cargo.toml crates/floe-python/Cargo.toml
 
+# floe-python declares an explicit [lib] (name = "_floe"), which cargo validates
+# while parsing the workspace manifest — so its lib source must exist even for
+# the dependency-only fetch layer. Stub it; the real source replaces it via the
+# `COPY crates crates` below.
+RUN mkdir -p crates/floe-python/src && touch crates/floe-python/src/lib.rs
+
 RUN cargo fetch --locked
 
 # Copy the full source and build with the duckdb feature on top of the default

--- a/crates/floe-cli/Cargo.toml
+++ b/crates/floe-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "floe-cli"
-version = "0.5.1"
+version = "0.5.2"
 edition = "2021"
 description = "CLI for Floe, a YAML-driven technical ingestion tool."
 license = "MIT"
@@ -17,7 +17,7 @@ path = "src/main.rs"
 
 [dependencies]
 clap = { version = "4", features = ["derive"] }
-floe-core = { path = "../floe-core", version = "0.5.1", default-features = false }
+floe-core = { path = "../floe-core", version = "0.5.2", default-features = false }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 

--- a/crates/floe-core/Cargo.toml
+++ b/crates/floe-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "floe-core"
-version = "0.5.1"
+version = "0.5.2"
 edition = "2021"
 description = "Core library for Floe, a YAML-driven technical ingestion tool."
 license = "MIT"

--- a/crates/floe-python/Cargo.toml
+++ b/crates/floe-python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "floe-python"
-version = "0.5.1"
+version = "0.5.2"
 edition = "2021"
 description = "Python bindings for floe-core (PyO3-based)"
 license = "Apache-2.0"
@@ -13,7 +13,7 @@ name = "_floe"
 crate-type = ["cdylib"]
 
 [dependencies]
-floe-core = { path = "../floe-core", version = "0.5.1", default-features = false }
+floe-core = { path = "../floe-core", version = "0.5.2", default-features = false }
 pyo3 = { version = "0.22", features = ["extension-module", "abi3-py310"] }
 serde_json = "1"
 

--- a/crates/floe-python/pyproject.duckdb.toml
+++ b/crates/floe-python/pyproject.duckdb.toml
@@ -22,7 +22,7 @@ build-backend = "maturin"
 
 [project]
 name = "floe-duckdb"
-version = "0.5.1"
+version = "0.5.2"
 description = "DuckDB companion extension for floe — adds the native DuckDB sink to the floe Python package"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -46,7 +46,7 @@ classifiers = [
 # only contributes the compiled DuckDB extension module into that package. Pin to
 # the exact lean version so the companion's `_floe_duckdb` ABI always matches the
 # `floe` package it plugs into.
-dependencies = ["floe-python==0.5.1"]
+dependencies = ["floe-python==0.5.2"]
 
 [project.urls]
 Homepage = "https://github.com/malon64/floe"

--- a/crates/floe-python/pyproject.toml
+++ b/crates/floe-python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "floe-python"
-version = "0.5.1"
+version = "0.5.2"
 description = "Python bindings for floe-core — run floe pipelines at Rust speed from Python and notebooks"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary

The **v0.5.1 CD run** (27139637216) shipped the **lean** `floe` correctly
(PyPI `floe-python 0.5.1`, `ghcr.io/malon64/floe:0.5.1`) but the **DuckDB
companion never published**. Two independent failures:

1. **`floe-duckdb` image build (amd64 + arm64) — code bug.**
   `Dockerfile.duckdb`'s dependency-cache layer copies
   `crates/floe-python/Cargo.toml` (which has an explicit `[lib] name = "_floe"`)
   without its source, so `cargo fetch --locked` fails parsing the workspace
   manifest: *"can't find library `_floe`"*. Fixed by stubbing
   `crates/floe-python/src/lib.rs` before the fetch; `COPY crates crates`
   replaces it with the real source. (Invisible to release dry-runs — Docker
   jobs are gated off on dry-runs.)
2. **`release` job — transient `download-artifact` flake** ("failed after 5
   retries"), unrelated to code. It left the `v0.5.1` GitHub Release with 0
   assets and skipped Homebrew/Scoop. A clean re-release fixes this.

Because `floe-python 0.5.1` is **immutable on PyPI** (the publish step has no
`skip-existing`), the `v0.5.1` tag cannot be re-run on the same version. This PR
**bumps all manifests to v0.5.2** so a fresh tag produces a complete release:
lean archives + Homebrew + Scoop + PyPI + lean image **and** the `floe-duckdb`
image + off-PyPI wheel.

Distribution-only patch — no engine/API/config changes (Local + MotherDuck
DuckDB targets unchanged).

## Changes
- `Dockerfile.duckdb`: stub `crates/floe-python/src/lib.rs` before `cargo fetch`.
- Bump to `0.5.2`: floe-core/floe-cli/floe-python Cargo.toml + internal dep refs,
  `pyproject.toml`, `pyproject.duckdb.toml` (incl. `floe-python==0.5.2` pin),
  `Cargo.lock`.
- `CHANGELOG.md`: v0.5.2 entry.

## Test plan
- [ ] CI green on this PR.
- [ ] Local: `Dockerfile.duckdb` build progresses past `cargo fetch` (verified —
      manifest-parse error gone).
- [ ] After merge, tag `v0.5.2`; confirm `docker-duckdb`, `docker-duckdb-merge`,
      `build-duckdb-wheel`, `publish-duckdb-wheel`, and `release` all succeed.