### PR TITLE
fix(python): resolve DuckDB companion under both module layouts; bump to v0.5.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -213,6 +213,15 @@ jobs:
           .venv/bin/pip install "maturin>=1.7,<2" pytest mypy
       - name: Build and install floe-python
         if: steps.changes.outputs.floe_python == 'true'
+        # Match the memory discipline of the "Run tests" step above. Without
+        # `-C debuginfo=0` maturin links `lib_floe.so` with full debug info, whose
+        # oversized object files make the bundled `lld` exceed the runner's
+        # memory/disk during the output write and abort with
+        # `ld terminated with signal 7 [Bus error], core dumped`. The flag keeps
+        # the cdylib link small enough to succeed (Python tests don't need symbols).
+        env:
+          CARGO_BUILD_JOBS: "4"
+          RUSTFLAGS: "-C debuginfo=0"
         run: .venv/bin/maturin develop --manifest-path crates/floe-python/Cargo.toml
       - name: Run Python tests
         if: steps.changes.outputs.floe_python == 'true'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,8 +19,21 @@ All notable changes to Floe are documented in this file.
   `https://malon64.github.io/floe/simple/` requires **GitHub Pages** to be enabled
   on the repository (source `gh-pages`); the release pipeline pushes the index to
   that branch but cannot enable Pages itself.
-- Distribution-only patch — no engine/API/config changes; DuckDB sink behavior and
-  supported targets (Local + MotherDuck) are unchanged.
+- **Fixes four OpenLineage emission bugs that made Floe's OL events unusable by
+  OpenMetadata 1.12.x and other strict consumers** (fixes #382, PR #386):
+  - S3 input dataset names no longer carry a leading slash (`split_storage_uri` now
+    drops the `/` separator, so `s3://bucket/path` splits into `("s3://bucket", "path")`).
+  - `runId` is now a spec-valid UUID v4 (a single `Uuid::new_v4()` is generated at
+    `RunStarted` and reused at `RunFinished`; each entity gets its own UUID) instead
+    of the raw timestamp-based run ID that OpenMetadata silently dropped.
+  - `inputs`/`outputs` now use resolvable storage coordinates (Iceberg → catalog
+    namespace + `{ns}.{table}`; all other sinks → `split_storage_uri` on the storage
+    path) instead of unmappable logical names, so lineage edges are derivable. The
+    redundant symlinks facets are removed.
+  - Entity job names no longer prepend the OL namespace (it already lives in the job
+    object's `namespace` field).
+- The DuckDB distribution changes above are distribution-only — DuckDB sink behavior
+  and supported targets (Local + MotherDuck) are unchanged.
 
 ## v0.5.3
 
@@ -91,6 +104,13 @@ All notable changes to Floe are documented in this file.
   - See [DuckDB sink](docs/sinks/duckdb.md) and [installation](docs/installation.md).
 
 - **`floe` 0.5.1**: version bump for this release.
+
+## dagster-floe v0.2.3
+
+- **Floe assets now carry a `compute_kind="floe"` branding badge** (PR #384):
+  - Every asset materialized by `dagster-floe` displays a "floe" compute-kind badge
+    in the Dagster UI, consistent with how `dagster-dbt` and `dagster-duckdb` brand
+    their assets. Cosmetic/UX only — no change to asset keys, execution, or run config.
 
 ## dagster-floe v0.2.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 All notable changes to Floe are documented in this file.
 
+## v0.5.4
+
+- **Fixes the Python DuckDB companion so `floe.run()` actually delegates to it.**
+  The off-PyPI `floe-duckdb` wheel installs its native extension as a **top-level
+  `_floe_duckdb`** package (maturin's pure-Rust layout), but the lean `floe`
+  wrapper only looked for the nested `floe._floe_duckdb` submodule via
+  `importlib.util.find_spec`. The two never matched, so a DuckDB-sink run on an
+  install that *had* the companion still raised *"the `floe-duckdb` companion
+  wheel is not installed"* — the Python DuckDB channel was non-functional as
+  shipped. The wrapper now accepts **both** layouts (`floe._floe_duckdb` and
+  top-level `_floe_duckdb`), preferring the nested name when present. Verified
+  end-to-end against the published `floe-duckdb` wheel: a `merge_scd1` DuckDB sink
+  inserts on first run and upserts idempotently on re-run.
+- Operational note (no code change): the off-PyPI PEP 503 index at
+  `https://malon64.github.io/floe/simple/` requires **GitHub Pages** to be enabled
+  on the repository (source `gh-pages`); the release pipeline pushes the index to
+  that branch but cannot enable Pages itself.
+- Distribution-only patch — no engine/API/config changes; DuckDB sink behavior and
+  supported targets (Local + MotherDuck) are unchanged.
+
 ## v0.5.3
 
 - **Fixes the release pipeline so the GitHub Release assets, Homebrew/Scoop

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3508,7 +3508,7 @@ dependencies = [
 
 [[package]]
 name = "floe-cli"
-version = "0.5.3"
+version = "0.5.4"
 dependencies = [
  "assert_cmd",
  "clap",
@@ -3521,7 +3521,7 @@ dependencies = [
 
 [[package]]
 name = "floe-core"
-version = "0.5.3"
+version = "0.5.4"
 dependencies = [
  "apache-avro 0.16.0",
  "arrow",
@@ -3565,7 +3565,7 @@ dependencies = [
 
 [[package]]
 name = "floe-python"
-version = "0.5.3"
+version = "0.5.4"
 dependencies = [
  "floe-core",
  "pyo3",

--- a/crates/floe-cli/Cargo.toml
+++ b/crates/floe-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "floe-cli"
-version = "0.5.3"
+version = "0.5.4"
 edition = "2021"
 description = "CLI for Floe, a YAML-driven technical ingestion tool."
 license = "MIT"
@@ -17,7 +17,7 @@ path = "src/main.rs"
 
 [dependencies]
 clap = { version = "4", features = ["derive"] }
-floe-core = { path = "../floe-core", version = "0.5.3", default-features = false }
+floe-core = { path = "../floe-core", version = "0.5.4", default-features = false }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 

--- a/crates/floe-core/Cargo.toml
+++ b/crates/floe-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "floe-core"
-version = "0.5.3"
+version = "0.5.4"
 edition = "2021"
 description = "Core library for Floe, a YAML-driven technical ingestion tool."
 license = "MIT"

--- a/crates/floe-python/Cargo.toml
+++ b/crates/floe-python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "floe-python"
-version = "0.5.3"
+version = "0.5.4"
 edition = "2021"
 description = "Python bindings for floe-core (PyO3-based)"
 license = "Apache-2.0"
@@ -13,7 +13,7 @@ name = "_floe"
 crate-type = ["cdylib"]
 
 [dependencies]
-floe-core = { path = "../floe-core", version = "0.5.3", default-features = false }
+floe-core = { path = "../floe-core", version = "0.5.4", default-features = false }
 pyo3 = { version = "0.22", features = ["extension-module", "abi3-py310"] }
 serde_json = "1"
 

--- a/crates/floe-python/pyproject.duckdb.toml
+++ b/crates/floe-python/pyproject.duckdb.toml
@@ -22,7 +22,7 @@ build-backend = "maturin"
 
 [project]
 name = "floe-duckdb"
-version = "0.5.3"
+version = "0.5.4"
 description = "DuckDB companion extension for floe — adds the native DuckDB sink to the floe Python package"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -46,7 +46,7 @@ classifiers = [
 # only contributes the compiled DuckDB extension module into that package. Pin to
 # the exact lean version so the companion's `_floe_duckdb` ABI always matches the
 # `floe` package it plugs into.
-dependencies = ["floe-python==0.5.3"]
+dependencies = ["floe-python==0.5.4"]
 
 [project.urls]
 Homepage = "https://github.com/malon64/floe"

--- a/crates/floe-python/pyproject.toml
+++ b/crates/floe-python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "floe-python"
-version = "0.5.3"
+version = "0.5.4"
 description = "Python bindings for floe-core — run floe pipelines at Rust speed from Python and notebooks"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/crates/floe-python/python/floe/__init__.py
+++ b/crates/floe-python/python/floe/__init__.py
@@ -118,6 +118,15 @@ def clear_observer():
     return _lean_clear_observer()
 
 
+# The companion extension's import path depends on how maturin lays out the
+# off-PyPI `floe-duckdb` wheel. The intended layout nests it as the
+# `floe._floe_duckdb` submodule, but maturin — building a pure-Rust wheel with no
+# `floe/` python-source to nest under — emits the pyo3 `#[pymodule] _floe_duckdb`
+# as a TOP-LEVEL `_floe_duckdb` package instead. Accept both names so delegation
+# works regardless of the wheel's layout, preferring the nested name when present.
+_DUCKDB_MODULE_NAMES = ("floe._floe_duckdb", "_floe_duckdb")
+
+
 def _loaded_duckdb_module():
     """Return the companion module only if it is already imported, else None.
 
@@ -125,23 +134,32 @@ def _loaded_duckdb_module():
     companion load error. Used on paths (observer registration) where a broken
     companion must not surface until a DuckDB run is actually attempted.
     """
-    return sys.modules.get("floe._floe_duckdb")
+    for name in _DUCKDB_MODULE_NAMES:
+        module = sys.modules.get(name)
+        if module is not None:
+            return module
+    return None
 
 
 def _duckdb_module():
-    """Return the `floe._floe_duckdb` companion extension, or None if not installed.
+    """Return the `floe-duckdb` companion extension, or None if not installed.
 
     A genuinely absent companion maps to None. If the companion IS installed but
     its native extension fails to load (incompatible libc, unresolved symbol), the
     loader error is allowed to propagate so it surfaces instead of a misleading
     "companion wheel is not installed" hint. `find_spec` distinguishes the two:
-    `from floe import _floe_duckdb` would raise a plain ImportError for the absent
-    case too (attribute fallback), so the exception type alone cannot tell them
-    apart — but `find_spec` returns None only when the module is truly not there.
+    a bare import would raise a plain ImportError for the absent case too
+    (attribute fallback), so the exception type alone cannot tell them apart — but
+    `find_spec` returns None only when the module is truly not there.
+
+    The companion may resolve under either the nested `floe._floe_duckdb` name
+    (intended layout) or a top-level `_floe_duckdb` (maturin's actual pure-Rust
+    output); try both and import the first that resolves.
     """
-    if importlib.util.find_spec("floe._floe_duckdb") is None:
-        return None
-    return importlib.import_module("floe._floe_duckdb")
+    for name in _DUCKDB_MODULE_NAMES:
+        if importlib.util.find_spec(name) is not None:
+            return importlib.import_module(name)
+    return None
 
 
 def run(config_path, *args, **kwargs):

--- a/orchestrators/dagster-floe/pyproject.toml
+++ b/orchestrators/dagster-floe/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "dagster-floe"
-version = "0.2.2"
+version = "0.2.3"
 description = "Dagster connector for Floe CLI (config-driven ingestion)"
 requires-python = ">=3.10"
 readme = "README.md"


### PR DESCRIPTION
## Summary
- Fix the lean `floe` Python wrapper so it locates the off-PyPI `floe-duckdb` companion under **both** module layouts. The intended nested layout is `floe._floe_duckdb`, but maturin — building a pure-Rust wheel with no `floe/` python-source to nest under — emits the pyo3 `#[pymodule] _floe_duckdb` as a **top-level** `_floe_duckdb` package. The wrapper now probes both names (`floe._floe_duckdb`, `_floe_duckdb`), preferring the nested one, so `floe.run` delegation works regardless of the wheel layout.
- Bump all manifests `0.5.3 → 0.5.4` (PATCH; distribution/fix only — no DuckLake, no Quack, no arrow bump).

## Background
v0.5.3 shipped the companion wheel + off-PyPI index, but end-to-end testing revealed two issues:
1. **GitHub Pages was never enabled** for the off-PyPI PEP 503 index — fixed live via the Pages API (operational, no code change). Noted in the changelog.
2. **Module-path mismatch** — the installed companion lands as top-level `_floe_duckdb`, but the wrapper only probed `floe._floe_duckdb`, so `floe.run` wrongly reported the companion as "not installed". This PR fixes that probe.

A new lean wheel is required because the 0.5.3 PyPI wheel is immutable.

## Test plan
- [x] Verified the published 0.5.3 companion installs as top-level `_floe_duckdb` and exposes `run`/`HAS_DUCKDB`
- [x] Proved the DuckDB engine works end-to-end (3-row `merge_scd1` insert + idempotent re-run upsert)
- [x] Verified the patched wrapper resolves the companion and delegates `floe.run` successfully against the real wheel
- [x] `python -m py_compile` clean on the wrapper
- [ ] CI green (clippy / duckdb / test / rustfmt)
- [ ] Post-release: install lean `floe` 0.5.4 + companion, confirm `floe.run` delegates a DuckDB sink end-to-end