### PR TITLE
chore(deps): supply-chain gates (cargo-deny + Dependabot), drop serde_yaml, migrate to official Azure SDK

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,33 @@
+version: 2
+updates:
+  - package-ecosystem: cargo
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    groups:
+      cargo-minor-and-patch:
+        update-types:
+          - minor
+          - patch
+    ignore:
+      # duckdb is pinned exactly (=1.10500.0): newer releases moved to arrow 58,
+      # which splits the RecordBatch type against floe-core's arrow 57. Unignore
+      # when the arrow 58 migration lands.
+      - dependency-name: "duckdb"
+      - dependency-name: "libduckdb-sys"
+
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+
+  - package-ecosystem: pip
+    directory: "/orchestrators/dagster-floe"
+    schedule:
+      interval: weekly
+
+  - package-ecosystem: pip
+    directory: "/orchestrators/airflow-floe"
+    schedule:
+      interval: weekly

--- a/.github/workflows/supply-chain.yml
+++ b/.github/workflows/supply-chain.yml
@@ -1,0 +1,27 @@
+name: Supply chain
+
+on:
+  pull_request:
+    paths:
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - "crates/**/Cargo.toml"
+      - "deny.toml"
+      - ".github/workflows/supply-chain.yml"
+  schedule:
+    # Weekly sweep so newly published RUSTSEC advisories surface even when no
+    # PR touches the dependency tree.
+    - cron: "0 6 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  cargo-deny:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: EmbarkStudios/cargo-deny-action@v2
+        with:
+          command: check advisories bans licenses sources

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,12 +3,6 @@
 version = 4
 
 [[package]]
-name = "RustyXML"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b5ace29ee3216de37c0546865ad08edef58b0f9e76838ed8959a84a990e58c5"
-
-[[package]]
 name = "adler2"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -28,7 +22,7 @@ checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
 dependencies = [
  "cfg-if",
  "cipher",
- "cpufeatures",
+ "cpufeatures 0.2.17",
 ]
 
 [[package]]
@@ -335,7 +329,7 @@ dependencies = [
  "arrow-schema",
  "arrow-select",
  "atoi",
- "base64 0.22.1",
+ "base64",
  "chrono",
  "comfy-table",
  "half",
@@ -384,7 +378,7 @@ dependencies = [
  "arrow-schema",
  "arrow-select",
  "flatbuffers",
- "lz4_flex 0.12.0",
+ "lz4_flex 0.12.1",
  "zstd",
 ]
 
@@ -514,17 +508,6 @@ dependencies = [
 
 [[package]]
 name = "async-channel"
-version = "1.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81953c529336010edd6d8e358f886d9581267795c61b19475b71314bffa46d35"
-dependencies = [
- "concurrent-queue",
- "event-listener 2.5.3",
- "futures-core",
-]
-
-[[package]]
-name = "async-channel"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
@@ -553,68 +536,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-io"
-version = "2.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "456b8a8feb6f42d237746d4b3e9a178494627745c3c56c6ea55d92ba50d026fc"
-dependencies = [
- "autocfg",
- "cfg-if",
- "concurrent-queue",
- "futures-io",
- "futures-lite 2.6.1",
- "parking",
- "polling",
- "rustix",
- "slab",
- "windows-sys 0.61.2",
-]
-
-[[package]]
 name = "async-lock"
 version = "3.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "290f7f2596bd5b78a9fec8088ccd89180d7f9f55b94b0576823bbbdc72ee8311"
 dependencies = [
- "event-listener 5.4.1",
+ "event-listener",
  "event-listener-strategy",
  "pin-project-lite",
-]
-
-[[package]]
-name = "async-process"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc50921ec0055cdd8a16de48773bfeec5c972598674347252c0399676be7da75"
-dependencies = [
- "async-channel 2.5.0",
- "async-io",
- "async-lock",
- "async-signal",
- "async-task",
- "blocking",
- "cfg-if",
- "event-listener 5.4.1",
- "futures-lite 2.6.1",
- "rustix",
-]
-
-[[package]]
-name = "async-signal"
-version = "0.2.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43c070bbf59cd3570b6b2dd54cd772527c7c3620fce8be898406dd3ed6adc64c"
-dependencies = [
- "async-io",
- "async-lock",
- "atomic-waker",
- "cfg-if",
- "futures-core",
- "futures-io",
- "rustix",
- "signal-hook-registry",
- "slab",
- "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -636,14 +565,8 @@ checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
-
-[[package]]
-name = "async-task"
-version = "4.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
 
 [[package]]
 name = "async-trait"
@@ -653,7 +576,7 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -705,7 +628,7 @@ dependencies = [
  "aws-smithy-types",
  "aws-types",
  "bytes",
- "fastrand 2.3.0",
+ "fastrand",
  "hex",
  "http 1.4.0",
  "ring",
@@ -730,9 +653,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.15.3"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e84ce723ab67259cfeb9877c6a639ee9eb7a27b28123abd71db7f0d5d0cc9d86"
+checksum = "5ec2f1fc3ec205783a5da9a7e6c1509cc69dedf09a1949e412c1e18469326d00"
 dependencies = [
  "aws-lc-sys",
  "untrusted 0.7.1",
@@ -741,9 +664,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.36.0"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43a442ece363113bd4bd4c8b18977a7798dd4d3c3383f34fb61936960e8f4ad8"
+checksum = "1a2f9779ce85b93ab6170dd940ad0169b5766ff848247aff13bb788b832fe3f4"
 dependencies = [
  "cc",
  "cmake",
@@ -767,7 +690,7 @@ dependencies = [
  "aws-smithy-types",
  "aws-types",
  "bytes",
- "fastrand 2.3.0",
+ "fastrand",
  "http 0.2.12",
  "http-body 0.4.6",
  "percent-encoding",
@@ -793,7 +716,7 @@ dependencies = [
  "aws-smithy-types",
  "aws-types",
  "bytes",
- "fastrand 2.3.0",
+ "fastrand",
  "http 0.2.12",
  "regex-lite",
  "tracing",
@@ -816,7 +739,7 @@ dependencies = [
  "aws-smithy-types",
  "aws-types",
  "bytes",
- "fastrand 2.3.0",
+ "fastrand",
  "http 0.2.12",
  "regex-lite",
  "tracing",
@@ -843,7 +766,7 @@ dependencies = [
  "aws-smithy-xml",
  "aws-types",
  "bytes",
- "fastrand 2.3.0",
+ "fastrand",
  "hex",
  "hmac",
  "http 0.2.12",
@@ -874,7 +797,7 @@ dependencies = [
  "aws-smithy-types",
  "aws-types",
  "bytes",
- "fastrand 2.3.0",
+ "fastrand",
  "http 0.2.12",
  "regex-lite",
  "tracing",
@@ -897,7 +820,7 @@ dependencies = [
  "aws-smithy-types",
  "aws-types",
  "bytes",
- "fastrand 2.3.0",
+ "fastrand",
  "http 0.2.12",
  "regex-lite",
  "tracing",
@@ -921,7 +844,7 @@ dependencies = [
  "aws-smithy-types",
  "aws-smithy-xml",
  "aws-types",
- "fastrand 2.3.0",
+ "fastrand",
  "http 0.2.12",
  "regex-lite",
  "tracing",
@@ -1090,7 +1013,7 @@ dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
  "bytes",
- "fastrand 2.3.0",
+ "fastrand",
  "http 0.2.12",
  "http 1.4.0",
  "http-body 0.4.6",
@@ -1169,109 +1092,72 @@ dependencies = [
 
 [[package]]
 name = "azure_core"
-version = "0.20.0"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34ce3de4b65b1ee2667c81d1fc692949049502a4cf9c38118d811d6d79a7eaef"
+checksum = "fe6a26a7d374b440015cbbcbf2d9d8be5a133aa940599f5e5dc569504baa262e"
 dependencies = [
+ "async-lock",
  "async-trait",
- "base64 0.22.1",
+ "azure_core_macros",
  "bytes",
- "dyn-clone",
  "futures",
- "getrandom 0.2.17",
- "hmac",
- "http-types",
- "once_cell",
- "paste",
  "pin-project",
- "quick-xml 0.31.0",
- "rand 0.8.5",
- "reqwest",
  "rustc_version",
  "serde",
  "serde_json",
- "sha2",
- "time",
+ "tokio",
  "tracing",
- "url",
- "uuid",
+ "typespec",
+ "typespec_client_core",
+]
+
+[[package]]
+name = "azure_core_macros"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9b52dba6a345f3ad2d42ff8d0d63df9d0994cfa29657bf18ffdbf149f78a4f5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "tracing",
 ]
 
 [[package]]
 name = "azure_identity"
-version = "0.20.0"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72c97790480791ec1ee9b76f5c6499b1d0aac0d4cd1e62010bfc19bb545544c5"
+checksum = "32edf96b356ca7c51d7590c4925cc36efc3947a5da4468e8e0b25c56ecbb3de5"
 dependencies = [
  "async-lock",
- "async-process",
  "async-trait",
  "azure_core",
  "futures",
- "oauth2",
  "pin-project",
  "serde",
+ "serde_json",
  "time",
  "tracing",
- "tz-rs",
  "url",
- "uuid",
 ]
 
 [[package]]
-name = "azure_storage"
-version = "0.20.0"
+name = "azure_storage_blob"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9713002fc30956a9f4061cdbc2e912ff739c6160e138ad3b6d992b3bcedccc6d"
+checksum = "1756febbcca86c862ef718b983b505d08bd65a9bc984a915b0a16af4a4c3fe5b"
 dependencies = [
- "RustyXML",
- "async-lock",
+ "async-stream",
  "async-trait",
  "azure_core",
  "bytes",
- "serde",
- "serde_derive",
- "time",
- "tracing",
- "url",
- "uuid",
-]
-
-[[package]]
-name = "azure_storage_blobs"
-version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5b3a31dd8f920739437b827d0c9f9a4011eb3f06f79a121764aa11af6c51ee2"
-dependencies = [
- "RustyXML",
- "azure_core",
- "azure_storage",
- "azure_svc_blobstorage",
- "bytes",
  "futures",
- "serde",
- "serde_derive",
- "serde_json",
- "time",
- "tracing",
- "url",
- "uuid",
-]
-
-[[package]]
-name = "azure_svc_blobstorage"
-version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ef37ba6180df451042f1c277d4d0898e2447f0a5d5072e0ff11ee6ea5e7ef38"
-dependencies = [
- "azure_core",
- "bytes",
- "futures",
- "log",
- "once_cell",
+ "percent-encoding",
+ "pin-project",
  "serde",
  "serde_json",
  "time",
+ "tokio",
 ]
 
 [[package]]
@@ -1280,7 +1166,7 @@ version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cffb0e931875b666fc4fcb20fee52e9bbd1ef836fd9e9e04ec21555f9f85f7ef"
 dependencies = [
- "fastrand 2.3.0",
+ "fastrand",
  "gloo-timers",
  "tokio",
 ]
@@ -1290,12 +1176,6 @@ name = "base16ct"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "349a06037c7bf932dd7e7d1f653678b2038b9ad46a74102f1fc7bd7872678cce"
-
-[[package]]
-name = "base64"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
 name = "base64"
@@ -1400,7 +1280,7 @@ dependencies = [
  "cc",
  "cfg-if",
  "constant_time_eq",
- "cpufeatures",
+ "cpufeatures 0.2.17",
 ]
 
 [[package]]
@@ -1419,19 +1299,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8894febbff9f758034a5b8e12d87918f56dfc64a8e1fe757d65e29041538d93"
 dependencies = [
  "generic-array",
-]
-
-[[package]]
-name = "blocking"
-version = "1.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e83f8d02be6967315521be875afa792a316e28d57b5a2d401897e2a7921b7f21"
-dependencies = [
- "async-channel 2.5.0",
- "async-task",
- "futures-io",
- "futures-lite 2.6.1",
- "piper",
 ]
 
 [[package]]
@@ -1466,7 +1333,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1490,7 +1357,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1576,7 +1443,7 @@ checksum = "f9abbd1bc6865053c427f7198e6af43bfdedc55ab791faed4fbd361d789575ff"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1587,9 +1454,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b35204fbdc0b3f4446b89fc1ac2cf84a8a68971995d0bf2e925ec7cd960f9cb3"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 dependencies = [
  "serde",
 ]
@@ -1696,6 +1563,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "chacha20"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1760,7 +1638,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1800,6 +1678,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "combine"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+dependencies = [
+ "bytes",
+ "memchr",
 ]
 
 [[package]]
@@ -1864,12 +1752,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "const_fn"
-version = "0.4.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f8a2ca5ac02d09563609681103aada9e1777d54fc57a5acd7a41404f9c93b6e"
-
-[[package]]
 name = "constant_time_eq"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1924,6 +1806,15 @@ name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -2145,7 +2036,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2159,7 +2050,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2170,7 +2061,7 @@ checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
  "darling_core 0.20.11",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2181,7 +2072,7 @@ checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
 dependencies = [
  "darling_core 0.21.3",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2548,7 +2439,7 @@ checksum = "794a9db7f7b96b3346fc007ff25e994f09b8f0511b4cf7dff651fadfe3ebb28f"
 dependencies = [
  "arrow",
  "arrow-buffer",
- "base64 0.22.1",
+ "base64",
  "blake2",
  "blake3",
  "chrono",
@@ -2679,7 +2570,7 @@ checksum = "1063ad4c9e094b3f798acee16d9a47bd7372d9699be2de21b05c3bd3f34ab848"
 dependencies = [
  "datafusion-doc",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2913,7 +2804,7 @@ dependencies = [
  "itertools 0.14.0",
  "object_store",
  "parquet",
- "reqwest",
+ "reqwest 0.12.28",
  "roaring",
  "rustc_version",
  "serde",
@@ -2935,7 +2826,7 @@ checksum = "32a311416f16d4793d2aa35f2c76d36ab9b14c808eba00ef24759b47b666255e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3057,7 +2948,7 @@ dependencies = [
  "itertools 0.14.0",
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3100,9 +2991,9 @@ dependencies = [
 
 [[package]]
 name = "deranged"
-version = "0.5.5"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ececcb659e7ba858fb4f10388c250a7252eb0a27373f1a72b8748afdd248e587"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "powerfmt",
  "serde_core",
@@ -3116,7 +3007,7 @@ checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3137,7 +3028,7 @@ dependencies = [
  "darling 0.20.11",
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3147,7 +3038,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
 dependencies = [
  "derive_builder_core",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3210,7 +3101,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3364,12 +3255,6 @@ checksum = "ca81e6b4777c89fd810c25a4be2b1bd93ea034fbe58e6a75216a34c6b82c539b"
 
 [[package]]
 name = "event-listener"
-version = "2.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
-
-[[package]]
-name = "event-listener"
 version = "5.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
@@ -3385,7 +3270,7 @@ version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
 dependencies = [
- "event-listener 5.4.1",
+ "event-listener",
  "pin-project-lite",
 ]
 
@@ -3427,15 +3312,6 @@ dependencies = [
  "num-integer",
  "num-traits",
  "serde",
-]
-
-[[package]]
-name = "fastrand"
-version = "1.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e51093e27b0797c359783294ca4f0a911c270184cb10f85783b118614a1501be"
-dependencies = [
- "instant",
 ]
 
 [[package]]
@@ -3525,13 +3401,13 @@ version = "0.5.4"
 dependencies = [
  "apache-avro 0.16.0",
  "arrow",
+ "async-trait",
  "aws-config",
  "aws-sdk-glue",
  "aws-sdk-s3",
  "azure_core",
  "azure_identity",
- "azure_storage",
- "azure_storage_blobs",
+ "azure_storage_blob",
  "calamine",
  "deltalake",
  "df-interchange",
@@ -3547,12 +3423,11 @@ dependencies = [
  "orc-rust",
  "polars",
  "rayon",
- "reqwest",
+ "reqwest 0.12.28",
  "roxmltree",
  "rust_xlsxwriter",
  "serde",
  "serde_json",
- "serde_yaml",
  "sha2",
  "tempfile",
  "thiserror 1.0.69",
@@ -3638,9 +3513,9 @@ checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futures"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -3653,9 +3528,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -3663,15 +3538,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
+checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -3680,60 +3555,32 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
-
-[[package]]
-name = "futures-lite"
-version = "1.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49a9d51ce47660b1e808d3c990b4709f2f415d928835a17dfd16991515c46bce"
-dependencies = [
- "fastrand 1.9.0",
- "futures-core",
- "futures-io",
- "memchr",
- "parking",
- "pin-project-lite",
- "waker-fn",
-]
-
-[[package]]
-name = "futures-lite"
-version = "2.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
-dependencies = [
- "fastrand 2.3.0",
- "futures-core",
- "futures-io",
- "parking",
- "pin-project-lite",
-]
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
 
 [[package]]
 name = "futures-task"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
 
 [[package]]
 name = "futures-timer"
@@ -3743,9 +3590,9 @@ checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
 
 [[package]]
 name = "futures-util"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -3755,7 +3602,6 @@ dependencies = [
  "futures-task",
  "memchr",
  "pin-project-lite",
- "pin-utils",
  "slab",
 ]
 
@@ -3766,11 +3612,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5bdedbc36e6b9d8d79558fbf2ebc098745bc721e9d37d3e369558e420038e360"
 dependencies = [
  "async-trait",
- "base64 0.22.1",
+ "base64",
  "gcloud-metadata",
  "home",
  "jsonwebtoken 10.3.0",
- "reqwest",
+ "reqwest 0.12.28",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -3787,7 +3633,7 @@ version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61f706788c1b58712c513e4d403234707fd255f49caa89d1c930197418b5fb2c"
 dependencies = [
- "reqwest",
+ "reqwest 0.12.28",
  "thiserror 2.0.18",
  "tokio",
 ]
@@ -3799,7 +3645,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6296e302b411580a7c9eeaba1677b604e31fbede80078b110228444eeb19cecf"
 dependencies = [
  "anyhow",
- "base64 0.22.1",
+ "base64",
  "bytes",
  "futures-util",
  "gcloud-auth",
@@ -3809,7 +3655,7 @@ dependencies = [
  "percent-encoding",
  "pkcs8 0.10.2",
  "regex",
- "reqwest",
+ "reqwest 0.12.28",
  "reqwest-middleware",
  "ring",
  "serde",
@@ -3835,17 +3681,6 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.1.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
-dependencies = [
- "cfg-if",
- "libc",
- "wasi 0.9.0+wasi-snapshot-preview1",
-]
-
-[[package]]
-name = "getrandom"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
@@ -3853,7 +3688,7 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "wasi 0.11.1+wasi-snapshot-preview1",
+ "wasi",
  "wasm-bindgen",
 ]
 
@@ -3866,9 +3701,23 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "r-efi",
+ "r-efi 5.3.0",
  "wasip2",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 6.0.0",
+ "rand_core 0.10.1",
+ "wasip2",
+ "wasip3",
 ]
 
 [[package]]
@@ -4120,26 +3969,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "http-types"
-version = "2.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e9b187a72d63adbfba487f48095306ac823049cb504ee195541e91c7775f5ad"
-dependencies = [
- "anyhow",
- "async-channel 1.9.0",
- "base64 0.13.1",
- "futures-lite 1.13.0",
- "infer",
- "pin-project-lite",
- "rand 0.7.3",
- "serde",
- "serde_json",
- "serde_qs",
- "serde_urlencoded",
- "url",
-]
-
-[[package]]
 name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4259,7 +4088,7 @@ version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "727805d60e7938b76b826a6ef209eb70eaa1812794f9424d4a4e2d740662df5f"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "bytes",
  "futures-channel",
  "futures-core",
@@ -4323,7 +4152,7 @@ dependencies = [
  "as-any",
  "async-trait",
  "backon",
- "base64 0.22.1",
+ "base64",
  "bimap",
  "bytes",
  "chrono",
@@ -4340,7 +4169,7 @@ dependencies = [
  "ordered-float 4.6.0",
  "parquet",
  "rand 0.9.4",
- "reqwest",
+ "reqwest 0.12.28",
  "roaring",
  "serde",
  "serde_bytes",
@@ -4368,7 +4197,7 @@ dependencies = [
  "http 1.4.0",
  "iceberg",
  "itertools 0.13.0",
- "reqwest",
+ "reqwest 0.12.28",
  "serde",
  "serde_derive",
  "serde_json",
@@ -4391,7 +4220,7 @@ dependencies = [
  "iceberg",
  "opendal",
  "reqsign",
- "reqwest",
+ "reqwest 0.12.28",
  "serde",
  "typetag",
  "url",
@@ -4479,6 +4308,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4538,12 +4373,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "infer"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64e9829a50b42bb782c1df523f78d332fe371b10c661e78b7a3c34b0198e9fac"
-
-[[package]]
 name = "inout"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4551,15 +4380,6 @@ checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
 dependencies = [
  "block-padding",
  "generic-array",
-]
-
-[[package]]
-name = "instant"
-version = "0.1.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
-dependencies = [
- "cfg-if",
 ]
 
 [[package]]
@@ -4646,7 +4466,7 @@ checksum = "980af8b43c3ad5d8d349ace167ec8170839f753a42d233ba19e08afe1850fa69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4662,6 +4482,55 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "875a5a69ac2bab1a891711cf5eccbec1ce0341ea805560dcd90b7a2e925132e8"
 dependencies = [
  "jiff-tzdb",
+]
+
+[[package]]
+name = "jni"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
+dependencies = [
+ "cfg-if",
+ "combine",
+ "jni-macros",
+ "jni-sys",
+ "log",
+ "simd_cesu8",
+ "thiserror 2.0.18",
+ "walkdir",
+ "windows-link",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4690,7 +4559,7 @@ version = "9.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a87cc7a48537badeae96744432de36f4be2b4a34a05a5ef32e9dd8a1c169dde"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "js-sys",
  "pem",
  "ring",
@@ -4706,7 +4575,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0529410abe238729a60b108898784df8984c87f6054c9c4fcacc47e4803c1ce1"
 dependencies = [
  "aws-lc-rs",
- "base64 0.22.1",
+ "base64",
  "getrandom 0.2.17",
  "js-sys",
  "pem",
@@ -4724,6 +4593,12 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 dependencies = [
  "spin 0.9.8",
 ]
+
+[[package]]
+name = "leb128fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "lexical-core"
@@ -4803,7 +4678,7 @@ dependencies = [
  "cc",
  "flate2",
  "pkg-config",
- "reqwest",
+ "reqwest 0.12.28",
  "serde",
  "serde_json",
  "tar",
@@ -4920,18 +4795,18 @@ dependencies = [
 
 [[package]]
 name = "lz4_flex"
-version = "0.11.5"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08ab2867e3eeeca90e844d1940eab391c9dc5228783db2ed999acbc0a9ed375a"
+checksum = "373f5eceeeab7925e0c1098212f2fbc4d416adec9d35051a6ab251e824c1854a"
 dependencies = [
  "twox-hash",
 ]
 
 [[package]]
 name = "lz4_flex"
-version = "0.12.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab6473172471198271ff72e9379150e9dfd70d8e533e0752a27e515b48dd375e"
+checksum = "98c23545df7ecf1b16c303910a69b079e8e251d60f7dd2cc9b4177f2afaf1746"
 dependencies = [
  "twox-hash",
 ]
@@ -5024,7 +4899,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
 dependencies = [
  "libc",
- "wasi 0.11.1+wasi-snapshot-preview1",
+ "wasi",
  "windows-sys 0.61.2",
 ]
 
@@ -5064,7 +4939,7 @@ dependencies = [
  "crossbeam-epoch",
  "crossbeam-utils",
  "equivalent",
- "event-listener 5.4.1",
+ "event-listener",
  "futures-util",
  "parking_lot",
  "portable-atomic",
@@ -5163,9 +5038,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.1.0"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "num-integer"
@@ -5219,34 +5094,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num_threads"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "oauth2"
-version = "4.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c38841cdd844847e3e7c8d29cef9dcfed8877f8f56f9071f77843ecf3baf937f"
-dependencies = [
- "base64 0.13.1",
- "chrono",
- "getrandom 0.2.17",
- "http 0.2.12",
- "rand 0.8.5",
- "serde",
- "serde_json",
- "serde_path_to_error",
- "sha2",
- "thiserror 1.0.69",
- "url",
-]
-
-[[package]]
 name = "object"
 version = "0.32.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5262,7 +5109,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fbfbfff40aeccab00ec8a910b57ca8ecf4319b335c542f2edcd19dd25a1e2a00"
 dependencies = [
  "async-trait",
- "base64 0.22.1",
+ "base64",
  "bytes",
  "chrono",
  "form_urlencoded",
@@ -5278,7 +5125,7 @@ dependencies = [
  "percent-encoding",
  "quick-xml 0.38.4",
  "rand 0.9.4",
- "reqwest",
+ "reqwest 0.12.28",
  "ring",
  "rustls-pemfile",
  "serde",
@@ -5313,7 +5160,7 @@ checksum = "d075ab8a203a6ab4bc1bce0a4b9fe486a72bf8b939037f4b78d95386384bc80a"
 dependencies = [
  "anyhow",
  "backon",
- "base64 0.22.1",
+ "base64",
  "bytes",
  "crc32c",
  "futures",
@@ -5326,7 +5173,7 @@ dependencies = [
  "percent-encoding",
  "quick-xml 0.38.4",
  "reqsign",
- "reqwest",
+ "reqwest 0.12.28",
  "serde",
  "serde_json",
  "tokio",
@@ -5357,7 +5204,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5416,7 +5263,7 @@ dependencies = [
  "flate2",
  "futures",
  "futures-util",
- "lz4_flex 0.11.5",
+ "lz4_flex 0.11.6",
  "lzokay-native",
  "num",
  "prost 0.13.5",
@@ -5514,7 +5361,7 @@ dependencies = [
  "arrow-ipc",
  "arrow-schema",
  "arrow-select",
- "base64 0.22.1",
+ "base64",
  "brotli",
  "bytes",
  "chrono",
@@ -5522,7 +5369,7 @@ dependencies = [
  "futures",
  "half",
  "hashbrown 0.16.1",
- "lz4_flex 0.12.0",
+ "lz4_flex 0.12.1",
  "num-bigint",
  "num-integer",
  "num-traits",
@@ -5559,7 +5406,7 @@ version = "3.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "serde_core",
 ]
 
@@ -5631,7 +5478,7 @@ checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5645,17 +5492,6 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
-
-[[package]]
-name = "piper"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96c8c490f422ef9a4efd2cb5b42b76c8613d7e7dfc1caf667b8a3350a5acc066"
-dependencies = [
- "atomic-waker",
- "fastrand 2.3.0",
- "futures-io",
-]
 
 [[package]]
 name = "pkcs1"
@@ -5935,7 +5771,7 @@ dependencies = [
  "polars-utils",
  "rayon",
  "regex",
- "reqwest",
+ "reqwest 0.12.28",
  "ryu",
  "serde",
  "serde_json",
@@ -6019,7 +5855,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b59c80a019ef0e6f09b4416d2647076a52839305c9eb11919e8298ec667f853"
 dependencies = [
  "argminmax",
- "base64 0.22.1",
+ "base64",
  "bytemuck",
  "chrono",
  "chrono-tz",
@@ -6052,7 +5888,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93c2439d127c59e6bfc9d698419bdb45210068a6f501d44e6096429ad72c2eaa"
 dependencies = [
  "async-stream",
- "base64 0.22.1",
+ "base64",
  "brotli",
  "bytemuck",
  "ethnum",
@@ -6173,7 +6009,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ff19612074640a9d65e5928b7223db76ffee63e55b276f1e466d06719eb7362"
 dependencies = [
- "async-channel 2.5.0",
+ "async-channel",
  "async-trait",
  "atomic-waker",
  "bitflags",
@@ -6264,20 +6100,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "polling"
-version = "3.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218"
-dependencies = [
- "cfg-if",
- "concurrent-queue",
- "hermit-abi",
- "pin-project-lite",
- "rustix",
- "windows-sys 0.61.2",
-]
-
-[[package]]
 name = "portable-atomic"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6353,7 +6175,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -6384,14 +6206,14 @@ dependencies = [
  "proc-macro-error-attr2",
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.105"
+version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "535d180e0ecab6268a3e718bb9fd44db66bbbc256257165fc699dadf70d16fe7"
+checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]
@@ -6426,7 +6248,7 @@ dependencies = [
  "itertools 0.14.0",
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -6439,7 +6261,7 @@ dependencies = [
  "itertools 0.14.0",
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -6519,7 +6341,7 @@ dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -6532,7 +6354,7 @@ dependencies = [
  "proc-macro2",
  "pyo3-build-config",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -6549,7 +6371,6 @@ checksum = "1004a344b30a54e2ee58d66a71b32d2db2feb0a31f9a2d302bf0536f15de2a33"
 dependencies = [
  "encoding_rs",
  "memchr",
- "serde",
 ]
 
 [[package]]
@@ -6567,6 +6388,16 @@ name = "quick-xml"
 version = "0.38.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b66c2058c55a409d601666cffe35f04333cf1013010882cec174a7467cd4e21c"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
+name = "quick-xml"
+version = "0.39.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdcc8dd4e2f670d309a5f0e83fe36dfdc05af317008fea29144da1a2ac858e5e"
 dependencies = [
  "memchr",
  "serde",
@@ -6598,6 +6429,7 @@ version = "0.11.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1906b49b0c3bc04b5fe5d86a77925ae6524a19b816ae38ce1e426255f1d8a31"
 dependencies = [
+ "aws-lc-rs",
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
@@ -6629,9 +6461,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.43"
+version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc74d9a594b72ae6656596548f56f667211f8a97b3d4c3d467150794690dc40a"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
@@ -6643,23 +6475,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
 name = "radium"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
-
-[[package]]
-name = "rand"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
-dependencies = [
- "getrandom 0.1.16",
- "libc",
- "rand_chacha 0.2.2",
- "rand_core 0.5.1",
- "rand_hc",
-]
 
 [[package]]
 name = "rand"
@@ -6683,13 +6508,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "rand_chacha"
-version = "0.2.2"
+name = "rand"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
 dependencies = [
- "ppv-lite86",
- "rand_core 0.5.1",
+ "chacha20",
+ "getrandom 0.4.2",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -6714,15 +6540,6 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
-dependencies = [
- "getrandom 0.1.16",
-]
-
-[[package]]
-name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
@@ -6740,6 +6557,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
 name = "rand_distr"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6747,15 +6570,6 @@ checksum = "6a8615d50dcf34fa31f7ab52692afec947c4dd0ab803cc87cb3b0b4570ff7463"
 dependencies = [
  "num-traits",
  "rand 0.9.4",
-]
-
-[[package]]
-name = "rand_hc"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
-dependencies = [
- "rand_core 0.5.1",
 ]
 
 [[package]]
@@ -6804,7 +6618,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76009fbe0614077fc1a2ce255e3a1881a2e3a3527097d5dc6d8212c585e7e38b"
 dependencies = [
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -6844,7 +6658,7 @@ checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -6905,7 +6719,7 @@ checksum = "43451dbf3590a7590684c25fb8d12ecdcc90ed3ac123433e500447c7d77ed701"
 dependencies = [
  "anyhow",
  "async-trait",
- "base64 0.22.1",
+ "base64",
  "chrono",
  "form_urlencoded",
  "getrandom 0.2.17",
@@ -6918,7 +6732,7 @@ dependencies = [
  "percent-encoding",
  "quick-xml 0.37.5",
  "rand 0.8.5",
- "reqwest",
+ "reqwest 0.12.28",
  "rsa",
  "rust-ini",
  "serde",
@@ -6934,7 +6748,7 @@ version = "0.12.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "bytes",
  "encoding_rs",
  "futures-channel",
@@ -6973,9 +6787,47 @@ dependencies = [
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
- "wasm-streams",
+ "wasm-streams 0.4.2",
  "web-sys",
  "webpki-roots",
+]
+
+[[package]]
+name = "reqwest"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.8.1",
+ "hyper-rustls 0.27.7",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls 0.23.36",
+ "rustls-pki-types",
+ "rustls-platform-verifier",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls 0.26.4",
+ "tokio-util",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-streams 0.5.0",
+ "web-sys",
 ]
 
 [[package]]
@@ -6987,7 +6839,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "http 1.4.0",
- "reqwest",
+ "reqwest 0.12.28",
  "serde",
  "thiserror 1.0.69",
  "tower-service",
@@ -7134,7 +6986,7 @@ dependencies = [
  "regex",
  "relative-path",
  "rustc_version",
- "syn 2.0.111",
+ "syn 2.0.117",
  "unicode-ident",
 ]
 
@@ -7225,7 +7077,7 @@ dependencies = [
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki 0.103.9",
+ "rustls-webpki 0.103.13",
  "subtle",
  "zeroize",
 ]
@@ -7262,6 +7114,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-platform-verifier"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
+dependencies = [
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "jni",
+ "log",
+ "once_cell",
+ "rustls 0.23.36",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki 0.103.13",
+ "security-framework 3.5.1",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
+
+[[package]]
 name = "rustls-webpki"
 version = "0.101.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7273,9 +7152,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.9"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -7487,7 +7366,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -7504,28 +7383,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_path_to_error"
-version = "0.1.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
-dependencies = [
- "itoa",
- "serde",
- "serde_core",
-]
-
-[[package]]
-name = "serde_qs"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7715380eec75f029a4ef7de39a9200e0a63823176b759d055b613f5a87df6a6"
-dependencies = [
- "percent-encoding",
- "serde",
- "thiserror 1.0.69",
-]
-
-[[package]]
 name = "serde_repr"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7533,7 +7390,7 @@ checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -7565,7 +7422,7 @@ version = "3.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fa237f2807440d238e0364a218270b98f767a00d3dada77b1c53ae88940e2e7"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "chrono",
  "hex",
  "indexmap 1.9.3",
@@ -7587,20 +7444,7 @@ dependencies = [
  "darling 0.21.3",
  "proc-macro2",
  "quote",
- "syn 2.0.111",
-]
-
-[[package]]
-name = "serde_yaml"
-version = "0.9.34+deprecated"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
-dependencies = [
- "indexmap 2.13.0",
- "itoa",
- "ryu",
- "serde",
- "unsafe-libyaml",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -7610,7 +7454,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 
@@ -7621,7 +7465,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 
@@ -7694,6 +7538,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "simd_cesu8"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
+
+[[package]]
 name = "simdutf8"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7759,10 +7613,10 @@ version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1c97747dbf44bb1ca44a561ece23508e99cb592e862f22222dcf42f51d1e451"
 dependencies = [
- "heck 0.5.0",
+ "heck 0.4.1",
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -7851,7 +7705,7 @@ checksum = "da5fc6819faabb412da764b99d3b713bb55083c11e7e0c00144d386cd6a1939c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -7931,7 +7785,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -7943,7 +7797,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -7965,9 +7819,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.111"
+version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "390cc9a294ab71bdb1aa2e99d13be9c753cd2d7bd6560c77118597410c4d2e87"
+checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7991,7 +7845,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -8050,7 +7904,7 @@ version = "3.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "655da9c7eb6305c55742045d5a8d2037996d61d8de95806335c7c86ce0f82e9c"
 dependencies = [
- "fastrand 2.3.0",
+ "fastrand",
  "getrandom 0.3.4",
  "once_cell",
  "rustix",
@@ -8089,7 +7943,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -8100,7 +7954,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -8116,16 +7970,13 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.45"
+version = "0.3.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9e442fc33d7fdb45aa9bfeb312c095964abdf596f7567261062b2a7107aaabd"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
 dependencies = [
  "deranged",
  "itoa",
- "js-sys",
- "libc",
  "num-conv",
- "num_threads",
  "powerfmt",
  "serde_core",
  "time-core",
@@ -8134,15 +7985,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b36ee98fd31ec7426d599183e8fe26932a8dc1fb76ddb6214d05493377d34ca"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
 
 [[package]]
 name = "time-macros"
-version = "0.2.25"
+version = "0.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71e552d1249bf61ac2a52db88179fd0673def1e1ad8243a00d9ec9ed71fee3dd"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
 dependencies = [
  "num-conv",
  "time-core",
@@ -8216,7 +8067,7 @@ checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -8313,13 +8164,18 @@ version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
+ "async-compression",
  "bitflags",
  "bytes",
+ "futures-core",
  "futures-util",
  "http 1.4.0",
  "http-body 1.0.1",
+ "http-body-util",
  "iri-string",
  "pin-project-lite",
+ "tokio",
+ "tokio-util",
  "tower",
  "tower-layer",
  "tower-service",
@@ -8357,7 +8213,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -8416,7 +8272,7 @@ checksum = "f03ca4cb38206e2bef0700092660bb74d696f808514dae47fa1467cbfe26e96e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -8427,7 +8283,7 @@ checksum = "3c36781cc0e46a83726d9879608e4cf6c2505237e263a8eb8c24502989cfdb28"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -8438,7 +8294,7 @@ checksum = "016c26257f448222014296978b2c8456e2cad4de308c35bdb1e383acd569ef5b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -8452,6 +8308,58 @@ name = "typenum"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+
+[[package]]
+name = "typespec"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21666a31293beab8f41d38c2849ddbc342cd9c7cb4d71a9818868287a8934e53"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures",
+ "quick-xml 0.39.4",
+ "serde",
+ "serde_json",
+ "url",
+]
+
+[[package]]
+name = "typespec_client_core"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "924f0c734e0ac3b881ab99d032bd28fcc969d2bb73ef1b8dd4772fd8e518a382"
+dependencies = [
+ "async-trait",
+ "base64",
+ "bytes",
+ "dyn-clone",
+ "futures",
+ "pin-project",
+ "rand 0.10.1",
+ "reqwest 0.13.4",
+ "serde",
+ "serde_json",
+ "time",
+ "tokio",
+ "tracing",
+ "typespec",
+ "typespec_macros",
+ "url",
+ "uuid",
+]
+
+[[package]]
+name = "typespec_macros"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c608f4427943f8adb211abc95c87672b1b98847152783507d54e3246e502f60"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "typetag"
@@ -8474,16 +8382,7 @@ checksum = "27a7a9b72ba121f6f1f6c3632b85604cac41aedb5ddc70accbebb6cac83de846"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
-]
-
-[[package]]
-name = "tz-rs"
-version = "0.6.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33851b15c848fad2cf4b105c6bb66eb9512b6f6c44a4b13f57c53c73c707e2b4"
-dependencies = [
- "const_fn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -8529,16 +8428,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
 name = "unindent"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7264e107f553ccae879d21fbea1d6724ac785e8c3bfc762137959b5802826ef3"
-
-[[package]]
-name = "unsafe-libyaml"
-version = "0.2.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "untrusted"
@@ -8591,13 +8490,13 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.19.0"
+version = "1.23.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2e054861b4bd027cd373e18e8d8d8e6548085000e41290d95ce0c373a654b4a"
+checksum = "144d6b123cef80b301b8f72a9e2ca4370ddec21950d0a103dd22c437006d2db7"
 dependencies = [
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "js-sys",
- "rand 0.9.4",
+ "rand 0.10.1",
  "serde_core",
  "wasm-bindgen",
 ]
@@ -8629,7 +8528,7 @@ dependencies = [
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -8678,12 +8577,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "waker-fn"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "317211a0dc0ceedd78fb2ca9a44aed3d7b9b26f81870d485c07122b4350673b7"
-
-[[package]]
 name = "walkdir"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8704,12 +8597,6 @@ dependencies = [
 
 [[package]]
 name = "wasi"
-version = "0.9.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
-
-[[package]]
-name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
@@ -8719,6 +8606,15 @@ name = "wasip2"
 version = "1.0.2+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
  "wit-bindgen",
 ]
@@ -8770,7 +8666,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
  "wasm-bindgen-shared",
 ]
 
@@ -8784,6 +8680,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap 2.13.0",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
 name = "wasm-streams"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8794,6 +8712,31 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
+]
+
+[[package]]
+name = "wasm-streams"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1ec4f6517c9e11ae630e200b2b65d193279042e28edd4a2cda233e46670bbb"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags",
+ "hashbrown 0.15.5",
+ "indexmap 2.13.0",
+ "semver",
 ]
 
 [[package]]
@@ -8814,6 +8757,15 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-root-certs"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -8877,7 +8829,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -8888,7 +8840,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -9105,6 +9057,88 @@ name = "wit-bindgen"
 version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck 0.5.0",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck 0.5.0",
+ "indexmap 2.13.0",
+ "prettyplease",
+ "syn 2.0.117",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "indexmap 2.13.0",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap 2.13.0",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
+]
 
 [[package]]
 name = "writeable"
@@ -9182,7 +9216,7 @@ checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -9209,7 +9243,7 @@ checksum = "2c7962b26b0a8685668b671ee4b54d007a67d4eaf05fda79ac0ecf41e32270f1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -9229,7 +9263,7 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -9269,7 +9303,7 @@ checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/crates/floe-core/Cargo.toml
+++ b/crates/floe-core/Cargo.toml
@@ -21,7 +21,6 @@ deltalake = { version = "0.30.1", features = ["datafusion", "s3", "azure", "gcs"
 url = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-serde_yaml = "0.9"
 time = { version = "0.3", features = ["formatting"] }
 glob = "0.3"
 roxmltree = "0.20"
@@ -33,10 +32,12 @@ apache-avro = "0.16"
 google-cloud-storage = { package = "gcloud-storage", version = "1.2.0" }
 tempfile = "3"
 tokio = { version = "1", features = ["rt", "rt-multi-thread", "fs", "io-util"] }
-azure_core = "0.20"
-azure_identity = "0.20"
-azure_storage = "0.20"
-azure_storage_blobs = "0.20"
+azure_core = "1"
+azure_identity = "1"
+azure_storage_blob = "1"
+# Required to implement azure_core's TokenCredential trait (it is async_trait-based)
+# for the ADLS credential chain; already in-tree via azure_identity.
+async-trait = "0.1"
 futures = "0.3"
 uuid = "1"
 arrow = "57"

--- a/crates/floe-core/src/add_entity.rs
+++ b/crates/floe-core/src/add_entity.rs
@@ -634,6 +634,11 @@ fn arrow_dtype_to_floe_type(dtype: &ArrowDataType) -> String {
 
 fn append_entity_yaml(config_text: &str, inferred: &InferredEntity) -> FloeResult<String> {
     let mut docs = YamlLoader::load_from_str(config_text)?;
+    if docs.len() > 1 {
+        return Err(Box::new(ConfigError(
+            "YAML contains multiple documents; expected one".to_string(),
+        )));
+    }
     let mut root = if docs.is_empty() {
         Yaml::Null
     } else {

--- a/crates/floe-core/src/add_entity.rs
+++ b/crates/floe-core/src/add_entity.rs
@@ -4,11 +4,11 @@ use std::io::{BufRead, BufReader};
 use std::path::{Path, PathBuf};
 
 use polars::prelude::{ArrowDataType, DataType, SerReader};
-use serde::Serialize;
 use serde_json::Value as JsonValue;
-use serde_yaml::Value as YamlValue;
 use tempfile::NamedTempFile;
 use url::Url;
+use yaml_rust2::yaml::Hash as YamlHash;
+use yaml_rust2::{Yaml, YamlEmitter, YamlLoader};
 
 use crate::config;
 use crate::errors::IoError;
@@ -50,67 +50,16 @@ struct InferredEntity {
     notes: Vec<String>,
 }
 
-#[derive(Debug, Clone, Serialize)]
-struct GeneratedEntityYaml {
-    name: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    domain: Option<String>,
-    source: GeneratedSourceYaml,
-    sink: GeneratedSinkYaml,
-    policy: GeneratedPolicyYaml,
-    schema: GeneratedSchemaYaml,
-}
-
-#[derive(Debug, Clone, Serialize)]
-struct GeneratedSourceYaml {
-    format: String,
-    path: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    options: Option<GeneratedSourceOptions>,
-}
-
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone)]
 struct GeneratedSourceOptions {
-    #[serde(skip_serializing_if = "Option::is_none")]
     separator: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     json_mode: Option<String>,
 }
 
-#[derive(Debug, Clone, Serialize)]
-struct GeneratedSinkYaml {
-    accepted: GeneratedSinkTargetYaml,
-    rejected: GeneratedSinkTargetYaml,
-}
-
-#[derive(Debug, Clone, Serialize)]
-struct GeneratedSinkTargetYaml {
-    format: String,
-    path: String,
-}
-
-#[derive(Debug, Clone, Serialize)]
-struct GeneratedPolicyYaml {
-    severity: String,
-}
-
-#[derive(Debug, Clone, Serialize)]
-struct GeneratedSchemaYaml {
-    mismatch: GeneratedMismatchYaml,
-    columns: Vec<GeneratedColumn>,
-}
-
-#[derive(Debug, Clone, Serialize)]
-struct GeneratedMismatchYaml {
-    missing_columns: String,
-    extra_columns: String,
-}
-
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone)]
 struct GeneratedColumn {
     name: String,
     source: String,
-    #[serde(rename = "type")]
     column_type: String,
     nullable: bool,
     unique: bool,
@@ -684,23 +633,28 @@ fn arrow_dtype_to_floe_type(dtype: &ArrowDataType) -> String {
 }
 
 fn append_entity_yaml(config_text: &str, inferred: &InferredEntity) -> FloeResult<String> {
-    let mut root: YamlValue = serde_yaml::from_str(config_text)?;
-    let root_map = root.as_mapping_mut().ok_or_else(|| {
-        Box::new(ConfigError(
+    let mut docs = YamlLoader::load_from_str(config_text)?;
+    let mut root = if docs.is_empty() {
+        Yaml::Null
+    } else {
+        docs.swap_remove(0)
+    };
+    let Yaml::Hash(root_map) = &mut root else {
+        return Err(Box::new(ConfigError(
             "config root must be a YAML mapping".to_string(),
-        )) as Box<dyn std::error::Error + Send + Sync>
-    })?;
+        )));
+    };
 
-    let entities_key = YamlValue::String("entities".to_string());
-    let new_entity_value = serde_yaml::to_value(build_generated_entity_yaml(inferred))?;
+    let entities_key = yaml_str("entities");
+    let new_entity_value = build_generated_entity_yaml(inferred);
 
     match root_map.get_mut(&entities_key) {
         Some(value) => {
-            let entities = value.as_sequence_mut().ok_or_else(|| {
-                Box::new(ConfigError(
+            let Yaml::Array(entities) = value else {
+                return Err(Box::new(ConfigError(
                     "root.entities must be a YAML sequence".to_string(),
-                )) as Box<dyn std::error::Error + Send + Sync>
-            })?;
+                )));
+            };
             if entities
                 .iter()
                 .any(|entity| entity_name_matches(entity, &inferred.name))
@@ -713,57 +667,97 @@ fn append_entity_yaml(config_text: &str, inferred: &InferredEntity) -> FloeResul
             entities.push(new_entity_value);
         }
         None => {
-            root_map.insert(entities_key, YamlValue::Sequence(vec![new_entity_value]));
+            root_map.insert(entities_key, Yaml::Array(vec![new_entity_value]));
         }
     }
 
-    Ok(serde_yaml::to_string(&root)?)
+    let mut rendered = String::new();
+    YamlEmitter::new(&mut rendered).dump(&root)?;
+    let body = rendered.strip_prefix("---\n").unwrap_or(&rendered);
+    Ok(format!("{body}\n"))
 }
 
-fn entity_name_matches(value: &YamlValue, name: &str) -> bool {
+fn entity_name_matches(value: &Yaml, name: &str) -> bool {
     value
-        .as_mapping()
-        .and_then(|map| map.get(YamlValue::String("name".to_string())))
-        .and_then(YamlValue::as_str)
+        .as_hash()
+        .and_then(|map| map.get(&yaml_str("name")))
+        .and_then(Yaml::as_str)
         == Some(name)
 }
 
-fn build_generated_entity_yaml(inferred: &InferredEntity) -> GeneratedEntityYaml {
+fn yaml_str(value: impl Into<String>) -> Yaml {
+    Yaml::String(value.into())
+}
+
+fn build_generated_entity_yaml(inferred: &InferredEntity) -> Yaml {
+    let mut entity = YamlHash::new();
+    entity.insert(yaml_str("name"), yaml_str(&inferred.name));
+    if let Some(domain) = &inferred.domain {
+        entity.insert(yaml_str("domain"), yaml_str(domain));
+    }
+
+    let mut source = YamlHash::new();
+    source.insert(yaml_str("format"), yaml_str(&inferred.format));
+    source.insert(yaml_str("path"), yaml_str(&inferred.input));
     let source_options = match inferred.format.as_str() {
-        "json" => inferred.source_options.clone(),
-        "csv" => inferred.source_options.clone(),
+        "json" | "csv" => inferred.source_options.as_ref(),
         _ => None,
     };
-
-    GeneratedEntityYaml {
-        name: inferred.name.clone(),
-        domain: inferred.domain.clone(),
-        source: GeneratedSourceYaml {
-            format: inferred.format.clone(),
-            path: inferred.input.clone(),
-            options: source_options,
-        },
-        sink: GeneratedSinkYaml {
-            accepted: GeneratedSinkTargetYaml {
-                format: "parquet".to_string(),
-                path: format!("out/accepted/{}/", inferred.name),
-            },
-            rejected: GeneratedSinkTargetYaml {
-                format: "csv".to_string(),
-                path: format!("out/rejected/{}/", inferred.name),
-            },
-        },
-        policy: GeneratedPolicyYaml {
-            severity: "reject".to_string(),
-        },
-        schema: GeneratedSchemaYaml {
-            mismatch: GeneratedMismatchYaml {
-                missing_columns: "reject_file".to_string(),
-                extra_columns: "ignore".to_string(),
-            },
-            columns: inferred.columns.clone(),
-        },
+    if let Some(options) = source_options {
+        let mut options_map = YamlHash::new();
+        if let Some(separator) = &options.separator {
+            options_map.insert(yaml_str("separator"), yaml_str(separator));
+        }
+        if let Some(json_mode) = &options.json_mode {
+            options_map.insert(yaml_str("json_mode"), yaml_str(json_mode));
+        }
+        source.insert(yaml_str("options"), Yaml::Hash(options_map));
     }
+    entity.insert(yaml_str("source"), Yaml::Hash(source));
+
+    let mut accepted = YamlHash::new();
+    accepted.insert(yaml_str("format"), yaml_str("parquet"));
+    accepted.insert(
+        yaml_str("path"),
+        yaml_str(format!("out/accepted/{}/", inferred.name)),
+    );
+    let mut rejected = YamlHash::new();
+    rejected.insert(yaml_str("format"), yaml_str("csv"));
+    rejected.insert(
+        yaml_str("path"),
+        yaml_str(format!("out/rejected/{}/", inferred.name)),
+    );
+    let mut sink = YamlHash::new();
+    sink.insert(yaml_str("accepted"), Yaml::Hash(accepted));
+    sink.insert(yaml_str("rejected"), Yaml::Hash(rejected));
+    entity.insert(yaml_str("sink"), Yaml::Hash(sink));
+
+    let mut policy = YamlHash::new();
+    policy.insert(yaml_str("severity"), yaml_str("reject"));
+    entity.insert(yaml_str("policy"), Yaml::Hash(policy));
+
+    let mut mismatch = YamlHash::new();
+    mismatch.insert(yaml_str("missing_columns"), yaml_str("reject_file"));
+    mismatch.insert(yaml_str("extra_columns"), yaml_str("ignore"));
+    let mut schema = YamlHash::new();
+    schema.insert(yaml_str("mismatch"), Yaml::Hash(mismatch));
+    schema.insert(
+        yaml_str("columns"),
+        Yaml::Array(inferred.columns.iter().map(generated_column_yaml).collect()),
+    );
+    entity.insert(yaml_str("schema"), Yaml::Hash(schema));
+
+    Yaml::Hash(entity)
+}
+
+fn generated_column_yaml(column: &GeneratedColumn) -> Yaml {
+    let mut map = YamlHash::new();
+    map.insert(yaml_str("name"), yaml_str(&column.name));
+    map.insert(yaml_str("source"), yaml_str(&column.source));
+    map.insert(yaml_str("type"), yaml_str(&column.column_type));
+    map.insert(yaml_str("nullable"), Yaml::Boolean(column.nullable));
+    map.insert(yaml_str("unique"), Yaml::Boolean(column.unique));
+    Yaml::Hash(map)
 }
 
 fn validate_generated_config(yaml: &str, target_path: &Path) -> FloeResult<()> {

--- a/crates/floe-core/src/io/storage/providers/adls.rs
+++ b/crates/floe-core/src/io/storage/providers/adls.rs
@@ -1,11 +1,19 @@
 use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 
-use azure_core::prelude::IfMatchCondition;
-use azure_identity::{DefaultAzureCredential, TokenCredentialOptions};
-use azure_storage::StorageCredentials;
-use azure_storage_blobs::prelude::{BlobServiceClient, ContainerClient};
-use futures::StreamExt;
+use azure_core::credentials::{AccessToken, TokenCredential, TokenRequestOptions};
+use azure_core::error::ErrorKind;
+use azure_core::http::{Etag, RequestContent, StatusCode, Url};
+use azure_identity::{
+    ClientSecretCredential, DeveloperToolsCredential, ManagedIdentityCredential,
+    WorkloadIdentityCredential,
+};
+use azure_storage_blob::models::{
+    BlobClientDeleteOptions, BlobClientUploadOptions, BlobContainerClientListBlobsOptions,
+};
+use azure_storage_blob::{BlobContainerClient, BlobServiceClient};
+use futures::{StreamExt, TryStreamExt};
 use tokio::runtime::Runtime;
 
 use crate::errors::StorageError;
@@ -19,7 +27,96 @@ pub struct AdlsClient {
     container: String,
     prefix: String,
     runtime: Runtime,
-    container_client: ContainerClient,
+    container_client: BlobContainerClient,
+}
+
+/// Ordered chain of token credentials, mirroring the retired
+/// `DefaultAzureCredential` from the pre-official SDK: each source is probed at
+/// token-acquisition time and the first one that succeeds is cached for
+/// subsequent calls. The official `azure_identity` crate ships no equivalent
+/// chain for production credentials, only the dev-time `DeveloperToolsCredential`.
+#[derive(Debug)]
+struct ChainedCredential {
+    sources: Vec<Arc<dyn TokenCredential>>,
+    cached_index: AtomicUsize,
+}
+
+#[async_trait::async_trait]
+impl TokenCredential for ChainedCredential {
+    async fn get_token(
+        &self,
+        scopes: &[&str],
+        options: Option<TokenRequestOptions<'_>>,
+    ) -> azure_core::Result<AccessToken> {
+        let cached = self.cached_index.load(Ordering::Relaxed);
+        if let Some(source) = self.sources.get(cached) {
+            return source.get_token(scopes, options).await;
+        }
+        let mut errors = Vec::new();
+        for (index, source) in self.sources.iter().enumerate() {
+            match source.get_token(scopes, options.clone()).await {
+                Ok(token) => {
+                    self.cached_index.store(index, Ordering::Relaxed);
+                    return Ok(token);
+                }
+                Err(error) => errors.push(error.to_string()),
+            }
+        }
+        Err(azure_core::Error::with_message(
+            ErrorKind::Credential,
+            format!(
+                "no Azure credential in the chain could authenticate: {}",
+                errors.join("; ")
+            ),
+        ))
+    }
+}
+
+/// Build the ADLS credential with the same resolution order users relied on
+/// under the old `DefaultAzureCredential`: explicit service-principal env vars,
+/// then workload identity, then managed identity, then developer tools (az CLI).
+fn build_credential() -> FloeResult<Arc<dyn TokenCredential>> {
+    if let (Ok(tenant), Ok(client), Ok(secret)) = (
+        std::env::var("AZURE_TENANT_ID"),
+        std::env::var("AZURE_CLIENT_ID"),
+        std::env::var("AZURE_CLIENT_SECRET"),
+    ) {
+        let credential = ClientSecretCredential::new(&tenant, client, secret.into(), None)
+            .map_err(|err| {
+                Box::new(StorageError(format!(
+                    "adls service-principal credential init failed: {err}"
+                )))
+            })?;
+        return Ok(credential);
+    }
+    if std::env::var("AZURE_FEDERATED_TOKEN_FILE").is_ok() {
+        let credential = WorkloadIdentityCredential::new(None).map_err(|err| {
+            Box::new(StorageError(format!(
+                "adls workload-identity credential init failed: {err}"
+            )))
+        })?;
+        return Ok(credential);
+    }
+
+    let mut sources: Vec<Arc<dyn TokenCredential>> = Vec::new();
+    if let Ok(managed) = ManagedIdentityCredential::new(None) {
+        sources.push(managed);
+    }
+    if let Ok(developer) = DeveloperToolsCredential::new(None) {
+        sources.push(developer);
+    }
+    if sources.is_empty() {
+        return Err(Box::new(StorageError(
+            "adls credential init failed: no Azure credential source is available \
+             (set AZURE_TENANT_ID/AZURE_CLIENT_ID/AZURE_CLIENT_SECRET, run on a host \
+             with managed identity, or sign in with the Azure CLI)"
+                .to_string(),
+        )));
+    }
+    Ok(Arc::new(ChainedCredential {
+        sources,
+        cached_index: AtomicUsize::new(usize::MAX),
+    }))
 }
 
 impl AdlsClient {
@@ -37,11 +134,16 @@ impl AdlsClient {
             .enable_all()
             .build()
             .map_err(|err| Box::new(StorageError(format!("adls runtime init failed: {err}"))))?;
-        let credential = DefaultAzureCredential::create(TokenCredentialOptions::default())
-            .map_err(|err| Box::new(StorageError(format!("adls credential init failed: {err}"))))?;
-        let storage_credentials = StorageCredentials::token_credential(Arc::new(credential));
-        let service_client = BlobServiceClient::new(account.clone(), storage_credentials);
-        let container_client = service_client.container_client(container.clone());
+        let credential = build_credential()?;
+        let service_url = Url::parse(&format!("https://{account}.blob.core.windows.net/"))
+            .map_err(|err| {
+                Box::new(StorageError(format!(
+                    "adls service url for account {account} is invalid: {err}"
+                )))
+            })?;
+        let service_client = BlobServiceClient::new(service_url, Some(credential), None)
+            .map_err(|err| Box::new(StorageError(format!("adls client init failed: {err}"))))?;
+        let container_client = service_client.blob_container_client(&container);
         Ok(Self {
             account,
             container,
@@ -69,32 +171,50 @@ impl AdlsClient {
 impl StorageClient for AdlsClient {
     fn list(&self, prefix_or_path: &str) -> FloeResult<Vec<ObjectRef>> {
         let prefix = self.full_path(prefix_or_path);
-        let container = self.container.clone();
-        let account = self.account.clone();
-        let client = self.container_client.clone();
-        self.runtime.block_on(async move {
-            let mut refs = Vec::new();
-            let mut stream = client.list_blobs().prefix(prefix.clone()).into_stream();
-            while let Some(resp) = stream.next().await {
-                let resp = resp.map_err(|err| {
+        self.runtime.block_on(async {
+            let options = BlobContainerClientListBlobsOptions {
+                prefix: Some(prefix),
+                ..Default::default()
+            };
+            let mut pages = self
+                .container_client
+                .list_blobs(Some(options))
+                .map_err(|err| {
                     Box::new(StorageError(format!("adls list failed: {err}")))
                         as Box<dyn std::error::Error + Send + Sync>
+                })?
+                .into_pages();
+            let mut refs = Vec::new();
+            while let Some(page) = pages.try_next().await.map_err(|err| {
+                Box::new(StorageError(format!("adls list failed: {err}")))
+                    as Box<dyn std::error::Error + Send + Sync>
+            })? {
+                let segment = page.into_model().map_err(|err| {
+                    Box::new(StorageError(format!("adls list decode failed: {err}")))
+                        as Box<dyn std::error::Error + Send + Sync>
                 })?;
-                for blob in resp.blobs.blobs() {
-                    let key = blob.name.clone();
+                for blob in segment.blob_items {
+                    let Some(key) = blob.name else { continue };
                     let uri = if key.is_empty() {
-                        format!("abfs://{}@{}.dfs.core.windows.net", container, account)
+                        format!(
+                            "abfs://{}@{}.dfs.core.windows.net",
+                            self.container, self.account
+                        )
                     } else {
                         format!(
                             "abfs://{}@{}.dfs.core.windows.net/{}",
-                            container, account, key
+                            self.container, self.account, key
                         )
                     };
+                    let properties = blob.properties;
                     refs.push(planner::object_ref(
                         uri,
                         key,
-                        Some(blob.properties.last_modified.to_string()),
-                        Some(blob.properties.content_length),
+                        properties
+                            .as_ref()
+                            .and_then(|props| props.last_modified)
+                            .map(|modified| modified.to_string()),
+                        properties.as_ref().and_then(|props| props.content_length),
                     ));
                 }
             }
@@ -109,35 +229,35 @@ impl StorageClient for AdlsClient {
             .unwrap_or("")
             .trim_start_matches('/')
             .to_string();
-        let key = if key.is_empty() {
+        if key.is_empty() {
             return Err(Box::new(StorageError(
                 "adls download requires a blob path".to_string(),
             )));
-        } else {
-            key
-        };
+        }
         let dest = planner::temp_path_for_key(temp_dir, &key);
-        let dest_clone = dest.clone();
-        let client = self.container_client.clone();
-        let key_clone = key.clone();
-        self.runtime.block_on(async move {
-            if let Some(parent) = dest_clone.parent() {
+        self.runtime.block_on(async {
+            if let Some(parent) = dest.parent() {
                 tokio::fs::create_dir_all(parent).await?;
             }
-            let blob = client.blob_client(key_clone);
-            let mut stream = blob.get().into_stream();
-            let mut file = tokio::fs::File::create(&dest_clone).await?;
-            while let Some(chunk) = stream.next().await {
-                let resp = chunk.map_err(|err| {
+            let response = self
+                .container_client
+                .blob_client(&key)
+                .download(None)
+                .await
+                .map_err(|err| {
                     Box::new(StorageError(format!("adls download failed: {err}")))
                         as Box<dyn std::error::Error + Send + Sync>
                 })?;
-                let bytes = resp.data.collect().await.map_err(|err| {
+            let mut body = response.body;
+            let mut file = tokio::fs::File::create(&dest).await?;
+            while let Some(chunk) = body.next().await {
+                let bytes = chunk.map_err(|err| {
                     Box::new(StorageError(format!("adls download read failed: {err}")))
                         as Box<dyn std::error::Error + Send + Sync>
                 })?;
                 tokio::io::AsyncWriteExt::write_all(&mut file, &bytes).await?;
             }
+            tokio::io::AsyncWriteExt::flush(&mut file).await?;
             Ok::<(), Box<dyn std::error::Error + Send + Sync>>(())
         })?;
         Ok(dest)
@@ -155,14 +275,15 @@ impl StorageClient for AdlsClient {
                 "adls upload requires a blob path".to_string(),
             )));
         }
-        let client = self.container_client.clone();
-        let path = local_path.to_path_buf();
-        self.runtime.block_on(async move {
-            let data = tokio::fs::read(path).await?;
-            let blob = client.blob_client(key);
-            blob.put_block_blob(data)
-                .content_type("application/octet-stream")
-                .into_future()
+        self.runtime.block_on(async {
+            let data = tokio::fs::read(local_path).await?;
+            let options = BlobClientUploadOptions {
+                blob_content_type: Some("application/octet-stream".to_string()),
+                ..Default::default()
+            };
+            self.container_client
+                .blob_client(&key)
+                .upload(RequestContent::from(data), Some(options))
                 .await
                 .map_err(|err| {
                     Box::new(StorageError(format!("adls upload failed: {err}")))
@@ -190,13 +311,15 @@ impl StorageClient for AdlsClient {
         if key.is_empty() {
             return Ok(());
         }
-        let client = self.container_client.clone();
-        self.runtime.block_on(async move {
-            let blob = client.blob_client(key);
-            blob.delete().into_future().await.map_err(|err| {
-                Box::new(StorageError(format!("adls delete failed: {err}")))
-                    as Box<dyn std::error::Error + Send + Sync>
-            })?;
+        self.runtime.block_on(async {
+            self.container_client
+                .blob_client(&key)
+                .delete(None)
+                .await
+                .map_err(|err| {
+                    Box::new(StorageError(format!("adls delete failed: {err}")))
+                        as Box<dyn std::error::Error + Send + Sync>
+                })?;
             Ok(())
         })
     }
@@ -213,33 +336,32 @@ impl StorageClient for AdlsClient {
 
     fn read_object(&self, uri: &str) -> FloeResult<Option<StoredObject>> {
         let key = adls_key_from_uri(uri)?;
-        let client = self.container_client.clone();
-        self.runtime.block_on(async move {
-            let blob = client.blob_client(key);
-            let mut stream = blob.get().into_stream();
-            let mut body = Vec::new();
-            let mut version = None;
-            while let Some(chunk) = stream.next().await {
-                let resp = match chunk {
-                    Ok(resp) => resp,
-                    Err(err) if is_not_found(&err) => return Ok(None),
-                    Err(err) => {
-                        return Err(
-                            Box::new(StorageError(format!("adls download failed: {err}")))
-                                as Box<dyn std::error::Error + Send + Sync>,
-                        )
-                    }
-                };
-                if version.is_none() {
-                    version = Some(resp.blob.properties.etag.to_string());
+        self.runtime.block_on(async {
+            let response = match self.container_client.blob_client(&key).download(None).await {
+                Ok(response) => response,
+                Err(err) if is_not_found(&err) => return Ok(None),
+                Err(err) => {
+                    return Err(
+                        Box::new(StorageError(format!("adls download failed: {err}")))
+                            as Box<dyn std::error::Error + Send + Sync>,
+                    )
                 }
-                let bytes = resp.data.collect().await.map_err(|err| {
-                    Box::new(StorageError(format!("adls download read failed: {err}")))
-                        as Box<dyn std::error::Error + Send + Sync>
-                })?;
-                body.extend_from_slice(&bytes);
-            }
-            Ok(version.map(|version| StoredObject { body, version }))
+            };
+            let version = response.properties.etag.clone().map(String::from);
+            let body = response.body.collect().await.map_err(|err| {
+                Box::new(StorageError(format!("adls download read failed: {err}")))
+                    as Box<dyn std::error::Error + Send + Sync>
+            })?;
+            let Some(version) = version else {
+                return Err(Box::new(StorageError(format!(
+                    "adls download response for {key} is missing an etag"
+                )))
+                    as Box<dyn std::error::Error + Send + Sync>);
+            };
+            Ok(Some(StoredObject {
+                body: body.to_vec(),
+                version,
+            }))
         })
     }
 
@@ -250,21 +372,31 @@ impl StorageClient for AdlsClient {
         body: &[u8],
     ) -> FloeResult<ConditionalWrite> {
         let key = adls_key_from_uri(uri)?;
-        let client = self.container_client.clone();
         let body = body.to_vec();
-        self.runtime.block_on(async move {
-            let condition = expected_version
-                .map(|version| IfMatchCondition::Match(version.to_string()))
-                .unwrap_or_else(|| IfMatchCondition::NotMatch("*".to_string()));
-            match client
-                .blob_client(key)
-                .put_block_blob(body)
-                .if_match(condition)
-                .content_type("application/json")
-                .into_future()
+        self.runtime.block_on(async {
+            let options = BlobClientUploadOptions {
+                blob_content_type: Some("application/json".to_string()),
+                if_match: expected_version.map(Etag::from),
+                if_none_match: expected_version.is_none().then(|| Etag::from("*")),
+                ..Default::default()
+            };
+            match self
+                .container_client
+                .blob_client(&key)
+                .upload(RequestContent::from(body), Some(options))
                 .await
             {
-                Ok(resp) => Ok(ConditionalWrite::Written { version: resp.etag }),
+                Ok(result) => {
+                    let Some(etag) = result.etag else {
+                        return Err(Box::new(StorageError(format!(
+                            "adls upload response for {key} is missing an etag"
+                        )))
+                            as Box<dyn std::error::Error + Send + Sync>);
+                    };
+                    Ok(ConditionalWrite::Written {
+                        version: String::from(etag),
+                    })
+                }
                 Err(err) if is_precondition(&err) => Ok(ConditionalWrite::Conflict),
                 Err(err) => Err(Box::new(StorageError(format!("adls upload failed: {err}")))
                     as Box<dyn std::error::Error + Send + Sync>),
@@ -283,13 +415,17 @@ impl StorageClient for AdlsClient {
             });
         };
         let key = adls_key_from_uri(uri)?;
-        let client = self.container_client.clone();
-        self.runtime.block_on(async move {
-            let request = client
-                .blob_client(key)
-                .delete()
-                .if_match(IfMatchCondition::Match(expected_version.to_string()));
-            match request.into_future().await {
+        self.runtime.block_on(async {
+            let options = BlobClientDeleteOptions {
+                if_match: Some(Etag::from(expected_version)),
+                ..Default::default()
+            };
+            match self
+                .container_client
+                .blob_client(&key)
+                .delete(Some(options))
+                .await
+            {
                 Ok(_) => Ok(ConditionalWrite::Written {
                     version: "deleted".to_string(),
                 }),
@@ -319,14 +455,26 @@ fn adls_key_from_uri(uri: &str) -> FloeResult<String> {
     Ok(key)
 }
 
-fn is_not_found<E: std::fmt::Display>(err: &E) -> bool {
-    let text = err.to_string();
-    text.contains("404") || text.contains("NotFound")
+fn http_status(err: &azure_core::Error) -> Option<StatusCode> {
+    match err.kind() {
+        ErrorKind::HttpResponse { status, .. } => Some(*status),
+        _ => None,
+    }
 }
 
-fn is_precondition<E: std::fmt::Display>(err: &E) -> bool {
-    let text = err.to_string();
-    text.contains("412") || text.contains("condition") || text.contains("Condition")
+fn is_not_found(err: &azure_core::Error) -> bool {
+    http_status(err) == Some(StatusCode::NotFound)
+}
+
+/// Conflict detection for CAS writes. Azure returns 412 (PreconditionFailed)
+/// for an `If-Match` mismatch but 409 (Conflict, `BlobAlreadyExists`) for a
+/// create-only `If-None-Match: *` that loses the race — both mean another
+/// writer won.
+fn is_precondition(err: &azure_core::Error) -> bool {
+    matches!(
+        http_status(err),
+        Some(StatusCode::PreconditionFailed) | Some(StatusCode::Conflict)
+    )
 }
 
 pub fn parse_adls_uri(uri: &str) -> FloeResult<AdlsLocation> {

--- a/crates/floe-core/src/io/storage/providers/adls.rs
+++ b/crates/floe-core/src/io/storage/providers/adls.rs
@@ -397,7 +397,12 @@ impl StorageClient for AdlsClient {
                         version: String::from(etag),
                     })
                 }
-                Err(err) if is_precondition(&err) => Ok(ConditionalWrite::Conflict),
+                Err(err)
+                    if is_precondition_failed(&err)
+                        || (expected_version.is_none() && is_create_race(&err)) =>
+                {
+                    Ok(ConditionalWrite::Conflict)
+                }
                 Err(err) => Err(Box::new(StorageError(format!("adls upload failed: {err}")))
                     as Box<dyn std::error::Error + Send + Sync>),
             }
@@ -429,7 +434,7 @@ impl StorageClient for AdlsClient {
                 Ok(_) => Ok(ConditionalWrite::Written {
                     version: "deleted".to_string(),
                 }),
-                Err(err) if is_precondition(&err) => Ok(ConditionalWrite::Conflict),
+                Err(err) if is_precondition_failed(&err) => Ok(ConditionalWrite::Conflict),
                 Err(err) if is_not_found(&err) => Ok(ConditionalWrite::Written {
                     version: "deleted".to_string(),
                 }),
@@ -455,25 +460,33 @@ fn adls_key_from_uri(uri: &str) -> FloeResult<String> {
     Ok(key)
 }
 
-fn http_status(err: &azure_core::Error) -> Option<StatusCode> {
+fn http_failure(err: &azure_core::Error) -> Option<(StatusCode, Option<&str>)> {
     match err.kind() {
-        ErrorKind::HttpResponse { status, .. } => Some(*status),
+        ErrorKind::HttpResponse {
+            status, error_code, ..
+        } => Some((*status, error_code.as_deref())),
         _ => None,
     }
 }
 
 fn is_not_found(err: &azure_core::Error) -> bool {
-    http_status(err) == Some(StatusCode::NotFound)
+    matches!(http_failure(err), Some((StatusCode::NotFound, _)))
 }
 
-/// Conflict detection for CAS writes. Azure returns 412 (PreconditionFailed)
-/// for an `If-Match` mismatch but 409 (Conflict, `BlobAlreadyExists`) for a
-/// create-only `If-None-Match: *` that loses the race — both mean another
-/// writer won.
-fn is_precondition(err: &azure_core::Error) -> bool {
+/// `If-Match` mismatch: another writer changed the blob since our read.
+fn is_precondition_failed(err: &azure_core::Error) -> bool {
+    matches!(http_failure(err), Some((StatusCode::PreconditionFailed, _)))
+}
+
+/// Create-only `If-None-Match: *` losing the race: Azure reports it as 409
+/// with error code `BlobAlreadyExists`, not 412. Scoped to that exact code —
+/// Azure uses 409 for many non-race failures (`BlobImmutableDueToPolicy`,
+/// `BlobArchived`, `SnapshotsPresent`, lease errors, ...) that must surface as
+/// real storage errors instead of triggering CAS retries.
+fn is_create_race(err: &azure_core::Error) -> bool {
     matches!(
-        http_status(err),
-        Some(StatusCode::PreconditionFailed) | Some(StatusCode::Conflict)
+        http_failure(err),
+        Some((StatusCode::Conflict, Some(code))) if code.eq_ignore_ascii_case("BlobAlreadyExists")
     )
 }
 
@@ -486,3 +499,68 @@ pub fn format_abfs_uri(container: &str, account: &str, path: &str) -> String {
 }
 
 pub type AdlsLocation = uri::AdlsLocation;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn http_error(status: StatusCode, error_code: Option<&str>) -> azure_core::Error {
+        azure_core::Error::with_message(
+            ErrorKind::HttpResponse {
+                status,
+                error_code: error_code.map(str::to_string),
+                raw_response: None,
+            },
+            "test error",
+        )
+    }
+
+    #[test]
+    fn if_match_conflict_is_412_only() {
+        assert!(is_precondition_failed(&http_error(
+            StatusCode::PreconditionFailed,
+            Some("ConditionNotMet")
+        )));
+        assert!(!is_precondition_failed(&http_error(
+            StatusCode::Conflict,
+            Some("BlobAlreadyExists")
+        )));
+    }
+
+    #[test]
+    fn create_race_requires_blob_already_exists_code() {
+        assert!(is_create_race(&http_error(
+            StatusCode::Conflict,
+            Some("BlobAlreadyExists")
+        )));
+        // Other 409 codes are real storage failures, not CAS races: mapping
+        // them to Conflict would make state operations retry unrecoverable
+        // conditions (immutability policies, legal holds, snapshots, leases).
+        assert!(!is_create_race(&http_error(
+            StatusCode::Conflict,
+            Some("BlobImmutableDueToPolicy")
+        )));
+        assert!(!is_create_race(&http_error(
+            StatusCode::Conflict,
+            Some("SnapshotsPresent")
+        )));
+        assert!(!is_create_race(&http_error(StatusCode::Conflict, None)));
+        assert!(!is_create_race(&http_error(
+            StatusCode::PreconditionFailed,
+            Some("ConditionNotMet")
+        )));
+    }
+
+    #[test]
+    fn not_found_matches_404_only() {
+        assert!(is_not_found(&http_error(
+            StatusCode::NotFound,
+            Some("BlobNotFound")
+        )));
+        assert!(!is_not_found(&http_error(StatusCode::Conflict, None)));
+        assert!(!is_not_found(&azure_core::Error::with_message(
+            ErrorKind::Other,
+            "not http"
+        )));
+    }
+}

--- a/crates/floe-core/tests/unit/config/add_entity.rs
+++ b/crates/floe-core/tests/unit/config/add_entity.rs
@@ -367,3 +367,36 @@ fn add_entity_unknown_extension_requires_explicit_format() {
 
     assert!(err.to_string().contains("use --format"));
 }
+
+#[test]
+fn add_entity_rejects_multi_document_config() {
+    let dir = tempdir().expect("tempdir");
+    let config_path = dir.path().join("config.yml");
+    let input_path = dir.path().join("customers.csv");
+
+    let multi_doc = format!(
+        "{}---\nversion: \"0.2\"\nentities: []\n",
+        base_config_yaml()
+    );
+    write_file(&config_path, &multi_doc);
+    write_file(&input_path, "id,name\n1,Alice\n");
+    let original = fs::read_to_string(&config_path).expect("read config");
+
+    let err = add_entity_to_config(AddEntityOptions {
+        config_path: config_path.clone(),
+        output_path: None,
+        input: input_path.display().to_string(),
+        format: Some("csv".to_string()),
+        name: Some("customers".to_string()),
+        domain: None,
+        dry_run: false,
+    })
+    .expect_err("multi-document config should be rejected");
+
+    assert_eq!(
+        err.to_string(),
+        "YAML contains multiple documents; expected one"
+    );
+    let after = fs::read_to_string(&config_path).expect("read config after failure");
+    assert_eq!(after, original, "config file must not be modified");
+}

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,80 @@
+# cargo-deny configuration — supply-chain gates for advisories, licenses,
+# bans, and sources. Run locally with `cargo deny check`; CI runs it in
+# .github/workflows/supply-chain.yml.
+
+[graph]
+# Audit the full feature surface (including the optional duckdb/delta/iceberg
+# sinks) so the companion build is covered by the same gates.
+all-features = true
+
+[advisories]
+version = 2
+yanked = "deny"
+# Flag unmaintained crates only when they are direct workspace dependencies;
+# the polars/aws/azure trees carry transitive ones we cannot act on.
+unmaintained = "workspace"
+ignore = [
+  # pyo3 0.22 advisories. Fixes require pyo3 >= 0.24.1 / >= 0.29, a major
+  # migration of floe-python tracked separately. Remove both when pyo3 is bumped.
+  { id = "RUSTSEC-2025-0020", reason = "fix needs pyo3 >= 0.24.1; floe-python migration tracked in a dedicated issue" },
+  { id = "RUSTSEC-2026-0177", reason = "fix needs pyo3 >= 0.29; floe-python migration tracked in a dedicated issue" },
+  # rsa Marvin timing side channel: no fixed release exists. Pulled transitively
+  # via reqsign <- opendal <- iceberg-storage-opendal; floe never performs RSA
+  # decryption with attacker-observable timing (signing requests only).
+  { id = "RUSTSEC-2023-0071", reason = "no fixed rsa release; transitive via reqsign/opendal, not used for RSA decryption oracles" },
+  # rustls-webpki 0.101.x advisories. The patched 0.103.x copy is already in the
+  # lock; the remaining 0.101.7 copy is hard-pinned by rustls 0.21 inside
+  # aws-smithy-http-client (legacy TLS path of the AWS SDK) and cannot be bumped
+  # downstream. Remove when the AWS SDK drops its rustls 0.21 fallback.
+  { id = "RUSTSEC-2026-0098", reason = "remaining affected copy pinned by aws-smithy-http-client's rustls 0.21 legacy path" },
+  { id = "RUSTSEC-2026-0099", reason = "remaining affected copy pinned by aws-smithy-http-client's rustls 0.21 legacy path" },
+  { id = "RUSTSEC-2026-0104", reason = "remaining affected copy pinned by aws-smithy-http-client's rustls 0.21 legacy path" },
+  # core2 0.4.0 was yanked with no in-range replacement; it is pinned by
+  # libflate <- apache-avro 0.16. Remove when apache-avro is bumped past 0.16.
+  { crate = "core2@0.4.0", reason = "yanked with no ^0.4 replacement; pinned by apache-avro 0.16's libflate" },
+]
+
+[licenses]
+version = 2
+allow = [
+  "MIT",
+  "Apache-2.0",
+  "Apache-2.0 WITH LLVM-exception",
+  "BSD-2-Clause",
+  "BSD-3-Clause",
+  "ISC",
+  "Zlib",
+  "BSL-1.0",
+  "CC0-1.0",
+  "CDLA-Permissive-2.0",
+  "Unicode-3.0",
+  "Unicode-DFS-2016",
+  "MPL-2.0",
+  "OpenSSL",
+  "bzip2-1.0.6",
+]
+
+# ring ships a combined license file without an SPDX expression in Cargo.toml.
+[[licenses.clarify]]
+crate = "ring"
+expression = "MIT AND ISC AND OpenSSL"
+license-files = [{ path = "LICENSE", hash = 0xbd0eed23 }]
+
+[bans]
+# The dependency tree (polars + aws + azure + arrow) inevitably carries
+# duplicate minor versions; gating on that would be permanently red.
+multiple-versions = "allow"
+wildcards = "deny"
+deny = [
+  # Removed in favor of the yaml-rust2 stack already used by config parsing;
+  # serde_yaml is archived/unmaintained. Keep it out.
+  { crate = "serde_yaml", reason = "unmaintained (archived); use yaml-rust2" },
+  # The pre-official Azure SDK track is deprecated; floe migrated to the
+  # official azure_identity + azure_storage_blob crates.
+  { crate = "azure_storage", reason = "deprecated unofficial Azure SDK track" },
+  { crate = "azure_storage_blobs", reason = "deprecated unofficial Azure SDK track" },
+]
+
+[sources]
+unknown-registry = "deny"
+unknown-git = "deny"


### PR DESCRIPTION
## What

Supply-chain hardening pass, first batch of the production-hardening review:

### 1. cargo-deny + Dependabot gates (new)
- `deny.toml`: advisories (vulns deny, yanked deny, direct-dep unmaintained), license allow-list, source allow-list, and **bans on reintroducing `serde_yaml` / the deprecated `azure_storage*` crates**.
- `.github/workflows/supply-chain.yml`: runs `cargo deny check` on PRs touching the dependency tree, weekly on schedule, and on demand.
- `.github/dependabot.yml`: weekly cargo (minor+patch grouped), GitHub Actions, and pip (both orchestrator packages). `duckdb`/`libduckdb-sys` ignored until the arrow-58 migration.

### 2. Advisory fixes the new gate caught immediately
- `aws-lc-sys` 0.36.0 → 0.41.0 (RUSTSEC-2026-0044/45/46/47/48 — X.509 name-constraint bypass, AES-CCM timing, PKCS7 validation bypasses, CRL logic error)
- `rustls-webpki` 0.103.9 → 0.103.13 (RUSTSEC-2026-0098/99/104/49)
- `lz4_flex` 0.11.5 → 0.11.6 and 0.12.0 → 0.12.1 (RUSTSEC-2026-0041 — uninitialized-memory leak on invalid input)
- Remaining unfixable-downstream advisories are explicitly ignored in `deny.toml` with reasons (rsa Marvin via reqsign/opendal; rustls-webpki 0.101 pinned by aws-smithy's rustls 0.21 legacy path; yanked core2 via apache-avro 0.16). The pyo3 advisories are tracked in #391.

### 3. Drop `serde_yaml` (archived/unmaintained)
`add_entity.rs` was the only consumer; it now builds the generated entity with the `yaml-rust2` stack the config parser already uses (one YAML library in the tree instead of two). Behavior preserved: same mapping order, same duplicate-entity error, output re-validated through `floe_core::validate` as before.

### 4. Migrate ADLS to the official Azure SDK (GA 1.0)
`azure_core`/`azure_identity`/`azure_storage`/`azure_storage_blobs` 0.20 (deprecated unofficial track) → `azure_core` + `azure_identity` + `azure_storage_blob` 1.0:
- **Conditional writes preserved**: `If-Match`/`If-None-Match: *` on put, `If-Match` on delete — the CAS contract `state/` relies on. Conflict detection is now **typed** (`ErrorKind::HttpResponse` status 412/409) instead of the old `err.to_string().contains("412")` matching; 409 now correctly maps the create-only race to `Conflict` (the old string match missed it).
- **Credential parity**: the official SDK removed `DefaultAzureCredential`, so a small `ChainedCredential` (same pattern as the SDK's own `DeveloperToolsCredential`) restores the old resolution order: service-principal env vars → workload identity → managed identity → Azure CLI.
- Downloads still stream chunk-by-chunk to disk; listing uses the new `Pager`.
- Lockfile notes: `time` pinned to 0.3.47 (0.3.48 has the ecosystem-wide E0119 coherence regression); `futures` 0.3.31 → 0.3.32 (required by `azure_storage_blob`).

## Verification

- `cargo fmt --all` — clean
- `cargo clippy --workspace --all-targets --no-default-features --features delta,iceberg -- -D warnings` — zero warnings
- `cargo check --workspace` — passes
- `cargo test -p floe-core` — all tests pass
- `cargo deny check advisories bans licenses sources` — all four pass

ADLS conditional-write behavior is not covered by integration tests (no Azure emulator in the suite — storage tests run via the local provider per `context/testing-strategy.md`); the conditional semantics were ported 1:1 and the conflict mapping is stricter than before. Worth a smoke run against a real ADLS container before the next release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
