### PR TITLE
fix(lineage): fix four OpenLineage emission bugs blocking OL consumers

### DIFF
--- a/crates/floe-core/src/lineage/mod.rs
+++ b/crates/floe-core/src/lineage/mod.rs
@@ -4,6 +4,7 @@ use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use serde_json::{json, Value};
+use uuid::Uuid;
 
 use crate::config::{EntityConfig, LineageConfig};
 use crate::run::events::{RunEvent, RunObserver};
@@ -20,10 +21,15 @@ struct ColumnMapping {
     source_field: Option<String>,
 }
 
+struct OlDataset {
+    namespace: String,
+    name: String,
+}
+
 struct EntityUris {
-    source: String,
-    accepted: String,
-    rejected: Option<String>,
+    source: OlDataset,
+    accepted: OlDataset,
+    rejected: Option<OlDataset>,
 }
 
 pub struct OpenLineageObserver {
@@ -32,6 +38,7 @@ pub struct OpenLineageObserver {
     entity_start_ms: Mutex<HashMap<String, u128>>,
     entity_run_ids: Mutex<HashMap<String, String>>,
     run_start_ms: Mutex<Option<u128>>,
+    run_uuid: Mutex<Option<String>>,
     entity_schemas: HashMap<String, Vec<ColumnMapping>>,
     entity_uris: HashMap<String, EntityUris>,
     run_job_name: String,
@@ -87,12 +94,44 @@ impl OpenLineageObserver {
         let entity_uris = entities
             .iter()
             .map(|e| {
+                let (src_ns, src_name) = split_storage_uri(&e.source.path);
+                let source = OlDataset {
+                    namespace: src_ns,
+                    name: src_name,
+                };
+
+                let accepted = match e.sink.accepted.iceberg.as_ref() {
+                    Some(iceberg) => {
+                        let ns = iceberg.namespace.as_deref().unwrap_or(e.name.as_str());
+                        let tbl = iceberg.table.as_deref().unwrap_or(e.name.as_str());
+                        OlDataset {
+                            namespace: config.namespace.clone(),
+                            name: format!("{ns}.{tbl}"),
+                        }
+                    }
+                    None => {
+                        let (acc_ns, acc_name) = split_storage_uri(&e.sink.accepted.path);
+                        OlDataset {
+                            namespace: acc_ns,
+                            name: acc_name,
+                        }
+                    }
+                };
+
+                let rejected = e.sink.rejected.as_ref().map(|r| {
+                    let (rej_ns, rej_name) = split_storage_uri(&r.path);
+                    OlDataset {
+                        namespace: rej_ns,
+                        name: rej_name,
+                    }
+                });
+
                 (
                     e.name.clone(),
                     EntityUris {
-                        source: e.source.path.clone(),
-                        accepted: e.sink.accepted.path.clone(),
-                        rejected: e.sink.rejected.as_ref().map(|r| r.path.clone()),
+                        source,
+                        accepted,
+                        rejected,
                     },
                 )
             })
@@ -104,6 +143,7 @@ impl OpenLineageObserver {
             entity_start_ms: Mutex::new(HashMap::new()),
             entity_run_ids: Mutex::new(HashMap::new()),
             run_start_ms: Mutex::new(None),
+            run_uuid: Mutex::new(None),
             entity_schemas,
             entity_uris,
             run_job_name,
@@ -236,15 +276,12 @@ impl OpenLineageObserver {
         uris: Option<&EntityUris>,
     ) {
         let event_time = ms_to_iso8601(ts_ms);
-        let job_name = format!("{}.{name}", self.config.namespace);
 
         let mut run_facets = json!({});
         if let Some(parent) = self.parent_run_facet() {
             run_facets["parent"] = parent;
         }
 
-        // Build inputs/outputs based on whether stats and uris are present (COMPLETE/FAIL)
-        // or absent (START — keep both empty).
         let (inputs, outputs) = match (stats.as_ref(), uris) {
             (Some(s), Some(u)) => {
                 let rejection_rate = if s.rows > 0 {
@@ -253,18 +290,11 @@ impl OpenLineageObserver {
                     0.0
                 };
 
-                // Input: source dataset — sub-namespace avoids collision with real entity names.
-                let (src_ns, src_path) = split_storage_uri(&u.source);
                 let inputs = json!([{
-                    "namespace": format!("{}.source", self.config.namespace),
-                    "name": name,
-                    "facets": {
-                        "symlinks": symlinks_facet(self.producer(), &src_ns, &src_path, "DIRECTORY")
-                    }
+                    "namespace": u.source.namespace,
+                    "name": u.source.name
                 }]);
 
-                // Accepted output: entity name as logical identifier, TABLE type.
-                let (acc_ns, acc_path) = split_storage_uri(&u.accepted);
                 let schema_facet = json!({
                     "fields": s.schema_fields.iter().map(|col| {
                         json!({ "name": col.output_name, "type": col.column_type })
@@ -291,7 +321,6 @@ impl OpenLineageObserver {
                 });
 
                 let mut accepted_facets = json!({
-                    "symlinks": symlinks_facet(self.producer(), &acc_ns, &acc_path, "TABLE"),
                     "schema": schema_facet,
                     "dataQualityMetrics": accepted_dq_facet,
                     "floeQualityRun": floe_facet
@@ -305,8 +334,8 @@ impl OpenLineageObserver {
                             let src = col.source_field.as_deref().unwrap_or(&col.output_name);
                             let entry = json!({
                                 "inputFields": [{
-                                    "namespace": format!("{}.source", self.config.namespace),
-                                    "name": name,
+                                    "namespace": u.source.namespace,
+                                    "name": u.source.name,
                                     "field": src
                                 }]
                             });
@@ -321,14 +350,12 @@ impl OpenLineageObserver {
                 }
 
                 let mut out = vec![json!({
-                    "namespace": self.config.namespace,
-                    "name": name,
+                    "namespace": u.accepted.namespace,
+                    "name": u.accepted.name,
                     "facets": accepted_facets
                 })];
 
-                // Rejected output (when configured): DIRECTORY type, rejected-row quality metrics.
                 if let Some(ref rej) = u.rejected {
-                    let (rej_ns, rej_path) = split_storage_uri(rej);
                     let rejected_dq_facet = json!({
                         "rowCount": s.rejected,
                         "validCount": 0u64,
@@ -337,10 +364,9 @@ impl OpenLineageObserver {
                         "_schemaURL": "https://openlineage.io/spec/facets/1-0-2/DataQualityMetricsOutputDatasetFacet.json"
                     });
                     out.push(json!({
-                        "namespace": format!("{}.rejected", self.config.namespace),
-                        "name": name,
+                        "namespace": rej.namespace,
+                        "name": rej.name,
                         "facets": {
-                            "symlinks": symlinks_facet(self.producer(), &rej_ns, &rej_path, "DIRECTORY"),
                             "dataQualityMetrics": rejected_dq_facet
                         }
                     }));
@@ -360,7 +386,7 @@ impl OpenLineageObserver {
             },
             "job": {
                 "namespace": self.config.namespace,
-                "name": job_name,
+                "name": name,
                 "facets": {}
             },
             "inputs": inputs,
@@ -403,33 +429,29 @@ fn split_storage_uri(uri: &str) -> (String, String) {
         if let Some(after_scheme) = uri.strip_prefix(prefix) {
             if let Some(slash) = after_scheme.find('/') {
                 let authority = uri[..prefix.len() + slash].to_string();
-                let path = after_scheme[slash..].to_string();
+                let path = after_scheme[slash + 1..].to_string();
                 return (authority, path);
             }
-            return (uri.to_string(), "/".to_string());
+            return (uri.to_string(), String::new());
         }
     }
     ("file".to_string(), uri.to_string())
 }
 
-fn symlinks_facet(producer: &str, namespace: &str, name: &str, ds_type: &str) -> Value {
-    json!({
-        "identifiers": [{ "namespace": namespace, "name": name, "type": ds_type }],
-        "_producer": producer,
-        "_schemaURL": "https://openlineage.io/spec/facets/1-0-0/SymlinksDatasetFacet.json"
-    })
-}
-
 impl RunObserver for OpenLineageObserver {
     fn on_event(&self, event: RunEvent) {
         match event {
-            RunEvent::RunStarted { run_id, ts_ms, .. } => {
+            RunEvent::RunStarted { ts_ms, .. } => {
                 // Reset circuit breaker at the start of each run so a recovered endpoint
                 // is retried in subsequent runs within the same long-lived process.
                 self.consecutive_failures.store(0, Ordering::Relaxed);
                 self.circuit_open.store(false, Ordering::Relaxed);
                 if let Ok(mut guard) = self.run_start_ms.lock() {
                     *guard = Some(ts_ms);
+                }
+                let run_uuid = Uuid::new_v4().to_string();
+                if let Ok(mut guard) = self.run_uuid.lock() {
+                    *guard = Some(run_uuid.clone());
                 }
                 let event_time = ms_to_iso8601(ts_ms);
                 let mut run_facets = json!({});
@@ -440,7 +462,7 @@ impl RunObserver for OpenLineageObserver {
                     "eventType": "START",
                     "eventTime": event_time,
                     "run": {
-                        "runId": run_id,
+                        "runId": run_uuid,
                         "facets": run_facets
                     },
                     "job": {
@@ -455,14 +477,8 @@ impl RunObserver for OpenLineageObserver {
                 });
                 self.post_event(body);
             }
-            RunEvent::EntityStarted {
-                run_id,
-                name,
-                ts_ms,
-            } => {
-                // Use a per-entity run_id (overall_run_id.entity.name) so that
-                // the START and COMPLETE events for the same entity share the same run_id.
-                let entity_run_id = format!("{run_id}.entity.{name}");
+            RunEvent::EntityStarted { name, ts_ms, .. } => {
+                let entity_run_id = Uuid::new_v4().to_string();
                 if let Ok(mut guard) = self.entity_start_ms.lock() {
                     guard.insert(name.clone(), ts_ms);
                 }
@@ -515,17 +531,18 @@ impl RunObserver for OpenLineageObserver {
                     uris,
                 );
             }
-            RunEvent::RunFinished {
-                run_id,
-                status,
-                ts_ms,
-                ..
-            } => {
+            RunEvent::RunFinished { status, ts_ms, .. } => {
                 let event_type = if status == "failed" || status == "aborted" {
                     "FAIL"
                 } else {
                     "COMPLETE"
                 };
+                let run_uuid = self
+                    .run_uuid
+                    .lock()
+                    .ok()
+                    .and_then(|g| g.clone())
+                    .unwrap_or_else(|| Uuid::new_v4().to_string());
                 let event_time = ms_to_iso8601(ts_ms);
                 let mut run_facets = json!({});
                 if let Some(parent) = self.parent_run_facet() {
@@ -535,7 +552,7 @@ impl RunObserver for OpenLineageObserver {
                     "eventType": event_type,
                     "eventTime": event_time,
                     "run": {
-                        "runId": run_id,
+                        "runId": run_uuid,
                         "facets": run_facets
                     },
                     "job": {

--- a/crates/floe-core/tests/unit/run/lineage.rs
+++ b/crates/floe-core/tests/unit/run/lineage.rs
@@ -1,6 +1,6 @@
 use floe_core::config::{
-    ColumnConfig, EntityConfig, IncrementalMode, LineageConfig, PolicyConfig, PolicySeverity,
-    SchemaConfig, SinkConfig, SinkTarget, SourceConfig, WriteMode,
+    ColumnConfig, EntityConfig, IcebergSinkTargetConfig, IncrementalMode, LineageConfig,
+    PolicyConfig, PolicySeverity, SchemaConfig, SinkConfig, SinkTarget, SourceConfig, WriteMode,
 };
 use floe_core::lineage::OpenLineageObserver;
 use floe_core::run::events::{RunEvent, RunObserver};
@@ -253,7 +253,7 @@ fn entity_finished_event(name: &str, status: &str) -> RunEvent {
     }
 }
 
-// COMPLETE entity event uses entity name as logical dataset identifier (not raw storage path).
+// COMPLETE entity event uses actual storage paths as dataset namespace/name.
 #[test]
 fn entity_complete_event_has_source_input_and_accepted_output() {
     let mut server = mockito::Server::new();
@@ -270,8 +270,8 @@ fn entity_complete_event_has_source_input_and_accepted_output() {
         .match_body(mockito::Matcher::AllOf(vec![
             mockito::Matcher::PartialJson(json!({
                 "eventType": "COMPLETE",
-                "inputs": [{ "namespace": "test-ns.source", "name": "orders" }],
-                "outputs": [{ "name": "orders" }]
+                "inputs": [{ "namespace": "file", "name": "/data/in/" }],
+                "outputs": [{ "namespace": "file", "name": "/data/out/" }]
             })),
         ]))
         .with_status(200)
@@ -305,10 +305,10 @@ fn entity_complete_event_includes_rejected_output_when_configured() {
         .match_body(mockito::Matcher::AllOf(vec![
             mockito::Matcher::PartialJson(json!({
                 "eventType": "COMPLETE",
-                "inputs": [{ "namespace": "test-ns.source", "name": "orders" }],
+                "inputs": [{ "namespace": "file", "name": "/data/in/" }],
                 "outputs": [
-                    { "namespace": "test-ns", "name": "orders" },
-                    { "namespace": "test-ns.rejected", "name": "orders" }
+                    { "namespace": "file", "name": "/data/out/" },
+                    { "namespace": "file", "name": "/data/rejected/" }
                 ]
             })),
         ]))
@@ -327,9 +327,9 @@ fn entity_complete_event_includes_rejected_output_when_configured() {
     _complete_mock.assert();
 }
 
-// Source dataset carries a SymlinksDatasetFacet with type=DIRECTORY pointing at the real path.
+// Source dataset uses the actual storage path as namespace/name (no symlinks).
 #[test]
-fn source_dataset_has_symlinks_with_directory_type() {
+fn source_dataset_uses_storage_namespace_and_name() {
     let mut server = mockito::Server::new();
 
     let _start_mock = server
@@ -343,20 +343,20 @@ fn source_dataset_has_symlinks_with_directory_type() {
         .match_body(mockito::Matcher::PartialJson(json!({
             "eventType": "COMPLETE",
             "inputs": [{
-                "namespace": "test-ns.source",
-                "name": "orders",
-                "facets": {
-                    "symlinks": {
-                        "identifiers": [{ "name": "/data/in/", "type": "DIRECTORY" }]
-                    }
-                }
+                "namespace": "s3://my-bucket",
+                "name": "data/raw/"
             }]
         })))
         .with_status(200)
         .expect(1)
         .create();
 
-    let entity = make_entity("orders", "/data/in/", "/data/out/", None);
+    let entity = make_entity(
+        "orders",
+        "s3://my-bucket/data/raw/",
+        "s3://my-bucket/data/out/",
+        None,
+    );
     let config = make_config(&server.url(), None);
     let obs = OpenLineageObserver::new(&config, &[entity], "config.yml").unwrap();
 
@@ -367,9 +367,9 @@ fn source_dataset_has_symlinks_with_directory_type() {
     _complete_mock.assert();
 }
 
-// Accepted output carries a SymlinksDatasetFacet with type=TABLE pointing at the real path.
+// Accepted output uses the actual storage path as namespace/name (no symlinks).
 #[test]
-fn accepted_dataset_has_symlinks_with_table_type() {
+fn accepted_dataset_uses_storage_namespace_and_name() {
     let mut server = mockito::Server::new();
 
     let _start_mock = server
@@ -383,19 +383,20 @@ fn accepted_dataset_has_symlinks_with_table_type() {
         .match_body(mockito::Matcher::PartialJson(json!({
             "eventType": "COMPLETE",
             "outputs": [{
-                "name": "orders",
-                "facets": {
-                    "symlinks": {
-                        "identifiers": [{ "name": "/data/out/", "type": "TABLE" }]
-                    }
-                }
+                "namespace": "s3://my-bucket",
+                "name": "data/out/"
             }]
         })))
         .with_status(200)
         .expect(1)
         .create();
 
-    let entity = make_entity("orders", "/data/in/", "/data/out/", None);
+    let entity = make_entity(
+        "orders",
+        "s3://my-bucket/data/raw/",
+        "s3://my-bucket/data/out/",
+        None,
+    );
     let config = make_config(&server.url(), None);
     let obs = OpenLineageObserver::new(&config, &[entity], "config.yml").unwrap();
 
@@ -421,7 +422,7 @@ fn accepted_dataset_has_schema_facet() {
         .mock("POST", "/api/v1/lineage")
         .match_body(mockito::Matcher::PartialJson(json!({
             "eventType": "COMPLETE",
-            "outputs": [{ "name": "orders", "facets": { "schema": {} } }]
+            "outputs": [{ "name": "/data/out/", "facets": { "schema": {} } }]
         })))
         .with_status(200)
         .expect(1)
@@ -455,7 +456,6 @@ fn accepted_dq_reflects_accepted_rows_only() {
         .match_body(mockito::Matcher::PartialJson(json!({
             "eventType": "COMPLETE",
             "outputs": [{
-                "name": "orders",
                 "facets": {
                     "dataQualityMetrics": {
                         "rowCount": 90_u64,
@@ -499,8 +499,8 @@ fn rejected_dq_reflects_rejected_rows_only() {
             "outputs": [
                 {},
                 {
-                    "namespace": "test-ns.rejected",
-                    "name": "orders",
+                    "namespace": "file",
+                    "name": "/data/rejected/",
                     "facets": {
                         "dataQualityMetrics": {
                             "rowCount": 10_u64,
@@ -583,7 +583,7 @@ fn floe_quality_run_has_no_accepted_rejected_keys() {
     _bad_mock.assert();
 }
 
-// Cloud storage URIs are split correctly: s3://bucket/path → namespace=s3://bucket, name=/path/.
+// S3 URIs split into bucket namespace and slash-free path name.
 #[test]
 fn split_storage_uri_s3() {
     let mut server = mockito::Server::new();
@@ -599,17 +599,8 @@ fn split_storage_uri_s3() {
         .match_body(mockito::Matcher::PartialJson(json!({
             "eventType": "COMPLETE",
             "inputs": [{
-                "namespace": "test-ns.source",
-                "name": "orders",
-                "facets": {
-                    "symlinks": {
-                        "identifiers": [{
-                            "namespace": "s3://my-bucket",
-                            "name": "/data/raw/",
-                            "type": "DIRECTORY"
-                        }]
-                    }
-                }
+                "namespace": "s3://my-bucket",
+                "name": "data/raw/"
             }]
         })))
         .with_status(200)
@@ -632,7 +623,7 @@ fn split_storage_uri_s3() {
     _complete_mock.assert();
 }
 
-// ADLS URIs are split at the first path separator after the authority component.
+// ADLS URIs split at the first path separator after the authority component.
 #[test]
 fn split_storage_uri_adls() {
     let mut server = mockito::Server::new();
@@ -648,17 +639,8 @@ fn split_storage_uri_adls() {
         .match_body(mockito::Matcher::PartialJson(json!({
             "eventType": "COMPLETE",
             "inputs": [{
-                "namespace": "test-ns.source",
-                "name": "orders",
-                "facets": {
-                    "symlinks": {
-                        "identifiers": [{
-                            "namespace": "abfss://container@acct.dfs.core.windows.net",
-                            "name": "/raw/",
-                            "type": "DIRECTORY"
-                        }]
-                    }
-                }
+                "namespace": "abfss://container@acct.dfs.core.windows.net",
+                "name": "raw/"
             }]
         })))
         .with_status(200)
@@ -681,7 +663,7 @@ fn split_storage_uri_adls() {
     _complete_mock.assert();
 }
 
-// abfs:// URIs are preserved as-is in symlink identifiers (not normalised to abfss://).
+// abfs:// URIs are preserved as-is in the namespace (not normalised to abfss://).
 #[test]
 fn split_storage_uri_abfs_preserved() {
     let mut server = mockito::Server::new();
@@ -697,17 +679,8 @@ fn split_storage_uri_abfs_preserved() {
         .match_body(mockito::Matcher::PartialJson(json!({
             "eventType": "COMPLETE",
             "inputs": [{
-                "namespace": "test-ns.source",
-                "name": "orders",
-                "facets": {
-                    "symlinks": {
-                        "identifiers": [{
-                            "namespace": "abfs://container@acct.dfs.core.windows.net",
-                            "name": "/raw/",
-                            "type": "DIRECTORY"
-                        }]
-                    }
-                }
+                "namespace": "abfs://container@acct.dfs.core.windows.net",
+                "name": "raw/"
             }]
         })))
         .with_status(200)
@@ -787,7 +760,7 @@ fn make_column(name: &str, column_type: &str, source: Option<&str>) -> ColumnCon
     }
 }
 
-// columnLineage facet maps each output column to itself when no explicit source field is set.
+// columnLineage facet maps each output column to the source dataset's storage coordinates.
 #[test]
 fn accepted_dataset_has_column_lineage_facet() {
     let mut server = mockito::Server::new();
@@ -803,14 +776,13 @@ fn accepted_dataset_has_column_lineage_facet() {
         .match_body(mockito::Matcher::PartialJson(json!({
             "eventType": "COMPLETE",
             "outputs": [{
-                "name": "orders",
                 "facets": {
                     "columnLineage": {
                         "fields": {
                             "order_id": {
                                 "inputFields": [{
-                                    "namespace": "test-ns.source",
-                                    "name": "orders",
+                                    "namespace": "file",
+                                    "name": "/data/in/",
                                     "field": "order_id"
                                 }]
                             }
@@ -851,14 +823,13 @@ fn column_lineage_uses_source_field_when_set() {
         .match_body(mockito::Matcher::PartialJson(json!({
             "eventType": "COMPLETE",
             "outputs": [{
-                "name": "orders",
                 "facets": {
                     "columnLineage": {
                         "fields": {
                             "amount": {
                                 "inputFields": [{
-                                    "namespace": "test-ns.source",
-                                    "name": "orders",
+                                    "namespace": "file",
+                                    "name": "/data/in/",
                                     "field": "raw_amt"
                                 }]
                             }
@@ -922,4 +893,141 @@ fn circuit_resets_on_new_run_started() {
     );
     assert_eq!(obs.consecutive_failures(), 0);
     success_mock.assert();
+}
+
+// RunStarted emits a run_id that is a valid UUID v4 (not a timestamp string).
+#[test]
+fn run_started_emits_valid_uuid_run_id() {
+    let mut server = mockito::Server::new();
+
+    let _mock = server
+        .mock("POST", "/api/v1/lineage")
+        .match_body(mockito::Matcher::Regex(
+            r#""runId"\s*:\s*"[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}""#
+                .to_string(),
+        ))
+        .with_status(200)
+        .expect(1)
+        .create();
+
+    let config = make_config(&server.url(), None);
+    let obs = OpenLineageObserver::new(&config, &[], "config.yml").unwrap();
+
+    obs.on_event(run_started_event());
+    _mock.assert();
+}
+
+// EntityStarted emits a run_id that is a valid UUID v4 (not a derived string).
+#[test]
+fn entity_started_emits_valid_uuid_run_id() {
+    let mut server = mockito::Server::new();
+
+    let _mock = server
+        .mock("POST", "/api/v1/lineage")
+        .match_body(mockito::Matcher::Regex(
+            r#""runId"\s*:\s*"[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}""#
+                .to_string(),
+        ))
+        .with_status(200)
+        .expect(1)
+        .create();
+
+    let config = make_config(&server.url(), None);
+    let obs = OpenLineageObserver::new(&config, &[], "config.yml").unwrap();
+
+    obs.on_event(entity_started_event());
+    _mock.assert();
+}
+
+// Entity job name is the entity name alone, not namespace.entity_name.
+#[test]
+fn entity_job_name_is_entity_name_without_namespace_prefix() {
+    let mut server = mockito::Server::new();
+
+    let _start_mock = server
+        .mock("POST", "/api/v1/lineage")
+        .with_status(200)
+        .expect(1)
+        .create();
+
+    let _complete_mock = server
+        .mock("POST", "/api/v1/lineage")
+        .match_body(mockito::Matcher::PartialJson(json!({
+            "eventType": "COMPLETE",
+            "job": { "namespace": "test-ns", "name": "orders" }
+        })))
+        .with_status(200)
+        .expect(1)
+        .create();
+
+    let entity = make_entity("orders", "/data/in/", "/data/out/", None);
+    let config = make_config(&server.url(), None);
+    let obs = OpenLineageObserver::new(&config, &[entity], "config.yml").unwrap();
+
+    obs.on_event(entity_started_event());
+    obs.on_event(entity_finished_event("orders", "success"));
+
+    _start_mock.assert();
+    _complete_mock.assert();
+}
+
+// Iceberg sink: accepted output uses OL config namespace + iceberg namespace.table as name.
+#[test]
+fn iceberg_accepted_uses_catalog_namespace_and_table_name() {
+    let mut server = mockito::Server::new();
+
+    let _start_mock = server
+        .mock("POST", "/api/v1/lineage")
+        .with_status(200)
+        .expect(1)
+        .create();
+
+    let _complete_mock = server
+        .mock("POST", "/api/v1/lineage")
+        .match_body(mockito::Matcher::PartialJson(json!({
+            "eventType": "COMPLETE",
+            "inputs": [{ "namespace": "s3://iceberg-data", "name": "bronze/sales/customers" }],
+            "outputs": [{ "namespace": "test-ns", "name": "sales_dev.customers" }]
+        })))
+        .with_status(200)
+        .expect(1)
+        .create();
+
+    let mut entity = make_entity(
+        "customers",
+        "s3://iceberg-data/bronze/sales/customers",
+        "s3://warehouse/silver/customers",
+        None,
+    );
+    entity.sink.accepted.iceberg = Some(IcebergSinkTargetConfig {
+        catalog: None,
+        namespace: Some("sales_dev".to_string()),
+        table: Some("customers".to_string()),
+        location: None,
+    });
+
+    let config = make_config(&server.url(), None);
+    let obs = OpenLineageObserver::new(&config, &[entity], "config.yml").unwrap();
+
+    obs.on_event(RunEvent::EntityStarted {
+        run_id: "test-run-1".to_string(),
+        name: "customers".to_string(),
+        ts_ms: 1_001_000,
+    });
+    obs.on_event(RunEvent::EntityFinished {
+        run_id: "test-run-1".to_string(),
+        name: "customers".to_string(),
+        status: "success".to_string(),
+        files: 1,
+        files_skipped: 0,
+        rows: 50,
+        accepted: 50,
+        rejected: 0,
+        warnings: 0,
+        errors: 0,
+        ts_ms: 1_002_000,
+    });
+
+    _start_mock.assert();
+    _complete_mock.assert();
 }


### PR DESCRIPTION
Fixes all four bugs from #382 that collectively made Floe's OpenLineage events unusable by OpenMetadata 1.12.x and any strict OL consumer.

## What changed

### Bug 1 — S3 input dataset name had a leading slash
`split_storage_uri` returned `after_scheme[slash..]`, which included the `/` separator character. Fixed to `after_scheme[slash + 1..]` so `s3://bucket/path/to/data` correctly splits into `("s3://bucket", "path/to/data")`.

### Bug 2 — `runId` was not a UUID v4
Run-level events emitted the raw timestamp-based run ID (e.g. `2024-01-15T14-30-00Z`); entity events emitted `{run_id}.entity.{name}`. Both are invalid per the OL spec and cause OpenMetadata to silently drop every event. Added a `run_uuid: Mutex<Option<String>>` field; `RunStarted` now generates `Uuid::new_v4()`, stores it, and reuses it in `RunFinished`. `EntityStarted` generates an independent UUID per entity.

### Bug 3 — `inputs`/`outputs` carried unresolvable logical names
Primary `namespace`/`name` used `{ol_namespace}.source` / entity-name instead of actual storage coordinates. OL consumers cannot map these to registered datasets, so no lineage edges are derivable. Replaced the raw-path `EntityUris` struct with a pre-computed `OlDataset { namespace, name }` pair built in `new()`:
- **Iceberg sinks**: `namespace = config.namespace` (the catalog URL), `name = "{iceberg_ns}.{table}"`
- **All other sinks**: `split_storage_uri` on the storage path

Symlinks facets (previously the only place physical paths appeared) are removed now that the primary identifier is the storage coordinate.

### Bug 4 — Entity job name included the OL namespace as a prefix
`emit_entity_run_event` built `format!("{}.{name}", config.namespace)`. Changed to use `name` directly; the namespace is already in the separate `"namespace"` field of the job object.

## Tests

- 10 existing tests updated to assert the now-correct behavior (storage-level coordinates, no symlinks facets, entity name as job name)
- 4 new tests added:
  - `run_started_emits_valid_uuid_run_id`
  - `entity_started_emits_valid_uuid_run_id`
  - `entity_job_name_is_entity_name_without_namespace_prefix`
  - `iceberg_accepted_uses_catalog_namespace_and_table_name`
- All 573 unit tests pass (`cargo test -p floe-core -- unit::`)

## Checklist
- [x] `cargo fmt --all`
- [x] `cargo clippy -p floe-core -p floe-cli -p floe-python -- -D warnings` — clean
- [x] `cargo test -p floe-core` — 573/573 pass