### PR TITLE
fix(release): scope release-job artifact download; bump to v0.5.3

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -550,6 +550,13 @@ jobs:
       - name: Download artifacts
         uses: actions/download-artifact@v7
         with:
+          # Only the platform binary archives are needed here (GH Release assets +
+          # checksums for the Homebrew/Scoop formulae). Without this pattern the
+          # step downloads every run artifact — incl. the ~80 MB DuckDB wheels and
+          # ~70 MB Python wheels (~1.1 GB total) — which intermittently fails the
+          # download "after 5 retries". The DuckDB wheels are handled separately by
+          # publish-duckdb-wheel (pattern: duckdb-wheel-*).
+          pattern: dist-*
           path: dist
           merge-multiple: true
       - name: Create GitHub Release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 All notable changes to Floe are documented in this file.
 
+## v0.5.3
+
+- **Fixes the release pipeline so the GitHub Release assets, Homebrew/Scoop
+  formulae, and off-PyPI `floe-duckdb` wheel actually publish.** In v0.5.2 the
+  `release` job's `Download artifacts` step had no `pattern`, so it pulled *every*
+  run artifact (~1.1 GB — including the ~80 MB DuckDB wheels and ~70 MB Python
+  wheels) and intermittently failed the download "after 5 retries", which left the
+  GitHub Release with no binary assets and skipped the dependent off-PyPI wheel
+  publish. The step is now scoped to `pattern: dist-*` (only the platform binary
+  archives it actually needs for the release assets and Homebrew/Scoop checksums);
+  the DuckDB wheels remain handled by the separately-scoped `publish-duckdb-wheel`
+  job. This was invisible to dry-runs because the `release` job is gated off on
+  dry-runs.
+- No engine or API changes: distribution-only patch. The DuckDB sink behavior,
+  config surface, and supported targets (Local + MotherDuck) are identical to
+  v0.5.0–v0.5.2.
+
 ## v0.5.2
 
 - **Fixes the v0.5.1 release pipeline so the DuckDB companion actually ships.** v0.5.1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3508,7 +3508,7 @@ dependencies = [
 
 [[package]]
 name = "floe-cli"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "assert_cmd",
  "clap",
@@ -3521,7 +3521,7 @@ dependencies = [
 
 [[package]]
 name = "floe-core"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "apache-avro 0.16.0",
  "arrow",
@@ -3565,7 +3565,7 @@ dependencies = [
 
 [[package]]
 name = "floe-python"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "floe-core",
  "pyo3",

--- a/crates/floe-cli/Cargo.toml
+++ b/crates/floe-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "floe-cli"
-version = "0.5.2"
+version = "0.5.3"
 edition = "2021"
 description = "CLI for Floe, a YAML-driven technical ingestion tool."
 license = "MIT"
@@ -17,7 +17,7 @@ path = "src/main.rs"
 
 [dependencies]
 clap = { version = "4", features = ["derive"] }
-floe-core = { path = "../floe-core", version = "0.5.2", default-features = false }
+floe-core = { path = "../floe-core", version = "0.5.3", default-features = false }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 

--- a/crates/floe-core/Cargo.toml
+++ b/crates/floe-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "floe-core"
-version = "0.5.2"
+version = "0.5.3"
 edition = "2021"
 description = "Core library for Floe, a YAML-driven technical ingestion tool."
 license = "MIT"

--- a/crates/floe-python/Cargo.toml
+++ b/crates/floe-python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "floe-python"
-version = "0.5.2"
+version = "0.5.3"
 edition = "2021"
 description = "Python bindings for floe-core (PyO3-based)"
 license = "Apache-2.0"
@@ -13,7 +13,7 @@ name = "_floe"
 crate-type = ["cdylib"]
 
 [dependencies]
-floe-core = { path = "../floe-core", version = "0.5.2", default-features = false }
+floe-core = { path = "../floe-core", version = "0.5.3", default-features = false }
 pyo3 = { version = "0.22", features = ["extension-module", "abi3-py310"] }
 serde_json = "1"
 

--- a/crates/floe-python/pyproject.duckdb.toml
+++ b/crates/floe-python/pyproject.duckdb.toml
@@ -22,7 +22,7 @@ build-backend = "maturin"
 
 [project]
 name = "floe-duckdb"
-version = "0.5.2"
+version = "0.5.3"
 description = "DuckDB companion extension for floe — adds the native DuckDB sink to the floe Python package"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -46,7 +46,7 @@ classifiers = [
 # only contributes the compiled DuckDB extension module into that package. Pin to
 # the exact lean version so the companion's `_floe_duckdb` ABI always matches the
 # `floe` package it plugs into.
-dependencies = ["floe-python==0.5.2"]
+dependencies = ["floe-python==0.5.3"]
 
 [project.urls]
 Homepage = "https://github.com/malon64/floe"

--- a/crates/floe-python/pyproject.toml
+++ b/crates/floe-python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "floe-python"
-version = "0.5.2"
+version = "0.5.3"
 description = "Python bindings for floe-core — run floe pipelines at Rust speed from Python and notebooks"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary
- Scopes the `release` job's `Download artifacts` step to `pattern: dist-*`. It previously had no pattern and downloaded *every* run artifact (~1.1 GB incl. the ~80 MB DuckDB wheels and ~70 MB Python wheels), intermittently failing the download **"after 5 retries"** — which left the v0.5.2 GitHub Release with **0 binary assets** and skipped the dependent off-PyPI wheel publish.
- The DuckDB wheels remain handled by the separately-scoped `publish-duckdb-wheel` job (`pattern: duckdb-wheel-*`); the release job only needs the platform archives for the Release assets + Homebrew/Scoop checksums.
- Bumps all manifests `0.5.2 → 0.5.3` (Cargo + pyproject + lock) and adds a CHANGELOG entry.

## Why a new version
The fix only takes effect on a **fresh** tagged run — re-running the existing v0.5.2 tag executes the workflow file from the tag commit, which still has the unscoped download. v0.5.2 already published `floe-core`/`floe-cli` (crates.io), `floe-python` (PyPI), and both Docker images, but the structural `release` failure blocked the GH Release assets, Homebrew/Scoop bump, and off-PyPI `floe-duckdb` wheel. v0.5.3 re-runs the corrected pipeline end-to-end. Distribution-only patch — no engine/API/config changes.

## Test plan
- [ ] Manifest-version validation job passes (all 5 manifests + 2 internal dep refs == tag).
- [ ] `release` job downloads only `dist-*` and attaches the 5 platform archives as GH Release assets.
- [ ] `publish-duckdb-wheel` runs (no longer skipped) and publishes the off-PyPI wheel + PEP503 index.
- [ ] Homebrew/Scoop formulae bump to 0.5.3.