### PR TITLE
feat(dagster-floe): add Floe branding badge to Dagster asset UI

### DIFF
--- a/orchestrators/dagster-floe/src/floe_dagster/assets.py
+++ b/orchestrators/dagster-floe/src/floe_dagster/assets.py
@@ -190,6 +190,7 @@ def _make_entity_multi_asset(
         group_name=group_name,
         check_specs=build_asset_check_specs(accepted_key),
         can_subset=False,
+        compute_kind="floe",
     )
     def _multi_asset(context):
         run = getattr(context, "run", None)


### PR DESCRIPTION
## What

Adds `compute_kind="floe"` to the `@multi_asset` decorator in `_make_entity_multi_asset()`.

## Why

The Dagster UI renders a small branded badge on each asset node (bottom-right corner) based on the `compute_kind` parameter. Integrations like `dagster-dbt` and `dagster-duckdb` use this to surface their logo/name. Floe assets had no badge at all — this brings them in line with the rest of the ecosystem.

## Change

Single-line addition in `orchestrators/dagster-floe/src/floe_dagster/assets.py`:

```python
@multi_asset(
    ...
    compute_kind="floe",   # ← new
)
```

## Reviewer notes

- No manifest schema changes, no new dependencies, no breaking changes.
- Dagster does not have a built-in icon for `"floe"` (only for well-known tools like dbt/duckdb/spark), so the UI will render a styled text pill — the standard treatment for third-party integrations.
- A follow-on can add the Floe SVG logo to Dagster's upstream icon registry if desired.